### PR TITLE
Fix missing sqlId Reactor context in R2DBC rowsUpdated()

### DIFF
--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -157,7 +157,7 @@ internal class DefaultSpringR2dbcKueryClient(
         }
 
         override suspend fun rowsUpdated(): Long = observe {
-            spec.fetch().rowsUpdated().awaitSingle()
+            spec.fetch().rowsUpdated().sqlId(sqlId).awaitSingle()
         }
 
         override suspend fun generatedValues(vararg columns: String): Map<String, Any> = observe {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/com/example/spring/r2dbc/SampleRepository.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/com/example/spring/r2dbc/SampleRepository.kt
@@ -1,9 +1,11 @@
 package com.example.spring.r2dbc
 
 import dev.hsbrysk.kuery.core.KueryClient
+import dev.hsbrysk.kuery.core.flow
 import dev.hsbrysk.kuery.core.list
 import dev.hsbrysk.kuery.core.single
 import dev.hsbrysk.kuery.core.singleOrNull
+import kotlinx.coroutines.flow.Flow
 
 data class User(
     val userId: Int,
@@ -32,6 +34,10 @@ class UserRepository(private val kueryClient: KueryClient) {
     suspend fun listMap(): List<Map<String, Any?>> = kueryClient.sql { +"SELECT * FROM users" }.listMap()
 
     suspend fun list(): List<User> = kueryClient.sql { +"SELECT * FROM users" }.list()
+
+    fun flowMap(): Flow<Map<String, Any?>> = kueryClient.sql { +"SELECT * FROM users" }.flowMap()
+
+    fun flow(): Flow<User> = kueryClient.sql { +"SELECT * FROM users" }.flow()
 
     suspend fun rowUpdated(
         username: String,

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/MySqlTestContainer.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/MySqlTestContainer.kt
@@ -12,7 +12,7 @@ import org.testcontainers.mysql.MySQLContainer
 
 class MySqlTestContainer : AutoCloseable {
     private val mysqlContainer = MySQLContainer("mysql:8.0.37").also { it.start() }
-    private val connectionFactory = connectionFactory()
+    val connectionFactory = connectionFactory()
     val databaseClient: DatabaseClient = DatabaseClient.builder()
         .connectionFactory(connectionFactory)
         .bindMarkers(DialectResolver.getDialect(connectionFactory).bindMarkersFactory)

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SqlIdReactorContextTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SqlIdReactorContextTest.kt
@@ -1,0 +1,179 @@
+package dev.hsbrysk.kuery.spring.r2dbc
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import com.example.spring.r2dbc.UserRepository
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.Result
+import io.r2dbc.spi.Statement
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import org.springframework.r2dbc.core.awaitRowsUpdated
+import reactor.core.publisher.Flux
+import java.util.concurrent.CopyOnWriteArrayList
+
+class SqlIdReactorContextTest {
+    private val capturedSqlIds = CopyOnWriteArrayList<String?>()
+    private val kueryClient = SpringR2dbcKueryClient.builder()
+        .connectionFactory(SqlIdCapturingConnectionFactory(mysql.connectionFactory, capturedSqlIds))
+        .enableAutoSqlIdGeneration(true)
+        .build()
+    private val userRepository = UserRepository(kueryClient)
+
+    @BeforeEach
+    fun setUp() = runTest {
+        mysql.databaseClient.sql(
+            """
+            CREATE TABLE users (
+                user_id INT AUTO_INCREMENT PRIMARY KEY,
+                username VARCHAR(50) NOT NULL,
+                email VARCHAR(100) NOT NULL
+            );
+
+            INSERT INTO users (username, email) VALUES
+            ('user1', 'user1@example.com'),
+            ('user2', 'user2@example.com');
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+        capturedSqlIds.clear()
+    }
+
+    @AfterEach
+    fun testDown() = runTest {
+        mysql.databaseClient.sql(
+            """
+            DROP TABLE users;
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun singleMap() = runTest {
+        userRepository.singleMap(1)
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.singleMap")
+    }
+
+    @Test
+    fun singleMapOrNull() = runTest {
+        userRepository.singleMapOrNull(1)
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.singleMapOrNull")
+    }
+
+    @Test
+    fun single() = runTest {
+        userRepository.single(1)
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.single")
+    }
+
+    @Test
+    fun singleOrNull() = runTest {
+        userRepository.singleOrNull(1)
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.singleOrNull")
+    }
+
+    @Test
+    fun listMap() = runTest {
+        userRepository.listMap()
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.listMap")
+    }
+
+    @Test
+    fun list() = runTest {
+        userRepository.list()
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.list")
+    }
+
+    @Test
+    fun flowMap() = runTest {
+        userRepository.flowMap().collect()
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.flowMap")
+    }
+
+    @Test
+    fun flow() = runTest {
+        userRepository.flow().collect()
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.flow")
+    }
+
+    @Test
+    fun rowsUpdated() = runTest {
+        userRepository.rowUpdated("user3", "user3@example.com")
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.rowUpdated")
+    }
+
+    @Test
+    fun generatedValues() = runTest {
+        userRepository.generatedValues("user3", "user3@example.com")
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.generatedValues")
+    }
+
+    private class SqlIdCapturingConnectionFactory(
+        private val delegate: ConnectionFactory,
+        private val captured: MutableList<String?>,
+    ) : ConnectionFactory by delegate {
+        override fun create(): Publisher<out Connection> = Flux.from(delegate.create())
+            .map { SqlIdCapturingConnection(it, captured) }
+    }
+
+    private class SqlIdCapturingConnection(
+        private val delegate: Connection,
+        private val captured: MutableList<String?>,
+    ) : Connection by delegate {
+        override fun createStatement(sql: String): Statement =
+            SqlIdCapturingStatement(delegate.createStatement(sql), captured)
+    }
+
+    // Fluent methods must return `this` (not the delegate) so that execute() below stays wrapped.
+    private class SqlIdCapturingStatement(
+        private val delegate: Statement,
+        private val captured: MutableList<String?>,
+    ) : Statement {
+        override fun add(): Statement = apply { delegate.add() }
+
+        override fun bind(
+            index: Int,
+            value: Any,
+        ): Statement = apply { delegate.bind(index, value) }
+
+        override fun bind(
+            name: String,
+            value: Any,
+        ): Statement = apply { delegate.bind(name, value) }
+
+        override fun bindNull(
+            index: Int,
+            type: Class<*>,
+        ): Statement = apply { delegate.bindNull(index, type) }
+
+        override fun bindNull(
+            name: String,
+            type: Class<*>,
+        ): Statement = apply { delegate.bindNull(name, type) }
+
+        override fun fetchSize(rows: Int): Statement = apply { delegate.fetchSize(rows) }
+
+        override fun returnGeneratedValues(vararg columns: String): Statement =
+            apply { delegate.returnGeneratedValues(*columns) }
+
+        override fun execute(): Publisher<out Result> = Flux.deferContextual { context ->
+            captured.add(SpringR2dbcKueryClient.sqlId(context))
+            Flux.from(delegate.execute())
+        }
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer()
+
+        @AfterAll
+        @JvmStatic
+        fun afterAll() {
+            mysql.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

All terminal operations in `DefaultSpringR2dbcKueryClient.FetchSpec` write the sqlId into the Reactor context via `.sqlId(sqlId)` — except `rowsUpdated()`. As a result, `SpringR2dbcKueryClient.sqlId(context)` returned `null` for INSERT/UPDATE/DELETE statements, which are exactly the ones users most want to identify in proxy listeners and logs. The JDBC module already covers this via `SqlIdInjector`, so the two modules were asymmetric.

## Changes

- Add the missing `.sqlId(sqlId)` to `rowsUpdated()` (one line).
- Add `SqlIdReactorContextTest` covering **all** terminal operations: it wraps the test `ConnectionFactory` / `Connection` / `Statement` and reads the Reactor context at `Statement.execute()` time — the same position a proxy listener would observe it.
- Test-first: before the fix, `rowsUpdated()` failed with a captured sqlId of `null` while the other nine operations passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)