### PR TITLE
Fix nested add/unaryPlus breaking string interpolation transformation

### DIFF
--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
@@ -188,6 +188,74 @@ class StringInterpolationTest {
     }
 
     @Test
+    fun `nested add`() {
+        val x = "X"
+        val y = "1; DROP TABLE users"
+        val sql = Sql {
+            add(
+                run {
+                    add("B $x")
+                    "S $y"
+                },
+            )
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "B :p0\nS :p1",
+                listOf(NamedSqlParameter("p0", "X"), NamedSqlParameter("p1", y)),
+            ),
+        )
+    }
+
+    @Test
+    fun `nested unaryPlus`() {
+        val x = "X"
+        val y = "1; DROP TABLE users"
+        val sql = Sql {
+            +run {
+                +"B $x"
+                "S $y"
+            }
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "B :p0\nS :p1",
+                listOf(NamedSqlParameter("p0", "X"), NamedSqlParameter("p1", y)),
+            ),
+        )
+    }
+
+    @Test
+    fun `doubly nested add`() {
+        val x = "X"
+        val y = "Y"
+        val z = "Z"
+        val sql = Sql {
+            add(
+                run {
+                    add(
+                        run {
+                            add("A $x")
+                            "B $y"
+                        },
+                    )
+                    "C $z"
+                },
+            )
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "A :p0\nB :p1\nC :p2",
+                listOf(
+                    NamedSqlParameter("p0", "X"),
+                    NamedSqlParameter("p1", "Y"),
+                    NamedSqlParameter("p2", "Z"),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `null string interpolation`() {
         // In such cases, string interpolation will not be executed.
         val sql1 = Sql {

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -28,6 +28,9 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
 
     override fun visitCall(expression: IrCall): IrExpression {
         if (expression.isAddOrUnaryPlus()) {
+            // Save/restore so that a nested add/unaryPlus inside the argument expression
+            // doesn't clear the enclosing call's context.
+            val previous = current
             return try {
                 current = expression
                 super.visitCall(expression)
@@ -38,7 +41,7 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
                     else -> error("Unexpected error") // not happened
                 }
             } finally {
-                current = null
+                current = previous
             }
         }
 


### PR DESCRIPTION
## Summary

`StringInterpolationTransformer` tracks the enclosing `add`/`unaryPlus` call in a single `current` field, and its `finally` block reset it to `null` instead of restoring the previous value. When an `add`/`unaryPlus` call appeared inside the argument expression of an enclosing one, e.g.:

```kotlin
add(
    run {
        add("B $x")
        "S $y"   // left untransformed
    },
)
```

the inner call cleared `current` before the enclosing template `"S $y"` was visited, so that template was never rewritten to `interpolate(...)`. At runtime the raw concatenated string (`"S " + y`) was passed to `addUnsafe` — no parameter binding, no error, no warning. Since binding all interpolated values is the core guarantee of this library, the failure is silent and data-dependent (a value containing a quote breaks the query, or worse).

## Fix

Save and restore the previous `current` value around each transformed call (`finally { current = previous }`). Nested calls now transform correctly against their own enclosing receiver.

## Tests

Added functional tests (compiled through the actual compiler plugin) for nested `add`, nested `unaryPlus`, and doubly nested `add`. Verified they fail before the fix (raw string leaked into the SQL body with missing parameters) and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)