### PR TITLE
Replace deprecated Kotlin IR API usage in StringInterpolationTransformer

### DIFF
--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -7,7 +7,6 @@ import dev.hsbrysk.kuery.compiler.ir.misc.StringConcatenationProcessor
 import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
-import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.expressions.IrCall
@@ -17,14 +16,12 @@ import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.classOrFail
-import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.irCastIfNeeded
 import org.jetbrains.kotlin.ir.util.isVararg
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 
-@OptIn(DeprecatedForRemovalCompilerApi::class)
 @Suppress("OPT_IN_USAGE")
 class StringInterpolationTransformer(private val pluginContext: IrPluginContext) : IrElementTransformerVoid() {
     private var current: IrCall? = null
@@ -55,6 +52,7 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
         val addUnsafe = sqlBuilderClass.functions.first { it.owner.name.asString() == "addUnsafe" }
         return builder.irCall(addUnsafe).apply {
             dispatchReceiver = sqlBuilder
+            @OptIn(DeprecatedForRemovalCompilerApi::class)
             putValueArgument(
                 0,
                 List(expression.valueArgumentsCount) { expression.getValueArgument(it) }
@@ -70,6 +68,7 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
         val addUnsafe = sqlBuilderClass.functions.first { it.owner.name.asString() == "addUnsafe" }
         return builder.irCall(addUnsafe).apply {
             dispatchReceiver = sqlBuilder
+            @OptIn(DeprecatedForRemovalCompilerApi::class)
             putValueArgument(0, expression.extensionReceiver)
         }
     }
@@ -93,7 +92,9 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
                 checkNotNull(current.dispatchReceiver),
                 defaultSqlBuilderClass.typeWith(),
             )
+            @OptIn(DeprecatedForRemovalCompilerApi::class)
             putValueArgument(0, fragments)
+            @OptIn(DeprecatedForRemovalCompilerApi::class)
             putValueArgument(1, values)
         }
     }
@@ -111,6 +112,7 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
     ): IrExpression {
         val vararg = irVararg(type, values)
         return irCall(pluginContext.listOfRef()).apply {
+            @OptIn(DeprecatedForRemovalCompilerApi::class)
             putValueArgument(0, vararg)
         }
     }
@@ -127,6 +129,9 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
         }
 
         private fun IrPluginContext.listOfRef(): IrSimpleFunctionSymbol = referenceFunctions(CallableIds.LIST_OF)
-            .first { it.owner.valueParameters.firstOrNull()?.isVararg ?: false }
+            .first {
+                @OptIn(DeprecatedForRemovalCompilerApi::class)
+                it.owner.valueParameters.firstOrNull()?.isVararg ?: false
+            }
     }
 }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -4,11 +4,11 @@ import dev.hsbrysk.kuery.compiler.ir.misc.CallableIds
 import dev.hsbrysk.kuery.compiler.ir.misc.ClassIds
 import dev.hsbrysk.kuery.compiler.ir.misc.ClassNames
 import dev.hsbrysk.kuery.compiler.ir.misc.StringConcatenationProcessor
-import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irVararg
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrStringConcatenation
@@ -52,12 +52,11 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
         val addUnsafe = sqlBuilderClass.functions.first { it.owner.name.asString() == "addUnsafe" }
         return builder.irCall(addUnsafe).apply {
             dispatchReceiver = sqlBuilder
-            @OptIn(DeprecatedForRemovalCompilerApi::class)
-            putValueArgument(
-                0,
-                List(expression.valueArgumentsCount) { expression.getValueArgument(it) }
-                    .first(),
-            )
+            val addUnsafeParam = addUnsafe.owner.parameters.first { it.kind == IrParameterKind.Regular }
+            val sqlArgument = expression.arguments[
+                expression.symbol.owner.parameters.first { it.kind == IrParameterKind.Regular }.indexInParameters,
+            ]
+            arguments[addUnsafeParam] = sqlArgument
         }
     }
 
@@ -68,8 +67,13 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
         val addUnsafe = sqlBuilderClass.functions.first { it.owner.name.asString() == "addUnsafe" }
         return builder.irCall(addUnsafe).apply {
             dispatchReceiver = sqlBuilder
-            @OptIn(DeprecatedForRemovalCompilerApi::class)
-            putValueArgument(0, expression.extensionReceiver)
+            val addUnsafeParam = addUnsafe.owner.parameters.first { it.kind == IrParameterKind.Regular }
+            val extensionReceiverValue = expression.arguments[
+                expression.symbol.owner.parameters.first {
+                    it.kind == IrParameterKind.ExtensionReceiver
+                }.indexInParameters,
+            ]
+            arguments[addUnsafeParam] = extensionReceiverValue
         }
     }
 
@@ -92,10 +96,9 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
                 checkNotNull(current.dispatchReceiver),
                 defaultSqlBuilderClass.typeWith(),
             )
-            @OptIn(DeprecatedForRemovalCompilerApi::class)
-            putValueArgument(0, fragments)
-            @OptIn(DeprecatedForRemovalCompilerApi::class)
-            putValueArgument(1, values)
+            val regularParams = interpolate.owner.parameters.filter { it.kind == IrParameterKind.Regular }
+            arguments[regularParams[0]] = fragments
+            arguments[regularParams[1]] = values
         }
     }
 
@@ -111,9 +114,10 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
         values: List<IrExpression>,
     ): IrExpression {
         val vararg = irVararg(type, values)
-        return irCall(pluginContext.listOfRef()).apply {
-            @OptIn(DeprecatedForRemovalCompilerApi::class)
-            putValueArgument(0, vararg)
+        val ref = pluginContext.listOfRef()
+        return irCall(ref).apply {
+            val listOfParam = ref.owner.parameters.first { it.kind == IrParameterKind.Regular }
+            arguments[listOfParam] = vararg
         }
     }
 
@@ -130,8 +134,7 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
 
         private fun IrPluginContext.listOfRef(): IrSimpleFunctionSymbol = referenceFunctions(CallableIds.LIST_OF)
             .first {
-                @OptIn(DeprecatedForRemovalCompilerApi::class)
-                it.owner.valueParameters.firstOrNull()?.isVararg ?: false
+                it.owner.parameters.firstOrNull { p -> p.kind == IrParameterKind.Regular }?.isVararg ?: false
             }
     }
 }


### PR DESCRIPTION
## Summary

  - Removed all usages of `@OptIn(DeprecatedForRemovalCompilerApi::class)` in `StringInterpolationTransformer`
  - Replaced deprecated IR parameter API with the new `arguments`-based API introduced in Kotlin 2.x

  ## Changes

  | Deprecated API | New API |
  |---|---|
  | `putValueArgument(index, value)` | `arguments[IrValueParameter] = value` |
  | `getValueArgument(index)` | `arguments[parameter.indexInParameters]` |
  | `valueArgumentsCount` / `valueParameters` | `parameters.filter { it.kind == IrParameterKind.Regular }` |
  | `extensionReceiver` | `arguments[parameter.indexInParameters]` via `IrParameterKind.ExtensionReceiver` |

  ## Test plan

  - [x] `./gradlew :kuery-client-compiler:build` passes (unit tests + ktlint + detekt)
  - [x] `./gradlew test` passes across all modules (including integration tests via Testcontainers)