### PR TITLE
Migrate examples from Jackson 2 to Jackson 3

### DIFF
--- a/examples/spring-data-jdbc/build.gradle.kts
+++ b/examples/spring-data-jdbc/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation("dev.hsbrysk.kuery-client:kuery-client-spring-data-jdbc")
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("com.mysql:mysql-connector-j")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("tools.jackson.module:jackson-module-kotlin")
 
     detektPlugins("dev.hsbrysk.kuery-client:kuery-client-detekt")
 }

--- a/examples/spring-data-r2dbc/build.gradle.kts
+++ b/examples/spring-data-r2dbc/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation("dev.hsbrysk.kuery-client:kuery-client-spring-data-r2dbc")
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("io.asyncer:r2dbc-mysql")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("tools.jackson.module:jackson-module-kotlin")
 
     detektPlugins("dev.hsbrysk.kuery-client:kuery-client-detekt")
 }


### PR DESCRIPTION
Spring Boot 4 ships Jackson 3 (tools.jackson.*).

Replace com.fasterxml.jackson.module:jackson-module-kotlin with tools.jackson.module:jackson-module-kotlin in both example modules.