### PR TITLE
Add sequenceMap/sequence streaming APIs to KueryBlockingClient.FetchSpec

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -147,6 +147,30 @@ val users: Flow<User> = kueyClient
     .flow()
 ```
 
+### [`kuery-client-spring-data-jdbc` only] `fun sequenceMap(): Sequence<Map<String, Any?>>`
+
+Receives the results of multiple rows as a sequence of maps.
+
+```kotlin
+val result: Sequence<Map<String, Any?>> = kueyClient
+    .sql { +"SELECT * FROM users WHERE user_id = 1" }
+    .sequenceMap()
+```
+
+Note: backed by an open JDBC ResultSet — iterate within an active transaction. Single-pass.
+
+### [`kuery-client-spring-data-jdbc` only] `fun <T : Any> sequence(returnType: KClass<T>): Sequence<T>`
+
+Receives the results of multiple rows converted to the specified type as a sequence.
+
+```kotlin
+val users: Sequence<User> = kueyClient
+    .sql { +"SELECT * FROM users WHERE user_id = 1" }
+    .sequence()
+```
+
+Note: backed by an open JDBC ResultSet — iterate within an active transaction. Single-pass.
+
 ### `(suspend) fun rowsUpdated(): Long`
 
 Contract for fetching the number of affected rows

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
@@ -54,6 +54,18 @@ interface KueryBlockingClient {
         fun <T : Any> list(returnType: KClass<T>): List<T>
 
         /**
+         * Receives the results of multiple rows as a sequence of maps.
+         * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active transaction.
+         */
+        fun sequenceMap(): Sequence<Map<String, Any?>>
+
+        /**
+         * Receives the results of multiple rows converted to the specified type as a sequence.
+         * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active transaction.
+         */
+        fun <T : Any> sequence(returnType: KClass<T>): Sequence<T>
+
+        /**
          * Contract for fetching the number of affected rows
          */
         fun rowsUpdated(): Long
@@ -80,3 +92,8 @@ inline fun <reified T : Any> FetchSpec.singleOrNull(): T? = singleOrNull(T::clas
  * Receives the results of multiple rows converted to the specified type.
  */
 inline fun <reified T : Any> FetchSpec.list(): List<T> = list(T::class)
+
+/**
+ * Receives the results of multiple rows converted to the specified type as a sequence.
+ */
+inline fun <reified T : Any> FetchSpec.sequence(): Sequence<T> = sequence(T::class)

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -15,6 +15,7 @@ import org.springframework.beans.BeanUtils
 import org.springframework.core.convert.ConversionService
 import org.springframework.dao.support.DataAccessUtils
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions
+import org.springframework.jdbc.core.ColumnMapRowMapper
 import org.springframework.jdbc.core.DataClassRowMapper
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.SingleColumnRowMapper
@@ -24,6 +25,7 @@ import org.springframework.jdbc.core.simple.JdbcClient.StatementSpec
 import org.springframework.jdbc.support.GeneratedKeyHolder
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
+import kotlin.streams.asSequence
 
 internal class DefaultSpringJdbcKueryClient(
     private val jdbcClient: JdbcClient,
@@ -127,6 +129,22 @@ internal class DefaultSpringJdbcKueryClient(
 
         override fun <T : Any> list(returnType: KClass<T>): List<T> = observe {
             spec.queryType(returnType).list()
+        }
+
+        override fun sequenceMap(): Sequence<Map<String, Any?>> {
+            // TODO:
+            // I also want to measure the observation of flow.
+            // However, should it be the time until the flow terminates or the time until the first element is obtained?
+            // There are many uncertainties, so I will not implement it for now.
+            return spec.query(ColumnMapRowMapper()).stream().asSequence()
+        }
+
+        override fun <T : Any> sequence(returnType: KClass<T>): Sequence<T> {
+            // TODO:
+            // I also want to measure the observation of flow.
+            // However, should it be the time until the flow terminates or the time until the first element is obtained?
+            // There are many uncertainties, so I will not implement it for now.
+            return spec.queryType(returnType).stream().asSequence()
         }
 
         override fun rowsUpdated(): Long = observe {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
@@ -9,6 +9,7 @@ import assertk.assertions.isNull
 import dev.hsbrysk.kuery.core.DelicateKueryClientApi
 import dev.hsbrysk.kuery.core.SqlBuilder
 import dev.hsbrysk.kuery.core.list
+import dev.hsbrysk.kuery.core.sequence
 import dev.hsbrysk.kuery.core.single
 import dev.hsbrysk.kuery.core.singleOrNull
 import org.junit.jupiter.api.AfterAll
@@ -280,6 +281,60 @@ class BasicUsageTest {
     fun `list empty`() {
         val userId = 3
         val result: List<User> = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }.list()
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun sequenceMap() {
+        val result = kueryClient.sql { +"SELECT * FROM users" }.sequenceMap().toList()
+        assertThat(result).isEqualTo(
+            listOf(
+                mapOf(
+                    "user_id" to 1,
+                    "username" to "user1",
+                    "email" to "user1@example.com",
+                ),
+                mapOf(
+                    "user_id" to 2,
+                    "username" to "user2",
+                    "email" to "user2@example.com",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `sequenceMap empty`() {
+        val userId = 3
+        val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }.sequenceMap().toList()
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun sequence() {
+        val result: List<User> = kueryClient.sql { +"SELECT * FROM users" }.sequence<User>().toList()
+        assertThat(result).isEqualTo(
+            listOf(
+                User(
+                    userId = 1,
+                    username = "user1",
+                    email = "user1@example.com",
+                ),
+                User(
+                    userId = 2,
+                    username = "user2",
+                    email = "user2@example.com",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `sequence empty`() {
+        val userId = 3
+        val result: List<User> = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }
+            .sequence<User>()
+            .toList()
         assertThat(result).isEmpty()
     }
 


### PR DESCRIPTION
  ## Summary

  - Adds `sequenceMap(): Sequence<Map<String, Any?>>` and `sequence(returnType: KClass<T>): Sequence<T>` to `KueryBlockingClient.FetchSpec`, as the blocking equivalent of the R2DBC `flowMap()` / `flow()` APIs
  - Also adds a reified inline extension `sequence<T>()` for ergonomic usage
  - Backed by Spring `JdbcClient.MappedQuerySpec.stream()` wrapped via `kotlin.streams.asSequence()`
  - Observation and sqlId scoping are intentionally skipped, consistent with the existing R2DBC `flow*` decision (ambiguous start/end timing)
  - Resource lifecycle (open JDBC ResultSet, active transaction requirement, single-pass constraint) is documented in KDoc and `docs/basics.md`; no automatic close is attempted

  ## Test plan

  - [x] `BasicUsageTest.sequenceMap` — fetches multiple rows as `Sequence<Map<String, Any?>>` and collects to list
  - [x] `BasicUsageTest.sequenceMap empty` — verifies empty result
  - [x] `BasicUsageTest.sequence` — fetches multiple rows mapped to a data class via reified extension
  - [x] `BasicUsageTest.sequence empty` — verifies empty result
  - [x] ktlint / detekt — no violations
  - [x] Full module build passes