### PR TITLE
allow to use custom JdbcClient

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder.kt
@@ -3,6 +3,7 @@ package dev.hsbrysk.kuery.spring.jdbc
 import dev.hsbrysk.kuery.core.KueryBlockingClient
 import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import io.micrometer.observation.ObservationRegistry
+import org.springframework.jdbc.core.simple.JdbcClient
 import javax.sql.DataSource
 
 interface SpringJdbcKueryClientBuilder {
@@ -10,6 +11,11 @@ interface SpringJdbcKueryClientBuilder {
      * Set [DataSource]
      */
     fun dataSource(dataSource: DataSource): SpringJdbcKueryClientBuilder
+
+    /**
+     * Set [JdbcClient]. It is useful if you need to customize [JdbcClient].
+     */
+    fun jdbcClient(jdbcClient: JdbcClient): SpringJdbcKueryClientBuilder
 
     /**
      * Set converters

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClientBuilder.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClientBuilder.kt
@@ -15,6 +15,7 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.simple.JdbcClient
 import javax.sql.DataSource
 
+@Suppress("TooManyFunctions")
 internal class DefaultSpringJdbcKueryClientBuilder : SpringJdbcKueryClientBuilder {
     private var dataSource: DataSource? = null
     private var jdbcClient: JdbcClient? = null

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClientBuilder.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClientBuilder.kt
@@ -17,6 +17,7 @@ import javax.sql.DataSource
 
 internal class DefaultSpringJdbcKueryClientBuilder : SpringJdbcKueryClientBuilder {
     private var dataSource: DataSource? = null
+    private var jdbcClient: JdbcClient? = null
     private var converters: List<Any> = emptyList()
     private var observationRegistry: ObservationRegistry? = null
     private var observationConvention: KueryClientFetchObservationConvention? = null
@@ -24,6 +25,11 @@ internal class DefaultSpringJdbcKueryClientBuilder : SpringJdbcKueryClientBuilde
 
     override fun dataSource(dataSource: DataSource): SpringJdbcKueryClientBuilder {
         this.dataSource = dataSource
+        return this
+    }
+
+    override fun jdbcClient(jdbcClient: JdbcClient): SpringJdbcKueryClientBuilder {
+        this.jdbcClient = jdbcClient
         return this
     }
 
@@ -54,7 +60,7 @@ internal class DefaultSpringJdbcKueryClientBuilder : SpringJdbcKueryClientBuilde
             "Specify dataSource."
         }
 
-        val jdbcClient = jdbcClient(dataSource)
+        val jdbcClient = jdbcClient ?: createJdbcClient(dataSource)
         val conversionService = DefaultConversionService()
         val customConversions = jdbcCustomConversions(dataSource).apply {
             registerConvertersIn(conversionService)
@@ -71,7 +77,7 @@ internal class DefaultSpringJdbcKueryClientBuilder : SpringJdbcKueryClientBuilde
         )
     }
 
-    private fun jdbcClient(dataSource: DataSource): JdbcClient = JdbcClient.create(dataSource)
+    private fun createJdbcClient(dataSource: DataSource): JdbcClient = JdbcClient.create(dataSource)
 
     private fun jdbcCustomConversions(dataSource: DataSource): JdbcCustomConversions {
         val dialect = dialect(dataSource)


### PR DESCRIPTION
JdbcClient has a constructor that uses `NamedParameterJdbcOperations`.
It seems that NamedParameterJdbcOperation is useful for extension point for JdbcClient, so I'd like to able to use custom JdbcClient that initialized with NamedParameterJdbcOperation.