### PR TITLE
Convert enum elements to name in collection/array binding

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -80,10 +80,10 @@ internal class DefaultSpringJdbcKueryClient(
             null
         } else {
             val targetType = customConversions.getCustomWriteTarget(it::class.java)
-            if (targetType.isPresent) {
-                conversionService.convert(it, targetType.get())
-            } else {
-                it
+            when {
+                targetType.isPresent -> conversionService.convert(it, targetType.get())
+                it is Enum<*> -> it.name
+                else -> it
             }
         }
     }
@@ -93,10 +93,10 @@ internal class DefaultSpringJdbcKueryClient(
             null
         } else {
             val targetType = customConversions.getCustomWriteTarget(it::class.java)
-            if (targetType.isPresent) {
-                conversionService.convert(it, targetType.get())
-            } else {
-                it
+            when {
+                targetType.isPresent -> conversionService.convert(it, targetType.get())
+                it is Enum<*> -> it.name
+                else -> it
             }
         }
     }.toTypedArray()

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/EnumConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/EnumConversionTest.kt
@@ -44,6 +44,18 @@ class EnumConversionTest {
         assertThat(map["text"]).isEqualTo("HOGE")
     }
 
+    @Test
+    fun testInCollection() {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
+        }.rowsUpdated()
+
+        val record: Record = kueryClient.sql {
+            +"SELECT * FROM converter WHERE text IN (${listOf(SampleEnum.HOGE)})"
+        }.single()
+        assertThat(record.text).isEqualTo(SampleEnum.HOGE)
+    }
+
     companion object {
         private val mysql = MySqlTestContainer()
 

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -86,10 +86,10 @@ internal class DefaultSpringR2dbcKueryClient(
             null
         } else {
             val targetType = customConversions.getCustomWriteTarget(it::class.java)
-            if (targetType.isPresent) {
-                conversionService.convert(it, targetType.get())
-            } else {
-                it
+            when {
+                targetType.isPresent -> conversionService.convert(it, targetType.get())
+                it is Enum<*> -> it.name
+                else -> it
             }
         }
     }
@@ -99,10 +99,10 @@ internal class DefaultSpringR2dbcKueryClient(
             null
         } else {
             val targetType = customConversions.getCustomWriteTarget(it::class.java)
-            if (targetType.isPresent) {
-                conversionService.convert(it, targetType.get())
-            } else {
-                it
+            when {
+                targetType.isPresent -> conversionService.convert(it, targetType.get())
+                it is Enum<*> -> it.name
+                else -> it
             }
         }
     }.toTypedArray()

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/EnumConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/EnumConversionTest.kt
@@ -45,6 +45,18 @@ class EnumConversionTest {
         assertThat(map["text"]).isEqualTo("HOGE")
     }
 
+    @Test
+    fun testInCollection() = runTest {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
+        }.rowsUpdated()
+
+        val record: Record = kueryClient.sql {
+            +"SELECT * FROM converter WHERE text IN (${listOf(SampleEnum.HOGE)})"
+        }.single()
+        assertThat(record.text).isEqualTo(SampleEnum.HOGE)
+    }
+
     companion object {
         private val mysql = MySqlTestContainer()
 


### PR DESCRIPTION
## Summary

Scalar enum values are bound as their `name`, but elements inside `Collection` / `Array` were passed through as-is. As a result, `WHERE status = ${Status.ACTIVE}` works but `WHERE status IN (${listOf(Status.ACTIVE)})` fails to encode at the driver level:

- JDBC (MySQL): the enum element is Java-serialized into a binary blob → `SQL state HY000, error code 3854: Cannot convert string '\xAC\xED...' from binary to utf8mb4`
- R2DBC: driver-level encode failure

This PR applies the same enum-to-name conversion in `convertCollection` / `convertArray` of both `DefaultSpringJdbcKueryClient` and `DefaultSpringR2dbcKueryClient`, keeping the same precedence as the scalar path (custom conversions win over enum name conversion).

## Tests

Added `IN (${listOf(enum)})` cases to `EnumConversionTest` in both modules. Verified they fail before the fix (errors above) and pass after.

Note: `IN (${arrayOf(...)})` is not covered — array binding for IN clauses does not work on MySQL regardless of element type (Spring expands collections into placeholders but passes arrays through whole; verified with a plain `arrayOf("HOGE")` failing identically before this change). The `convertArray` fix is still applied for consistency and for drivers with native array support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)