### PR TITLE
support to return single column and value

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SingleBasicTypeTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SingleBasicTypeTest.kt
@@ -1,0 +1,56 @@
+package dev.hsbrysk.kuery.spring.jdbc
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.net.URI
+import kotlin.reflect.KClass
+
+class SingleBasicTypeTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @ParameterizedTest
+    @MethodSource("singleValues")
+    fun testSingleValues(
+        query: String,
+        expected: Any,
+        type: KClass<*>,
+    ) {
+        val result = kueryClient.sql {
+            +query
+        }.single(type)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun testSingleColumnWithMultiValue() {
+        val result = kueryClient.sql {
+            +"SELECT 1 UNION SELECT 0"
+        }.list(Int::class)
+
+        assertThat(result).isEqualTo(listOf(1, 0))
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer()
+
+        @AfterAll
+        @JvmStatic
+        fun afterAll() {
+            mysql.close()
+        }
+
+        @JvmStatic
+        fun singleValues(): List<Any> = listOf(
+            Arguments.of("SELECT 1", 1, Int::class),
+            Arguments.of("""SELECT "https://example.com"""", URI("https://example.com"), URI::class),
+            Arguments.of("""SELECT 1""", true, Boolean::class),
+            Arguments.of("""SELECT 0""", false, Boolean::class),
+        )
+    }
+}


### PR DESCRIPTION
resolve #106 .
Also I'd like to add the cache of `RowMapper`, because `DefaultJdbcClient` has the cache to reuse `RowMapper`.

ref: https://github.com/spring-projects/spring-framework/blob/fcb8aed03f10be7c8e42235988299384b22482a0/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/DefaultJdbcClient.java#L201
