### PR TITLE
Remove kuery-client-core dependency from kuery-client-compiler

### DIFF
--- a/kuery-client-compiler/build.gradle.kts
+++ b/kuery-client-compiler/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 description = "Compiler plugin for the Kuery client."
 
 dependencies {
-    implementation(projects.kueryClientCore)
     implementation(kotlin("compiler-embeddable"))
     testImplementation(libs.kotlin.compile.testing)
 }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/ClassNames.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/ClassNames.kt
@@ -1,8 +1,6 @@
 package dev.hsbrysk.kuery.compiler.ir.misc
 
-import dev.hsbrysk.kuery.core.SqlBuilder
-
 internal object ClassNames {
     val STRING = checkNotNull(String::class.qualifiedName)
-    val SQL_BUILDER = checkNotNull(SqlBuilder::class.qualifiedName)
+    const val SQL_BUILDER = "dev.hsbrysk.kuery.core.SqlBuilder"
 }


### PR DESCRIPTION
There is no need to depend on it unnecessarily.