### PR TITLE
Fix resource leak in JDBC sequence()/sequenceMap()

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/CloseableSequence.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/CloseableSequence.kt
@@ -14,6 +14,9 @@ package dev.hsbrysk.kuery.core
  * ```
  *
  * This sequence can be iterated only once.
+ *
+ * Like ordinary [Sequence]s (and the underlying JDBC resources), this sequence is not thread-safe;
+ * obtain and iterate it on a single thread.
  */
 interface CloseableSequence<out T> :
     Sequence<T>,

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/CloseableSequence.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/CloseableSequence.kt
@@ -1,0 +1,20 @@
+package dev.hsbrysk.kuery.core
+
+/**
+ * A [Sequence] backed by an underlying resource (e.g., an open JDBC ResultSet) that must be released.
+ *
+ * The resource is closed automatically when the iteration reaches the end, or when an exception is
+ * thrown during the iteration. If you stop iterating midway (e.g., with `take` or `first`), close it
+ * explicitly with [close], typically via [use]:
+ *
+ * ```kotlin
+ * client.sql { +"SELECT * FROM users" }.sequence<User>().use { seq ->
+ *     seq.first()
+ * }
+ * ```
+ *
+ * This sequence can be iterated only once.
+ */
+interface CloseableSequence<out T> :
+    Sequence<T>,
+    AutoCloseable

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
@@ -72,14 +72,18 @@ interface KueryBlockingClient {
         /**
          * Receives the results of multiple rows as a sequence of maps.
          * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active transaction.
+         * It is closed automatically when fully iterated or when an exception is thrown during the iteration.
+         * If you stop iterating midway, close it explicitly (e.g., with [use]). It can be iterated only once.
          */
-        fun sequenceMap(): Sequence<Map<String, Any?>>
+        fun sequenceMap(): CloseableSequence<Map<String, Any?>>
 
         /**
          * Receives the results of multiple rows converted to the specified type as a sequence.
          * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active transaction.
+         * It is closed automatically when fully iterated or when an exception is thrown during the iteration.
+         * If you stop iterating midway, close it explicitly (e.g., with [use]). It can be iterated only once.
          */
-        fun <T : Any> sequence(returnType: KClass<T>): Sequence<T>
+        fun <T : Any> sequence(returnType: KClass<T>): CloseableSequence<T>
 
         /**
          * Contract for fetching the number of affected rows
@@ -112,4 +116,4 @@ inline fun <reified T : Any> FetchSpec.list(): List<T> = list(T::class)
 /**
  * Receives the results of multiple rows converted to the specified type as a sequence.
  */
-inline fun <reified T : Any> FetchSpec.sequence(): Sequence<T> = sequence(T::class)
+inline fun <reified T : Any> FetchSpec.sequence(): CloseableSequence<T> = sequence(T::class)

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -1,5 +1,6 @@
 package dev.hsbrysk.kuery.spring.jdbc.internal
 
+import dev.hsbrysk.kuery.core.CloseableSequence
 import dev.hsbrysk.kuery.core.KueryBlockingClient
 import dev.hsbrysk.kuery.core.NamedSqlParameter
 import dev.hsbrysk.kuery.core.Sql
@@ -25,7 +26,6 @@ import org.springframework.jdbc.core.simple.JdbcClient.StatementSpec
 import org.springframework.jdbc.support.GeneratedKeyHolder
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
-import kotlin.streams.asSequence
 
 internal class DefaultSpringJdbcKueryClient(
     private val jdbcClient: JdbcClient,
@@ -150,20 +150,20 @@ internal class DefaultSpringJdbcKueryClient(
             buildSpec().queryType(returnType).list()
         }
 
-        override fun sequenceMap(): Sequence<Map<String, Any?>> {
+        override fun sequenceMap(): CloseableSequence<Map<String, Any?>> {
             // TODO:
             // I also want to measure the observation of flow.
             // However, should it be the time until the flow terminates or the time until the first element is obtained?
             // There are many uncertainties, so I will not implement it for now.
-            return buildSpec().query(ColumnMapRowMapper()).stream().asSequence()
+            return buildSpec().query(ColumnMapRowMapper()).stream().asCloseableSequence()
         }
 
-        override fun <T : Any> sequence(returnType: KClass<T>): Sequence<T> {
+        override fun <T : Any> sequence(returnType: KClass<T>): CloseableSequence<T> {
             // TODO:
             // I also want to measure the observation of flow.
             // However, should it be the time until the flow terminates or the time until the first element is obtained?
             // There are many uncertainties, so I will not implement it for now.
-            return buildSpec().queryType(returnType).stream().asSequence()
+            return buildSpec().queryType(returnType).stream().asCloseableSequence()
         }
 
         override fun rowsUpdated(): Long = observe {

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequence.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequence.kt
@@ -1,0 +1,53 @@
+package dev.hsbrysk.kuery.spring.jdbc.internal
+
+import dev.hsbrysk.kuery.core.CloseableSequence
+import java.util.stream.Stream
+
+/**
+ * Wraps this [Stream] into a [CloseableSequence] that preserves the stream's close handlers.
+ *
+ * The stream is closed when the iteration reaches the end, when [Iterator.hasNext] / [Iterator.next]
+ * throws, or when [CloseableSequence.close] is called explicitly.
+ */
+internal fun <T> Stream<T>.asCloseableSequence(): CloseableSequence<T> = StreamCloseableSequence(this)
+
+private class StreamCloseableSequence<T>(private val stream: Stream<T>) : CloseableSequence<T> {
+    private var closed = false
+    private var iterated = false
+
+    override fun iterator(): Iterator<T> {
+        check(!iterated) { "This sequence can be iterated only once." }
+        check(!closed) { "This sequence is already closed." }
+        iterated = true
+        val iterator = stream.iterator()
+        // The underlying stream iterator throws NoSuchElementException when exhausted.
+        @Suppress("IteratorNotThrowingNoSuchElementException")
+        return object : Iterator<T> {
+            override fun hasNext(): Boolean = closeOnFailure {
+                val hasNext = iterator.hasNext()
+                if (!hasNext) {
+                    close()
+                }
+                hasNext
+            }
+
+            override fun next(): T = closeOnFailure {
+                iterator.next()
+            }
+        }
+    }
+
+    override fun close() {
+        if (!closed) {
+            closed = true
+            stream.close()
+        }
+    }
+
+    private inline fun <R> closeOnFailure(block: () -> R): R = try {
+        block()
+    } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+        close()
+        throw e
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/MySqlTestContainer.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/MySqlTestContainer.kt
@@ -8,7 +8,7 @@ import org.testcontainers.mysql.MySQLContainer
 
 class MySqlTestContainer : AutoCloseable {
     private val mysqlContainer = MySQLContainer("mysql:8.0.37").also { it.start() }
-    private val dataSource = MysqlDataSource().apply {
+    val dataSource = MysqlDataSource().apply {
         setURL(mysqlContainer.jdbcUrl)
         user = mysqlContainer.username
         password = mysqlContainer.password

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SequenceResourceManagementTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SequenceResourceManagementTest.kt
@@ -1,0 +1,118 @@
+package dev.hsbrysk.kuery.spring.jdbc
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isTrue
+import dev.hsbrysk.kuery.core.sequence
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.sql.DataSource
+
+class SequenceResourceManagementTest {
+    private val kueryClient = SpringJdbcKueryClient.builder()
+        .dataSource(trackingDataSource)
+        .build()
+
+    @BeforeEach
+    fun beforeEach() {
+        mysql.jdbcClient.sql(
+            """
+            CREATE TABLE users (
+                user_id INT AUTO_INCREMENT PRIMARY KEY,
+                username VARCHAR(50) NOT NULL
+            )
+            """.trimIndent(),
+        ).update()
+        mysql.jdbcClient.sql("INSERT INTO users (username) VALUES ('user1'), ('user2')").update()
+        trackingDataSource.connections.clear()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        mysql.jdbcClient.sql("DROP TABLE users").update()
+    }
+
+    @Test
+    fun `sequence releases the connection after full iteration`() {
+        val result: List<User> = kueryClient.sql { +"SELECT * FROM users" }.sequence<User>().toList()
+        assertThat(result).isEqualTo(
+            listOf(
+                User(userId = 1, username = "user1"),
+                User(userId = 2, username = "user2"),
+            ),
+        )
+        assertAllTrackedConnectionsClosed()
+    }
+
+    @Test
+    fun `sequenceMap releases the connection after full iteration`() {
+        val result = kueryClient.sql { +"SELECT * FROM users" }.sequenceMap().toList()
+        assertThat(result).isEqualTo(
+            listOf(
+                mapOf("user_id" to 1, "username" to "user1"),
+                mapOf("user_id" to 2, "username" to "user2"),
+            ),
+        )
+        assertAllTrackedConnectionsClosed()
+    }
+
+    @Test
+    fun `sequence releases the connection when row mapping fails`() {
+        assertFailure {
+            kueryClient.sql { +"SELECT username FROM users" }.sequence<Int>().toList()
+        }
+        assertAllTrackedConnectionsClosed()
+    }
+
+    @Test
+    fun `sequence releases the connection when closed via use after partial iteration`() {
+        val result = kueryClient.sql { +"SELECT * FROM users" }.sequence<User>().use { seq ->
+            seq.first()
+        }
+        assertThat(result).isEqualTo(User(userId = 1, username = "user1"))
+        assertAllTrackedConnectionsClosed()
+    }
+
+    @Test
+    fun `sequence can be iterated only once`() {
+        val seq = kueryClient.sql { +"SELECT * FROM users" }.sequence<User>()
+        seq.toList()
+        assertFailure { seq.toList() }.isInstanceOf(IllegalStateException::class)
+    }
+
+    private fun assertAllTrackedConnectionsClosed() {
+        assertThat(trackingDataSource.connections).isNotEmpty()
+        trackingDataSource.connections.forEach {
+            assertThat(it.isClosed).isTrue()
+        }
+    }
+
+    data class User(
+        val userId: Int,
+        val username: String,
+    )
+
+    private class TrackingDataSource(private val delegate: DataSource) : DataSource by delegate {
+        val connections = CopyOnWriteArrayList<Connection>()
+
+        override fun getConnection(): Connection = delegate.connection.also { connections.add(it) }
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer()
+        private val trackingDataSource = TrackingDataSource(mysql.dataSource)
+
+        @AfterAll
+        @JvmStatic
+        fun afterAll() {
+            mysql.close()
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`KueryBlockingClient.FetchSpec.sequence()` / `sequenceMap()` wrapped the `Stream` returned by `JdbcTemplate.queryForStream` with `kotlin.streams.asSequence()`, which discards the stream's `onClose` handler. A Java `Stream` is never closed by mere iteration, so the underlying Statement/ResultSet (and, outside a transaction, the Connection) were **never released — even after fully iterating the sequence**. Calling these methods repeatedly outside a transaction leaks one connection per call and eventually exhausts the pool.

## Fix

- Introduce `CloseableSequence<T>` (`Sequence<T> + AutoCloseable`) in `kuery-client-core` and change the return type of `sequence()` / `sequenceMap()` to it (source-compatible narrowing; pre-1.0 so binary compatibility is not a concern).
- Wrap the stream in the JDBC module so that it is closed automatically:
  - when the iteration reaches the end
  - when `hasNext()` / `next()` throws (e.g., row mapping failure)
- Callers that stop iterating midway (`take`, `first`, etc.) can release the resource explicitly via `use {}`.
- The sequence can be iterated only once; a second `iterator()` call fails with a clear `IllegalStateException` instead of the confusing stream-reuse error.

## Tests

New `SequenceResourceManagementTest` tracks connections handed out by the `DataSource` and asserts they are closed. Written test-first: the full-iteration and mapping-failure cases were confirmed to fail (= leak reproduced) against the previous implementation.

- full iteration releases the connection (`sequence` / `sequenceMap`)
- `use {}` releases the connection after partial iteration
- row-mapping failure releases the connection
- second iteration fails with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)