### PR TITLE
Fix runtime crash when interpolating const val in SQL templates

### DIFF
--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
@@ -5,6 +5,9 @@ import assertk.assertions.isEqualTo
 import io.mockk.InternalPlatformDsl.toStr
 import org.junit.jupiter.api.Test
 
+private const val TABLE = "users"
+private const val ORDER_COLUMN = "created_at"
+
 class StringInterpolationTest {
     @Test
     fun none() {
@@ -251,6 +254,98 @@ class StringInterpolationTest {
                     NamedSqlParameter("p1", "Y"),
                     NamedSqlParameter("p2", "Z"),
                 ),
+            ),
+        )
+    }
+
+    @Test
+    fun `const val string interpolation`() {
+        val id = 1
+        val sql = Sql {
+            +"SELECT * FROM $TABLE WHERE id = $id"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "SELECT * FROM users WHERE id = :p0",
+                listOf(NamedSqlParameter("p0", 1)),
+            ),
+        )
+    }
+
+    @Test
+    fun `const val only`() {
+        val sql = Sql {
+            +"$TABLE"
+        }
+        assertThat(sql).isEqualTo(Sql("users"))
+    }
+
+    @Test
+    fun `trailing const val`() {
+        val id = 1
+        val sql = Sql {
+            +"WHERE id = $id ORDER BY $ORDER_COLUMN"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "WHERE id = :p0 ORDER BY created_at",
+                listOf(NamedSqlParameter("p0", 1)),
+            ),
+        )
+    }
+
+    @Test
+    fun `char constant string interpolation`() {
+        val x = 1
+        val sql = Sql {
+            +"SELECT data->>'${'$'}name' FROM t WHERE id = $x"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "SELECT data->>'\$name' FROM t WHERE id = :p0",
+                listOf(NamedSqlParameter("p0", 1)),
+            ),
+        )
+    }
+
+    @Test
+    fun `char percent constant string interpolation`() {
+        val keyword = "foo"
+        val sql = Sql {
+            +"WHERE name LIKE ${'%'}$keyword${'%'}"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "WHERE name LIKE %:p0%",
+                listOf(NamedSqlParameter("p0", "foo")),
+            ),
+        )
+    }
+
+    @Test
+    fun `consecutive constants are merged`() {
+        val x = 1
+        val sql = Sql {
+            +"a$TABLE${'c'} $x"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "ausersc :p0",
+                listOf(NamedSqlParameter("p0", 1)),
+            ),
+        )
+    }
+
+    @Test
+    fun `literal string interpolation mixed with runtime value`() {
+        val x = 1
+        val sql = Sql {
+            +"a ${"hoge"} b $x"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "a hoge b :p0",
+                listOf(NamedSqlParameter("p0", 1)),
             ),
         )
     }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/StringConcatenationProcessor.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/StringConcatenationProcessor.kt
@@ -5,8 +5,6 @@ import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstKind
 import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.types.classFqName
-import org.jetbrains.kotlin.ir.util.superTypes
 
 internal class StringConcatenationProcessor(private val builder: IrBuilderWithScope) {
     // first: fragments, second: values
@@ -14,30 +12,36 @@ internal class StringConcatenationProcessor(private val builder: IrBuilderWithSc
         val fragments = mutableListOf<IrExpression>()
         val values = mutableListOf<IrExpression>()
 
-        val iterator = expressions.iterator()
-        var mustAddFragment = true
-
-        while (iterator.hasNext()) {
-            val current = iterator.next()
-            if (isFragment(current)) {
-                fragments.add(current)
-                mustAddFragment = false
+        // K2 constant-folds `const val` references into standalone IrConst nodes without merging
+        // them with adjacent literal fragments, so consecutive constants must be concatenated here
+        // to keep the fragments/values invariant expected by `DefaultSqlBuilder.interpolate`.
+        val pending = StringBuilder()
+        for (expression in expressions) {
+            val text = fragmentTextOrNull(expression)
+            if (text != null) {
+                pending.append(text)
             } else {
                 // The reason for adding an empty string fragment can be found in `DefaultSqlBuilder.interpolate`.
-                if (mustAddFragment) {
-                    fragments.add(builder.irString(""))
-                }
-                values.add(current)
-                mustAddFragment = true
+                fragments.add(builder.irString(pending.toString()))
+                pending.clear()
+                values.add(expression)
             }
+        }
+        if (pending.isNotEmpty()) {
+            fragments.add(builder.irString(pending.toString()))
         }
 
         return fragments to values
     }
 
-    private fun isFragment(expression: IrExpression): Boolean {
-        val isString = expression.type.classFqName?.asString() == ClassNames.STRING ||
-            expression.type.superTypes().any { it.classFqName?.asString() == ClassNames.STRING }
-        return isString && expression is IrConst && expression.kind == IrConstKind.String
+    // Compile-time String/Char constants become SQL text, while runtime values are bound as parameters.
+    private fun fragmentTextOrNull(expression: IrExpression): String? {
+        if (expression !is IrConst) {
+            return null
+        }
+        return when (expression.kind) {
+            IrConstKind.String, IrConstKind.Char -> expression.value.toString()
+            else -> null
+        }
     }
 }


### PR DESCRIPTION
## Problem

Interpolating a compile-time constant in a SQL template crashed at runtime:

```kotlin
const val TABLE = "users"

client.sql {
    +"SELECT * FROM $TABLE WHERE id = $id"
}
// => IllegalStateException: The number of elements in `fragments`(3) and `values`(1) is incorrect.
//    There might be an issue with the Kotlin compiler plugin.
```

K2 constant-folds `const val` references into standalone `IrConst` nodes but does **not** merge them with adjacent literal fragments. `StringConcatenationProcessor` therefore produced `fragments=3 / values=1`, violating the invariant checked in `DefaultSqlBuilder.interpolate` (fragments == values or values + 1).

Relatedly, `Char` constants such as `${'$'}` / `${'%'}` (commonly used to escape `$` in templates) were classified as runtime values and silently bound as parameters — `+"SELECT data->>'${'$'}name' FROM t WHERE id = $x"` produced body `SELECT data->>':p0name' ...` with `p0='$'`.

## Fix

`StringConcatenationProcessor` now:

- treats compile-time **String and Char constants** as SQL text fragments (Char was previously bound as a parameter), and
- **concatenates consecutive constant fragments at compile time**, restoring the fragments/values invariant.

The rule stays minimal: only String/Char constants become SQL text. Non-string constants like `${1}` / `${true}` / `${null}` keep the existing behavior of being bound as parameters (existing tests unchanged). Note that binding `const val` references is not implementable: at the IR stage they are already folded into `IrConst` nodes indistinguishable from literal fragments (verified via IR dump on Kotlin 2.4.0). Text expansion also matches the common use case of constants for table/column names, and `add(CONST)` already behaving as raw text. A value-intended constant can still be bound by dropping the `const` modifier.

## Tests

Added functional tests (test-first; confirmed failing before the fix):

- const val interpolation (previously: `IllegalStateException`)
- trailing const val (`fragments == values + 1` path, previously: `IllegalStateException`)
- `${'$'}` / `${'%'}` Char constants (previously: silently bound as parameters)
- consecutive literal/const/Char constants merged into one fragment
- regressions pinning current behavior: const-only template, literal-string interpolation mixed with a runtime value

🤖 Generated with [Claude Code](https://claude.com/claude-code)