### PR TITLE
A try to upgrade to kotlin 2.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 detekt = "1.23.8"
-kotlin-core = "2.1.21"
+kotlin-core = "2.2.0"
 kotlin-coroutines = "1.10.2"
 ktlint = "1.6.0"
 micrometer = "1.15.2"

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -4,9 +4,9 @@ import dev.hsbrysk.kuery.compiler.ir.misc.CallableIds
 import dev.hsbrysk.kuery.compiler.ir.misc.ClassIds
 import dev.hsbrysk.kuery.compiler.ir.misc.ClassNames
 import dev.hsbrysk.kuery.compiler.ir.misc.StringConcatenationProcessor
+import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
-import org.jetbrains.kotlin.ir.backend.js.utils.valueArguments
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irVararg
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.ir.util.irCastIfNeeded
 import org.jetbrains.kotlin.ir.util.isVararg
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 
+@OptIn(DeprecatedForRemovalCompilerApi::class)
 @Suppress("OPT_IN_USAGE")
 class StringInterpolationTransformer(private val pluginContext: IrPluginContext) : IrElementTransformerVoid() {
     private var current: IrCall? = null
@@ -54,7 +55,11 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
         val addUnsafe = sqlBuilderClass.functions.first { it.owner.name.asString() == "addUnsafe" }
         return builder.irCall(addUnsafe, pluginContext.symbols.unit.defaultType).apply {
             dispatchReceiver = sqlBuilder
-            putValueArgument(0, expression.valueArguments.first())
+            putValueArgument(
+                0,
+                List(expression.valueArgumentsCount) { expression.getValueArgument(it) }
+                    .first(),
+            )
         }
     }
 


### PR DESCRIPTION
As title described, this PR is just a try to upgrade to kotlin 2.2.0.
`getValueArgument`, `putValueArgument`, ... are already deprecated from kotlin 2.1.20, we have to refactor StringInterpolationTransformer as well, that is not in scope of this PR so i use `@OptIn(DeprecatedForRemovalCompilerApi::class)` instead
