### PR TITLE
Align JDBC generatedValues() failure exceptions with R2DBC

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -178,7 +178,9 @@ internal class DefaultSpringJdbcKueryClient(
             } else {
                 spec.update(keyHolder, *columns)
             }
-            checkNotNull(keyHolder.keys)
+            // Align the exception types with the R2DBC module: EmptyResultDataAccessException when no
+            // keys were generated (e.g. non-INSERT), IncorrectResultSizeDataAccessException for multi-row.
+            DataAccessUtils.requiredSingleResult(keyHolder.keyList)
         }
 
         private fun <T> observe(block: () -> T): T {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
@@ -385,6 +385,32 @@ class BasicUsageTest {
     }
 
     @Test
+    fun `generatedValues no generated keys`() {
+        assertFailure {
+            kueryClient
+                .sql {
+                    +"UPDATE users SET username = 'updated' WHERE user_id = 1"
+                }
+                .generatedValues()
+        }.isInstanceOf(EmptyResultDataAccessException::class)
+    }
+
+    @Test
+    fun `generatedValues multiple generated keys`() {
+        assertFailure {
+            kueryClient
+                .sql {
+                    +"""
+                    INSERT INTO users (username, email) VALUES
+                    ('user3', 'user3@example.com'),
+                    ('user4', 'user4@example.com')
+                    """.trimIndent()
+                }
+                .generatedValues("user_id")
+        }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
+    }
+
+    @Test
     fun userOrder() {
         data class UserOrder(
             val username: String,

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresGeneratedValuesTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresGeneratedValuesTest.kt
@@ -1,0 +1,87 @@
+package dev.hsbrysk.kuery.spring.r2dbc
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.dao.IncorrectResultSizeDataAccessException
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * Pins the failure contract of [dev.hsbrysk.kuery.core.KueryClient.FetchSpec.generatedValues]:
+ * EmptyResultDataAccessException when the driver emits no generated-value rows,
+ * IncorrectResultSizeDataAccessException when it emits more than one.
+ *
+ * These cases are exercised with PostgreSQL because its RETURNING-based generated values actually
+ * emit zero or multiple rows. r2dbc-mysql synthesizes a single lastInsertId row even for UPDATE or
+ * multi-row INSERT, so neither failure path can be reproduced with MySQL.
+ */
+class PostgresGeneratedValuesTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        postgres.databaseClient.sql(
+            """
+            CREATE TABLE users (
+                user_id SERIAL PRIMARY KEY,
+                username VARCHAR(50) NOT NULL,
+                email VARCHAR(100) NOT NULL
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        postgres.databaseClient.sql("DROP TABLE users").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun generatedValues() = runTest {
+        val result = kueryClient
+            .sql { +"INSERT INTO users (username, email) VALUES ('user1', 'user1@example.com')" }
+            .generatedValues("user_id")
+        assertThat(result).isEqualTo(mapOf("user_id" to 1))
+    }
+
+    @Test
+    fun `generatedValues no generated keys`() = runTest {
+        assertFailure {
+            kueryClient
+                .sql { +"UPDATE users SET username = 'updated' WHERE user_id = 1" }
+                .generatedValues("user_id")
+        }.isInstanceOf(EmptyResultDataAccessException::class)
+    }
+
+    @Test
+    fun `generatedValues multiple generated keys`() = runTest {
+        assertFailure {
+            kueryClient
+                .sql {
+                    +"""
+                    INSERT INTO users (username, email) VALUES
+                    ('user1', 'user1@example.com'),
+                    ('user2', 'user2@example.com')
+                    """.trimIndent()
+                }
+                .generatedValues("user_id")
+        }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer()
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            postgres.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes review backlog item B7.

`generatedValues()` in the JDBC module used `checkNotNull(keyHolder.keys)`, so:

- When no keys were generated (e.g. calling it for an UPDATE), it threw a bare `IllegalStateException("Required value was null.")`.
- For a multi-row INSERT (MySQL Connector/J returns one key per row), `GeneratedKeyHolder.getKeys()` threw `InvalidDataAccessApiUsageException`, whose "use getKeyList() instead" guidance is meaningless for kuery-client users.

Meanwhile the R2DBC module goes through `fetch().one()` + `switchIfEmpty(EmptyResultDataAccessException(1))`.

Replaced the `checkNotNull` with `DataAccessUtils.requiredSingleResult(keyHolder.keyList)` — Spring's standard "expect exactly one result" contract, which `single()`/`singleMap()` already use in both modules:

| case | before (JDBC) | after (JDBC) | R2DBC |
|---|---|---|---|
| no generated keys | `IllegalStateException` | `EmptyResultDataAccessException(1)` | `EmptyResultDataAccessException(1)` |
| multiple generated keys | `InvalidDataAccessApiUsageException` | `IncorrectResultSizeDataAccessException(1, n)` | `IncorrectResultSizeDataAccessException` (via `one()`) |

Note: when each case actually occurs still depends on the driver. For example, r2dbc-mysql synthesizes a `lastInsertId` row even for UPDATE (verified: it succeeds instead of hitting the empty path), while MySQL Connector/J returns no keys. This PR aligns the mapping-layer exception contract, not driver behavior.

## Tests

JDBC side, written test-first (confirmed the old behavior failed before fixing):

- `generatedValues no generated keys`: UPDATE → `EmptyResultDataAccessException` (previously `IllegalStateException`)
- `generatedValues multiple generated keys`: multi-row INSERT → `IncorrectResultSizeDataAccessException` (previously `InvalidDataAccessApiUsageException`)

R2DBC side: the failure contract above was not covered by any test, and cannot be reproduced with MySQL (r2dbc-mysql always synthesizes a single `lastInsertId` row). Added `PostgresGeneratedValuesTest` pinning it with PostgreSQL, whose RETURNING-based generated values actually emit zero rows (UPDATE matching nothing) or multiple rows (multi-row INSERT). No production change on the R2DBC side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)