### PR TITLE
fix compile error for kotlin2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Check
-        run: ./gradlew check detektMain detektTest
+        run: |
+          ./gradlew check detektMain detektTest
+          ./gradlew -p examples check detektMain detektTest
 
   report-gradle-dependency-diff:
     runs-on: ubuntu-latest

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,9 +19,10 @@ cd examples
 ### Run application
 
 ```shell
-./gradlew :examples:spring-data-r2dbc:bootRun
+cd examples
+./gradlew :spring-data-r2dbc:bootRun
 
 # or
 
-./gradlew :examples:spring-data-jdbc:bootRun
+./gradlew :spring-data-jdbc:bootRun
 ```

--- a/examples/settings.gradle.kts
+++ b/examples/settings.gradle.kts
@@ -1,5 +1,6 @@
 pluginManagement {
-    includeBuild("build-logic")
+    includeBuild("../build-logic")
+    includeBuild("../")
     repositories {
         gradlePluginPortal()
         // mavenLocal()
@@ -10,11 +11,15 @@ dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
         mavenCentral()
-        // mavenLocal()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
     }
 }
 
-rootProject.name = "kuery-client"
+rootProject.name = "examples"
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
@@ -23,10 +28,8 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
 }
 
-include("kuery-client-compiler")
-include("kuery-client-compiler:functional-test")
-include("kuery-client-core")
-include("kuery-client-detekt")
-include("kuery-client-gradle-plugin")
-include("kuery-client-spring-data-jdbc")
-include("kuery-client-spring-data-r2dbc")
+include("spring-data-jdbc")
+include("spring-data-r2dbc")
+
+// Include the root project to use `dev.hsbrysk.kuery-client:*` modules
+includeBuild("../")

--- a/examples/spring-data-jdbc/build.gradle.kts
+++ b/examples/spring-data-jdbc/build.gradle.kts
@@ -1,10 +1,8 @@
-import io.gitlab.arturbosch.detekt.Detekt
-
 plugins {
     id("conventions.preset.base")
+    id("dev.hsbrysk.kuery-client")
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
-    alias(libs.plugins.kuery.client)
 }
 
 description = "Example of spring-data-jdbc"
@@ -14,20 +12,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
-    implementation(projects.kueryClientSpringDataJdbc)
+    implementation("dev.hsbrysk.kuery-client:kuery-client-spring-data-jdbc")
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("com.mysql:mysql-connector-j")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    detektPlugins(projects.kueryClientDetekt)
+    detektPlugins("dev.hsbrysk.kuery-client:kuery-client-detekt")
 }
 
 detekt {
-    config.setFrom("${rootProject.rootDir}/examples/detekt.yml")
+    config.setFrom("${rootProject.rootDir}/detekt.yml")
     disableDefaultRuleSets = true
-}
-
-// Since they are dependent within the same project, I am writing it this way. There is no need to imitate this.
-tasks.withType<Detekt> {
-    dependsOn(":${projects.kueryClientDetekt.name}:assemble")
 }

--- a/examples/spring-data-r2dbc/build.gradle.kts
+++ b/examples/spring-data-r2dbc/build.gradle.kts
@@ -1,10 +1,8 @@
-import io.gitlab.arturbosch.detekt.Detekt
-
 plugins {
     id("conventions.preset.base")
+    id("dev.hsbrysk.kuery-client")
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
-    alias(libs.plugins.kuery.client)
 }
 
 description = "Example of spring-data-r2dbc"
@@ -14,20 +12,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
-    implementation(projects.kueryClientSpringDataR2dbc)
+    implementation("dev.hsbrysk.kuery-client:kuery-client-spring-data-r2dbc")
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("io.asyncer:r2dbc-mysql")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    detektPlugins(projects.kueryClientDetekt)
+    detektPlugins("dev.hsbrysk.kuery-client:kuery-client-detekt")
 }
 
 detekt {
-    config.setFrom("${rootProject.rootDir}/examples/detekt.yml")
+    config.setFrom("${rootProject.rootDir}/detekt.yml")
     disableDefaultRuleSets = true
-}
-
-// Since they are dependent within the same project, I am writing it this way. There is no need to imitate this.
-tasks.withType<Detekt> {
-    dependsOn(":${projects.kueryClientDetekt.name}:assemble")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,5 @@ gradle-plugin-maven-publish = { module = "com.vanniktech:gradle-maven-publish-pl
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "5.6.5" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin-core" }
-kuery-client = { id = "dev.hsbrysk.kuery-client", version = "0.7.2" } # for example code
 plugin-publish = { id = "com.gradle.plugin-publish", version = "1.3.1" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 detekt = "1.23.8"
-kotlin-core = "2.0.21"
+kotlin-core = "2.1.21"
 kotlin-coroutines = "1.10.2"
 ktlint = "1.6.0"
 micrometer = "1.15.0"

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/StringConcatenationProcessor.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/StringConcatenationProcessor.kt
@@ -38,6 +38,6 @@ internal class StringConcatenationProcessor(private val builder: IrBuilderWithSc
     private fun isFragment(expression: IrExpression): Boolean {
         val isString = expression.type.classFqName?.asString() == ClassNames.STRING ||
             expression.type.superTypes().any { it.classFqName?.asString() == ClassNames.STRING }
-        return isString && expression is IrConst<*> && expression.kind == IrConstKind.String
+        return isString && expression is IrConst && expression.kind == IrConstKind.String
     }
 }


### PR DESCRIPTION
- upgrade kotlin to 2.1 & fixes compile error
- separate example modules from compiler plugin
    - this time example modules also require compiler plugin built with kotlin 2.1, which has not published yet
    - to import local compiler plugin, I had to separate example modules (otherwise circular reference occurs on build-logic)