### PR TITLE
Fix R2DBC observation leaking ThreadLocal scope across coroutine suspension

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-co
 kotlin-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlin-coroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlint" }
+micrometer-context-propagation = { module = "io.micrometer:context-propagation", version = "1.2.1" }
 micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
 micrometer-observation-test = { module = "io.micrometer:micrometer-observation-test", version.ref = "micrometer" }
 mockk-core = { module = "io.mockk:mockk", version = "1.14.11" }

--- a/kuery-client-spring-data-r2dbc/build.gradle.kts
+++ b/kuery-client-spring-data-r2dbc/build.gradle.kts
@@ -13,11 +13,16 @@ dependencies {
     api(libs.kotlin.coroutines.core)
     api(libs.kotlin.coroutines.reactor)
 
+    // Required only to compile against ObservationThreadLocalAccessor.KEY (a compile-time
+    // constant inlined into the bytecode), so it is not needed at runtime.
+    compileOnly(libs.micrometer.context.propagation)
+
     testImplementation(platform(libs.spring.boot.bom))
     testImplementation("com.mysql:mysql-connector-j")
     testImplementation("io.asyncer:r2dbc-mysql")
     testImplementation("org.testcontainers:testcontainers-mysql")
     testImplementation(libs.kotlin.coroutines.test)
+    testImplementation(libs.micrometer.context.propagation)
     testImplementation(libs.micrometer.observation.test)
 
     kotlinCompilerPluginClasspath(projects.kueryClientCompiler)

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -28,7 +28,6 @@ import org.springframework.r2dbc.core.RowsFetchSpec
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Function
 import kotlin.reflect.KClass
 
@@ -183,35 +182,37 @@ internal class DefaultSpringR2dbcKueryClient(
         // Propagate the observation via the Reactor context instead, so downstream instrumentation
         // (r2dbc-proxy, Spring Boot's automatic context propagation) can restore it.
         // Same pattern as Spring's DefaultWebClient.exchange().
+        //
+        // The observation is stopped via usingWhen's cleanup handlers, which run BEFORE the terminal
+        // signal propagates downstream — this guarantees the observation is already stopped when the
+        // suspending caller resumes from awaitXxx.
         private fun <T : Any> Mono<T>.observe(): Mono<T> {
             val registry = observationRegistry ?: return this
             return Mono.deferContextual { contextView ->
-                val observation = KueryClientObservationDocumentation.FETCH.observation(
-                    observationConvention,
-                    defaultObservationConvention,
-                    { KueryClientFetchContext(sqlId, sql) },
-                    registry,
+                Mono.usingWhen(
+                    Mono.fromSupplier {
+                        KueryClientObservationDocumentation.FETCH
+                            .observation(
+                                observationConvention,
+                                defaultObservationConvention,
+                                { KueryClientFetchContext(sqlId, sql) },
+                                registry,
+                            )
+                            .parentObservation(
+                                contextView.getOrEmpty<Observation>(ObservationThreadLocalAccessor.KEY).orElse(null),
+                            )
+                            .start()
+                    },
+                    { observation -> this.contextWrite { it.put(ObservationThreadLocalAccessor.KEY, observation) } },
+                    { observation -> Mono.fromRunnable<Unit> { observation.stop() } },
+                    { observation, e ->
+                        Mono.fromRunnable<Unit> {
+                            observation.error(e)
+                            observation.stop()
+                        }
+                    },
+                    { observation -> Mono.fromRunnable<Unit> { observation.stop() } },
                 )
-                observation
-                    .parentObservation(
-                        contextView.getOrEmpty<Observation>(ObservationThreadLocalAccessor.KEY).orElse(null),
-                    )
-                    .start()
-                // Stop via doOnTerminate (which runs BEFORE the terminal signal reaches the awaiting
-                // caller) so the observation is guaranteed to be stopped when awaitXxx resumes.
-                // doOnCancel covers cancellation; the guard prevents a double stop when a cancel
-                // arrives after the terminal signal.
-                val stopped = AtomicBoolean()
-                val stopOnce = {
-                    if (stopped.compareAndSet(false, true)) {
-                        observation.stop()
-                    }
-                }
-                this
-                    .doOnError { observation.error(it) }
-                    .doOnTerminate { stopOnce() }
-                    .doOnCancel { stopOnce() }
-                    .contextWrite { it.put(ObservationThreadLocalAccessor.KEY, observation) }
             }
         }
 

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -11,6 +11,7 @@ import dev.hsbrysk.kuery.core.observation.KueryClientObservationDocumentation
 import dev.hsbrysk.kuery.spring.r2dbc.SpringR2dbcKueryClient
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor
 import io.r2dbc.spi.Readable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
@@ -116,29 +117,37 @@ internal class DefaultSpringR2dbcKueryClient(
         override fun fetchSize(fetchSize: Int): KueryClient.FetchSpec =
             FetchSpec(sqlId, sql, spec.filter(Function { it.fetchSize(fetchSize) }))
 
-        override suspend fun singleMap(): Map<String, Any?> = observe {
-            spec.fetch().one().sqlId(sqlId).awaitSingleOrNull() ?: throw EmptyResultDataAccessException(1)
-        }
+        override suspend fun singleMap(): Map<String, Any?> = spec.fetch().one()
+            .switchIfEmpty(Mono.error { EmptyResultDataAccessException(1) })
+            .sqlId(sqlId)
+            .observe()
+            .awaitSingle()
 
-        override suspend fun singleMapOrNull(): Map<String, Any?>? = observe {
-            spec.fetch().one().sqlId(sqlId).awaitSingleOrNull()
-        }
+        override suspend fun singleMapOrNull(): Map<String, Any?>? = spec.fetch().one()
+            .sqlId(sqlId)
+            .observe()
+            .awaitSingleOrNull()
 
-        override suspend fun <T : Any> single(returnType: KClass<T>): T = observe {
-            spec.map(returnType).one().sqlId(sqlId).awaitSingleOrNull() ?: throw EmptyResultDataAccessException(1)
-        }
+        override suspend fun <T : Any> single(returnType: KClass<T>): T = spec.map(returnType).one()
+            .switchIfEmpty(Mono.error { EmptyResultDataAccessException(1) })
+            .sqlId(sqlId)
+            .observe()
+            .awaitSingle()
 
-        override suspend fun <T : Any> singleOrNull(returnType: KClass<T>): T? = observe {
-            spec.map(returnType).one().sqlId(sqlId).awaitSingleOrNull()
-        }
+        override suspend fun <T : Any> singleOrNull(returnType: KClass<T>): T? = spec.map(returnType).one()
+            .sqlId(sqlId)
+            .observe()
+            .awaitSingleOrNull()
 
-        override suspend fun listMap(): List<Map<String, Any?>> = observe {
-            spec.fetch().all().collectList().sqlId(sqlId).awaitSingle()
-        }
+        override suspend fun listMap(): List<Map<String, Any?>> = spec.fetch().all().collectList()
+            .sqlId(sqlId)
+            .observe()
+            .awaitSingle()
 
-        override suspend fun <T : Any> list(returnType: KClass<T>): List<T> = observe {
-            spec.map(returnType).all().collectList().sqlId(sqlId).awaitSingle()
-        }
+        override suspend fun <T : Any> list(returnType: KClass<T>): List<T> = spec.map(returnType).all().collectList()
+            .sqlId(sqlId)
+            .observe()
+            .awaitSingle()
 
         override fun flowMap(): Flow<Map<String, Any?>> {
             // TODO:
@@ -156,41 +165,42 @@ internal class DefaultSpringR2dbcKueryClient(
             return spec.map(returnType).all().sqlId(sqlId).asFlow()
         }
 
-        override suspend fun rowsUpdated(): Long = observe {
-            spec.fetch().rowsUpdated().sqlId(sqlId).awaitSingle()
-        }
+        override suspend fun rowsUpdated(): Long = spec.fetch().rowsUpdated()
+            .sqlId(sqlId)
+            .observe()
+            .awaitSingle()
 
-        override suspend fun generatedValues(vararg columns: String): Map<String, Any> = observe {
-            spec.filter(Function { it.returnGeneratedValues(*columns) }).fetch().one().sqlId(sqlId).awaitSingleOrNull()
-                ?: throw EmptyResultDataAccessException(1)
-        }
+        override suspend fun generatedValues(vararg columns: String): Map<String, Any> =
+            spec.filter(Function { it.returnGeneratedValues(*columns) }).fetch().one()
+                .switchIfEmpty(Mono.error { EmptyResultDataAccessException(1) })
+                .sqlId(sqlId)
+                .observe()
+                .awaitSingle()
 
-        private suspend fun <T> observe(block: suspend () -> T): T {
-            val observation = observationOrNull() ?: return block()
-
-            observation.start()
-            return observation.openScope().use {
-                try {
-                    block()
-                } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
-                    observation.error(e)
-                    throw e
-                } finally {
-                    observation.stop()
-                }
+        // Do NOT open a ThreadLocal-based Observation.Scope here. The caller suspends (awaitSingle etc.),
+        // and an open scope would leak to unrelated coroutines running on the same thread while suspended.
+        // Propagate the observation via the Reactor context instead, so downstream instrumentation
+        // (r2dbc-proxy, Spring Boot's automatic context propagation) can restore it.
+        // Same pattern as Spring's DefaultWebClient.exchange().
+        private fun <T : Any> Mono<T>.observe(): Mono<T> {
+            val registry = observationRegistry ?: return this
+            return Mono.deferContextual { contextView ->
+                val observation = KueryClientObservationDocumentation.FETCH.observation(
+                    observationConvention,
+                    defaultObservationConvention,
+                    { KueryClientFetchContext(sqlId, sql) },
+                    registry,
+                )
+                observation
+                    .parentObservation(
+                        contextView.getOrEmpty<Observation>(ObservationThreadLocalAccessor.KEY).orElse(null),
+                    )
+                    .start()
+                this
+                    .doOnError { observation.error(it) }
+                    .doFinally { observation.stop() }
+                    .contextWrite { it.put(ObservationThreadLocalAccessor.KEY, observation) }
             }
-        }
-
-        private fun observationOrNull(): Observation? {
-            if (observationRegistry == null) {
-                return null
-            }
-            return KueryClientObservationDocumentation.FETCH.observation(
-                observationConvention,
-                defaultObservationConvention,
-                { KueryClientFetchContext(sqlId, sql) },
-                observationRegistry,
-            )
         }
 
         private fun <T : Any> Mono<T>.sqlId(sqlId: String): Mono<T> = contextWrite {

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -28,6 +28,7 @@ import org.springframework.r2dbc.core.RowsFetchSpec
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Function
 import kotlin.reflect.KClass
 
@@ -196,9 +197,20 @@ internal class DefaultSpringR2dbcKueryClient(
                         contextView.getOrEmpty<Observation>(ObservationThreadLocalAccessor.KEY).orElse(null),
                     )
                     .start()
+                // Stop via doOnTerminate (which runs BEFORE the terminal signal reaches the awaiting
+                // caller) so the observation is guaranteed to be stopped when awaitXxx resumes.
+                // doOnCancel covers cancellation; the guard prevents a double stop when a cancel
+                // arrives after the terminal signal.
+                val stopped = AtomicBoolean()
+                val stopOnce = {
+                    if (stopped.compareAndSet(false, true)) {
+                        observation.stop()
+                    }
+                }
                 this
                     .doOnError { observation.error(it) }
-                    .doFinally { observation.stop() }
+                    .doOnTerminate { stopOnce() }
+                    .doOnCancel { stopOnce() }
                     .contextWrite { it.put(ObservationThreadLocalAccessor.KEY, observation) }
             }
         }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationReactorContextTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationReactorContextTest.kt
@@ -1,0 +1,201 @@
+package dev.hsbrysk.kuery.spring.r2dbc
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import com.example.spring.r2dbc.UserRepository
+import dev.hsbrysk.kuery.core.observation.KueryClientFetchContext
+import io.micrometer.observation.Observation
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor
+import io.micrometer.observation.tck.TestObservationRegistry
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.Result
+import io.r2dbc.spi.Statement
+import kotlinx.coroutines.reactor.asCoroutineContext
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import org.springframework.r2dbc.core.awaitRowsUpdated
+import reactor.core.publisher.Flux
+import reactor.util.context.Context
+import java.util.concurrent.CopyOnWriteArrayList
+
+class ObservationReactorContextTest {
+    private val registry = TestObservationRegistry.create()
+    private val capturedObservations = CopyOnWriteArrayList<Observation?>()
+    private val kueryClient = SpringR2dbcKueryClient.builder()
+        .connectionFactory(ObservationCapturingConnectionFactory(mysql.connectionFactory, capturedObservations))
+        .observationRegistry(registry)
+        .enableAutoSqlIdGeneration(true)
+        .build()
+    private val userRepository = UserRepository(kueryClient)
+
+    @BeforeEach
+    fun setUp() = runTest {
+        mysql.databaseClient.sql(
+            """
+            CREATE TABLE users (
+                user_id INT AUTO_INCREMENT PRIMARY KEY,
+                username VARCHAR(50) NOT NULL,
+                email VARCHAR(100) NOT NULL
+            );
+
+            INSERT INTO users (username, email) VALUES
+            ('user1', 'user1@example.com'),
+            ('user2', 'user2@example.com');
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+        capturedObservations.clear()
+    }
+
+    @AfterEach
+    fun testDown() = runTest {
+        mysql.databaseClient.sql(
+            """
+            DROP TABLE users;
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun singleMap() = runTest {
+        userRepository.singleMap(1)
+        assertCapturedObservation("com.example.spring.r2dbc.UserRepository.singleMap")
+    }
+
+    @Test
+    fun singleMapOrNull() = runTest {
+        userRepository.singleMapOrNull(1)
+        assertCapturedObservation("com.example.spring.r2dbc.UserRepository.singleMapOrNull")
+    }
+
+    @Test
+    fun single() = runTest {
+        userRepository.single(1)
+        assertCapturedObservation("com.example.spring.r2dbc.UserRepository.single")
+    }
+
+    @Test
+    fun singleOrNull() = runTest {
+        userRepository.singleOrNull(1)
+        assertCapturedObservation("com.example.spring.r2dbc.UserRepository.singleOrNull")
+    }
+
+    @Test
+    fun listMap() = runTest {
+        userRepository.listMap()
+        assertCapturedObservation("com.example.spring.r2dbc.UserRepository.listMap")
+    }
+
+    @Test
+    fun list() = runTest {
+        userRepository.list()
+        assertCapturedObservation("com.example.spring.r2dbc.UserRepository.list")
+    }
+
+    @Test
+    fun rowsUpdated() = runTest {
+        userRepository.rowUpdated("user3", "user3@example.com")
+        assertCapturedObservation("com.example.spring.r2dbc.UserRepository.rowUpdated")
+    }
+
+    @Test
+    fun generatedValues() = runTest {
+        userRepository.generatedValues("user3", "user3@example.com")
+        assertCapturedObservation("com.example.spring.r2dbc.UserRepository.generatedValues")
+    }
+
+    @Test
+    fun `links parent observation from the Reactor context`() = runTest {
+        val parent = Observation.start("parent", registry)
+        try {
+            withContext(Context.of(ObservationThreadLocalAccessor.KEY, parent).asCoroutineContext()) {
+                userRepository.singleMap(1)
+            }
+        } finally {
+            parent.stop()
+        }
+
+        assertThat(capturedObservations).hasSize(1)
+        val observation = assertThat(capturedObservations.single()).isNotNull()
+        observation.transform { it.context.parentObservation }.isEqualTo(parent)
+    }
+
+    private fun assertCapturedObservation(sqlId: String) {
+        assertThat(capturedObservations).hasSize(1)
+        val observation = assertThat(capturedObservations.single()).isNotNull()
+        observation.transform { it.context }.isInstanceOf(KueryClientFetchContext::class)
+            .transform { it.sqlId }.isEqualTo(sqlId)
+    }
+
+    private class ObservationCapturingConnectionFactory(
+        private val delegate: ConnectionFactory,
+        private val captured: MutableList<Observation?>,
+    ) : ConnectionFactory by delegate {
+        override fun create(): Publisher<out Connection> = Flux.from(delegate.create())
+            .map { ObservationCapturingConnection(it, captured) }
+    }
+
+    private class ObservationCapturingConnection(
+        private val delegate: Connection,
+        private val captured: MutableList<Observation?>,
+    ) : Connection by delegate {
+        override fun createStatement(sql: String): Statement =
+            ObservationCapturingStatement(delegate.createStatement(sql), captured)
+    }
+
+    // Fluent methods must return `this` (not the delegate) so that execute() below stays wrapped.
+    private class ObservationCapturingStatement(
+        private val delegate: Statement,
+        private val captured: MutableList<Observation?>,
+    ) : Statement {
+        override fun add(): Statement = apply { delegate.add() }
+
+        override fun bind(
+            index: Int,
+            value: Any,
+        ): Statement = apply { delegate.bind(index, value) }
+
+        override fun bind(
+            name: String,
+            value: Any,
+        ): Statement = apply { delegate.bind(name, value) }
+
+        override fun bindNull(
+            index: Int,
+            type: Class<*>,
+        ): Statement = apply { delegate.bindNull(index, type) }
+
+        override fun bindNull(
+            name: String,
+            type: Class<*>,
+        ): Statement = apply { delegate.bindNull(name, type) }
+
+        override fun fetchSize(rows: Int): Statement = apply { delegate.fetchSize(rows) }
+
+        override fun returnGeneratedValues(vararg columns: String): Statement =
+            apply { delegate.returnGeneratedValues(*columns) }
+
+        override fun execute(): Publisher<out Result> = Flux.deferContextual { context ->
+            captured.add(context.getOrEmpty<Observation>(ObservationThreadLocalAccessor.KEY).orElse(null))
+            Flux.from(delegate.execute())
+        }
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer()
+
+        @AfterAll
+        @JvmStatic
+        fun afterAll() {
+            mysql.close()
+        }
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationTest.kt
@@ -1,14 +1,25 @@
 package dev.hsbrysk.kuery.spring.r2dbc
 
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isInstanceOf
 import com.example.spring.r2dbc.UserRepository
+import io.micrometer.observation.Observation
 import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.r2dbc.core.awaitRowsUpdated
+import java.util.concurrent.Executors
 
 class ObservationTest {
     private val registry = TestObservationRegistry.create()
@@ -111,6 +122,38 @@ class ObservationTest {
             sqlId = "com.example.spring.r2dbc.UserRepository.generatedValues",
             sql = "INSERT INTO users (username, email) VALUES (:p0, :p1)",
         )
+    }
+
+    @Test
+    fun `records error when single result is missing`() = runTest {
+        assertFailure { userRepository.singleMap(999) }.isInstanceOf(EmptyResultDataAccessException::class)
+        TestObservationRegistryAssert.assertThat(registry)
+            .doesNotHaveAnyRemainingCurrentObservation()
+            .hasObservationWithNameEqualTo("kuery.client.fetches")
+            .that()
+            .hasBeenStarted()
+            .hasBeenStopped()
+            .hasError()
+    }
+
+    @Test
+    fun `does not leak observation to sibling coroutines on the same thread`() {
+        Executors.newSingleThreadExecutor().asCoroutineDispatcher().use { dispatcher ->
+            runBlocking(dispatcher) {
+                val query = launch {
+                    kueryClient.sql { +"SELECT SLEEP(1)" }.singleMap()
+                }
+                // While the query coroutine is suspended in awaitXxx (guaranteed by SLEEP(1)),
+                // sample the ThreadLocal current observation from a sibling coroutine on the same thread.
+                val leaked = mutableListOf<Observation>()
+                repeat(8) {
+                    delay(100)
+                    registry.currentObservation?.let { leaked.add(it) }
+                }
+                query.join()
+                assertThat(leaked).isEmpty()
+            }
+        }
     }
 
     private fun assertObservation(


### PR DESCRIPTION
## Problem

`DefaultSpringR2dbcKueryClient.observe()` opened a ThreadLocal-based `Observation.Scope` around a **suspending** block:

```kotlin
observation.start()
return observation.openScope().use {
    try {
        block() // suspends in awaitSingle() etc.
    } ...
}
```

While `block()` was suspended, the scope stayed open on the calling thread, so:

- The observation **leaked to unrelated coroutines** running on the same thread while suspended (polluting spans/MDC of other requests).
- After resumption on a different thread, `scope.close()` restored the ThreadLocal state of the **wrong thread**.

The open scope also provided no real benefit: the actual DB calls run on the Reactor pipeline on other threads, where a ThreadLocal scope never propagates anyway.

## Fix

Rework `observe()` as a `Mono` operator, following the same pattern as Spring's `DefaultWebClient.exchange()` (and Lettuce's `MicrometerTracing`):

- **Never open a ThreadLocal scope.** The observation is modeled as a resource via `Mono.usingWhen`: created and started on subscription (inside `Mono.deferContextual`), and stopped in the per-path cleanup handlers (complete / error / cancel), with `error()` recorded before `stop()` on the error path. `usingWhen` runs its cleanup **before** the terminal signal propagates downstream, which guarantees the observation is already stopped when the suspending caller resumes from `awaitXxx` — `doFinally` runs after downstream propagation and has no such happens-before (assertions right after the call raced with `stop()` on slow CI machines), and it also manages the three paths exclusively, so no manual double-stop guard is needed.
- **Resolve the parent observation explicitly from the Reactor context** (`ObservationThreadLocalAccessor.KEY`) instead of relying on the ThreadLocal current observation, which is unreliable on reactive paths. When called from e.g. a WebFlux suspend handler, `awaitXxx` propagates the coroutine's `ReactorContext`, so the server-side observation is linked as the parent.
- **Write the observation into the Reactor context** so downstream instrumentation (r2dbc-proxy, Spring Boot 3.2+ automatic context propagation) can pick it up as the parent. This mirrors how `sqlId` is already propagated (#338).
- Raise `EmptyResultDataAccessException` inside the Mono (`switchIfEmpty`) so it is still recorded via `observation.error()`, keeping symmetry with the JDBC implementation.

`io.micrometer:context-propagation` is added **compileOnly** just to compile against `ObservationThreadLocalAccessor.KEY` (a compile-time constant inlined into the bytecode); it is not required at runtime.

## Behavior changes (intentional)

- `registry.currentObservation` (ThreadLocal) is no longer set during a fetch. It was never reliably set on the reactive path and its leak was the bug this PR fixes.
- On coroutine cancellation, the observation is stopped without recording an error (previously `CancellationException` was recorded as an error). Cancellation is not a failure.
- The previous `stop()`-before-`scope.close()` ordering nit disappears together with the scope.

## Tests (test-first: confirmed RED before the fix)

- **`ObservationReactorContextTest`** (new): wraps the R2DBC `ConnectionFactory` (same technique as `SqlIdReactorContextTest`) and asserts at `Statement.execute()` time that the Reactor context contains the kuery observation — for all 8 instrumented operations — plus a test that a parent observation supplied via the caller's Reactor context is linked. All failed before the fix.
- **`ObservationTest`**: new leak-reproduction test — runs `SELECT SLEEP(1)` on a single-thread dispatcher and samples `registry.currentObservation` from a sibling coroutine while the query coroutine is suspended. Before the fix every sample observed the leaked observation; now none do. Also adds a regression test that an empty `single()` result still records an error on the observation.
- All existing tests (`ObservationTest`, `SqlIdReactorContextTest`, etc.) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
