### PR TITLE
Update Kotlin to v2.3.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 detekt = "1.23.8"
-kotlin-core = "2.3.10"
+kotlin-core = "2.3.21"
 kotlin-coroutines = "1.11.0"
 ktlint = "1.8.0"
 micrometer = "1.16.5"

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -88,7 +88,8 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
             )
         }
 
-        val defaultSqlBuilderClass = checkNotNull(pluginContext.referenceClass(ClassIds.DEFAULT_SQL_BUILDER))
+        val defaultSqlBuilderClass =
+            checkNotNull(pluginContext.finderForBuiltins().findClass(ClassIds.DEFAULT_SQL_BUILDER))
         val interpolate = defaultSqlBuilderClass.functions.first { it.owner.name.asString() == "interpolate" }
 
         return builder.irCall(interpolate).apply {
@@ -132,9 +133,10 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
             return false
         }
 
-        private fun IrPluginContext.listOfRef(): IrSimpleFunctionSymbol = referenceFunctions(CallableIds.LIST_OF)
-            .first {
-                it.owner.parameters.firstOrNull { p -> p.kind == IrParameterKind.Regular }?.isVararg ?: false
-            }
+        private fun IrPluginContext.listOfRef(): IrSimpleFunctionSymbol =
+            finderForBuiltins().findFunctions(CallableIds.LIST_OF)
+                .first {
+                    it.owner.parameters.firstOrNull { p -> p.kind == IrParameterKind.Regular }?.isVararg ?: false
+                }
     }
 }


### PR DESCRIPTION
## Summary

  - Bump `kotlin-core` from `2.3.10` to `2.3.21` in `gradle/libs.versions.toml`
  - Migrate deprecated `IrPluginContext` reference APIs in `StringInterpolationTransformer` to the new `finderForBuiltins()` based API introduced in Kotlin 2.3.x

  ## Details

  Kotlin 2.3.21 deprecated `IrPluginContext.referenceClass()` and `IrPluginContext.referenceFunctions()` in favor of `finderForBuiltins()` / `finderForSource(fromFile)`. Since this project enforces `allWarningsAsErrors = true`, these
  deprecations caused build failures and required migration alongside the version bump.

  | Before | After |
  |---|---|
  | `pluginContext.referenceClass(ClassIds.DEFAULT_SQL_BUILDER)` | `pluginContext.finderForBuiltins().findClass(ClassIds.DEFAULT_SQL_BUILDER)` |
  | `pluginContext.referenceFunctions(CallableIds.LIST_OF)` | `pluginContext.finderForBuiltins().findFunctions(CallableIds.LIST_OF)` |

  Closes the Renovate PRs for `renovate/kotlin.core` and `renovate/kotlin-monorepo` (both bumped the same `kotlin-core` version reference).