### PR TITLE
Introduce `@DelicateKueryClientApi`

### DIFF
--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import org.junit.jupiter.api.Test
 
+@OptIn(DelicateKueryClientApi::class)
 class SqlTest {
     @Test
     fun `simple create`() {

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DelicateKueryClientApi.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DelicateKueryClientApi.kt
@@ -1,0 +1,10 @@
+package dev.hsbrysk.kuery.core
+
+@MustBeDocumented
+@Retention(value = AnnotationRetention.BINARY)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This is a delicate API and its use requires care." +
+        " Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.",
+)
+annotation class DelicateKueryClientApi

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
@@ -37,11 +37,13 @@ interface SqlBuilder {
      * addUnsafe("user_id = ${bind(userId)}")
      * ```
      */
+    @DelicateKueryClientApi
     fun addUnsafe(@Language("sql") sql: String)
 
     /**
      * Bind variables to SQL
      * It is intended to be used together with addUnsafe.
      */
+    @DelicateKueryClientApi
     fun bind(parameter: Any?): String
 }

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilderHelpers.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilderHelpers.kt
@@ -1,5 +1,6 @@
 package dev.hsbrysk.kuery.core
 
+@OptIn(DelicateKueryClientApi::class)
 fun SqlBuilder.values(input: List<List<Any?>>) {
     require(input.isNotEmpty()) { "inputted list is empty" }
     val firstSize = input.first().size

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilder.kt
@@ -1,5 +1,6 @@
 package dev.hsbrysk.kuery.core.internal
 
+import dev.hsbrysk.kuery.core.DelicateKueryClientApi
 import dev.hsbrysk.kuery.core.NamedSqlParameter
 import dev.hsbrysk.kuery.core.Sql
 import dev.hsbrysk.kuery.core.SqlBuilder
@@ -12,10 +13,14 @@ internal class DefaultSqlBuilder : SqlBuilder {
 
     override fun String.unaryPlus(): Unit = injectByPlugin()
 
+    // Only the developers of the kuery client will use the DefaultSqlBuilder, so we’ll make it opt-in here.
+    @OptIn(DelicateKueryClientApi::class)
     override fun addUnsafe(sql: String) {
         body.appendLine(sql)
     }
 
+    // Only the developers of the kuery client will use the DefaultSqlBuilder, so we’ll make it opt-in here.
+    @OptIn(DelicateKueryClientApi::class)
     override fun bind(parameter: Any?): String {
         val currentIndex = parameters.size
         parameters.add(DefaultNamedSqlParameter(PARAMETER_NAME_PREFIX + currentIndex, parameter))

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/SqlBuilderHelpersTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/SqlBuilderHelpersTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import org.junit.jupiter.api.Test
 
+@OptIn(DelicateKueryClientApi::class)
 class SqlBuilderHelpersTest {
     @Test
     fun `values single`() {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
+import dev.hsbrysk.kuery.core.DelicateKueryClientApi
 import dev.hsbrysk.kuery.core.SqlBuilder
 import dev.hsbrysk.kuery.core.list
 import dev.hsbrysk.kuery.core.single
@@ -391,6 +392,7 @@ class BasicUsageTest {
 
     @Test
     fun `using extension function`() {
+        @OptIn(DelicateKueryClientApi::class)
         fun SqlBuilder.userIdEqualsTo(userId: Int) {
             addUnsafe("users.user_id = ${bind(userId)}")
         }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/BasicUsageTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/BasicUsageTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
 import com.example.spring.r2dbc.User
+import dev.hsbrysk.kuery.core.DelicateKueryClientApi
 import dev.hsbrysk.kuery.core.SqlBuilder
 import dev.hsbrysk.kuery.core.flow
 import dev.hsbrysk.kuery.core.list
@@ -428,6 +429,7 @@ open class BasicUsageTest {
 
     @Test
     fun `using extension function`() = runTest {
+        @OptIn(DelicateKueryClientApi::class)
         fun SqlBuilder.userIdEqualsTo(userId: Int) {
             addUnsafe("users.user_id = ${bind(userId)}")
         }


### PR DESCRIPTION
Since `addUnsafe` and `bind` need to be used with care, I'll add the `@DelicateKueryClientApi` annotation to them.

This utilizes Kotlin's "Opt-in requirements" feature:
[Kotlin Documentation: Opt-in Requirements](https://kotlinlang.org/docs/opt-in-requirements.html)

For example, a similar approach is used in Kotlin Coroutines:
[Annotation Example in Kotlin Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/fed40ad1f9942d1b16be872cc555e08f965cf881/kotlinx-coroutines-core/common/src/Annotations.kt#L12-L19)
