### PR TITLE
Apply SqlIdInjector to JDBC sequence()/sequenceMap()

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -155,7 +155,12 @@ internal class DefaultSpringJdbcKueryClient(
             // I also want to measure the observation of flow.
             // However, should it be the time until the flow terminates or the time until the first element is obtained?
             // There are many uncertainties, so I will not implement it for now.
-            return buildSpec().query(ColumnMapRowMapper()).stream().asCloseableSequence()
+            //
+            // The underlying statement is executed eagerly inside stream(), so wrapping it with
+            // SqlIdInjector is enough for SpringJdbcKueryClient.sqlId() to be visible at execution time.
+            return SqlIdInjector(sqlId).use {
+                buildSpec().query(ColumnMapRowMapper()).stream().asCloseableSequence()
+            }
         }
 
         override fun <T : Any> sequence(returnType: KClass<T>): CloseableSequence<T> {
@@ -163,7 +168,12 @@ internal class DefaultSpringJdbcKueryClient(
             // I also want to measure the observation of flow.
             // However, should it be the time until the flow terminates or the time until the first element is obtained?
             // There are many uncertainties, so I will not implement it for now.
-            return buildSpec().queryType(returnType).stream().asCloseableSequence()
+            //
+            // The underlying statement is executed eagerly inside stream(), so wrapping it with
+            // SqlIdInjector is enough for SpringJdbcKueryClient.sqlId() to be visible at execution time.
+            return SqlIdInjector(sqlId).use {
+                buildSpec().queryType(returnType).stream().asCloseableSequence()
+            }
         }
 
         override fun rowsUpdated(): Long = observe {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/com/example/spring/jdbc/SampleRepository.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/com/example/spring/jdbc/SampleRepository.kt
@@ -1,7 +1,9 @@
 package com.example.spring.jdbc
 
+import dev.hsbrysk.kuery.core.CloseableSequence
 import dev.hsbrysk.kuery.core.KueryBlockingClient
 import dev.hsbrysk.kuery.core.list
+import dev.hsbrysk.kuery.core.sequence
 import dev.hsbrysk.kuery.core.single
 import dev.hsbrysk.kuery.core.singleOrNull
 
@@ -28,6 +30,10 @@ class UserRepository(private val kueryClient: KueryBlockingClient) {
     fun listMap(): List<Map<String, Any?>> = kueryClient.sql { +"SELECT * FROM users" }.listMap()
 
     fun list(): List<User> = kueryClient.sql { +"SELECT * FROM users" }.list()
+
+    fun sequenceMap(): CloseableSequence<Map<String, Any?>> = kueryClient.sql { +"SELECT * FROM users" }.sequenceMap()
+
+    fun sequence(): CloseableSequence<User> = kueryClient.sql { +"SELECT * FROM users" }.sequence()
 
     fun rowUpdated(
         username: String,

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SqlIdThreadLocalTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SqlIdThreadLocalTest.kt
@@ -1,0 +1,160 @@
+package dev.hsbrysk.kuery.spring.jdbc
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import com.example.spring.jdbc.UserRepository
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.sql.Connection
+import java.sql.PreparedStatement
+import javax.sql.DataSource
+
+class SqlIdThreadLocalTest {
+    private val capturedSqlIds = mutableListOf<String?>()
+    private val kueryClient = SpringJdbcKueryClient.builder()
+        .dataSource(SqlIdCapturingDataSource(mysql.dataSource, capturedSqlIds))
+        .enableAutoSqlIdGeneration(true)
+        .build()
+    private val userRepository = UserRepository(kueryClient)
+
+    @BeforeEach
+    fun setUp() {
+        mysql.jdbcClient.sql(
+            """
+            CREATE TABLE users (
+                user_id INT AUTO_INCREMENT PRIMARY KEY,
+                username VARCHAR(50) NOT NULL,
+                email VARCHAR(100) NOT NULL
+            )
+            """.trimIndent(),
+        ).update()
+        mysql.jdbcClient.sql(
+            """
+            INSERT INTO users (username, email) VALUES
+            ('user1', 'user1@example.com'),
+            ('user2', 'user2@example.com')
+            """.trimIndent(),
+        ).update()
+        capturedSqlIds.clear()
+    }
+
+    @AfterEach
+    fun testDown() {
+        mysql.jdbcClient.sql("DROP TABLE users").update()
+    }
+
+    @Test
+    fun singleMap() {
+        userRepository.singleMap(1)
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.singleMap")
+    }
+
+    @Test
+    fun singleMapOrNull() {
+        userRepository.singleMapOrNull(1)
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.singleMapOrNull")
+    }
+
+    @Test
+    fun single() {
+        userRepository.single(1)
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.single")
+    }
+
+    @Test
+    fun singleOrNull() {
+        userRepository.singleOrNull(1)
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.singleOrNull")
+    }
+
+    @Test
+    fun listMap() {
+        userRepository.listMap()
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.listMap")
+    }
+
+    @Test
+    fun list() {
+        userRepository.list()
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.list")
+    }
+
+    @Test
+    fun sequenceMap() {
+        userRepository.sequenceMap().use { it.toList() }
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.sequenceMap")
+    }
+
+    @Test
+    fun sequence() {
+        userRepository.sequence().use { it.toList() }
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.sequence")
+    }
+
+    @Test
+    fun rowsUpdated() {
+        userRepository.rowUpdated("user3", "user3@example.com")
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.rowUpdated")
+    }
+
+    @Test
+    fun generatedValues() {
+        userRepository.generatedValues("user3", "user3@example.com")
+        assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.generatedValues")
+    }
+
+    private class SqlIdCapturingDataSource(
+        private val delegate: DataSource,
+        private val captured: MutableList<String?>,
+    ) : DataSource by delegate {
+        override fun getConnection(): Connection = wrapConnection(delegate.connection)
+
+        override fun getConnection(
+            username: String?,
+            password: String?,
+        ): Connection = wrapConnection(delegate.getConnection(username, password))
+
+        private fun wrapConnection(connection: Connection): Connection = Proxy.newProxyInstance(
+            connection.javaClass.classLoader,
+            arrayOf(Connection::class.java),
+        ) { _, method, args ->
+            val result = invoke(method, connection, args)
+            if (result is PreparedStatement) wrapStatement(result) else result
+        } as Connection
+
+        private fun wrapStatement(statement: PreparedStatement): PreparedStatement = Proxy.newProxyInstance(
+            statement.javaClass.classLoader,
+            arrayOf(PreparedStatement::class.java),
+        ) { _, method, args ->
+            if (method.name.startsWith("execute")) {
+                captured.add(SpringJdbcKueryClient.sqlId())
+            }
+            invoke(method, statement, args)
+        } as PreparedStatement
+
+        private fun invoke(
+            method: Method,
+            target: Any,
+            args: Array<Any?>?,
+        ): Any? = try {
+            if (args == null) method.invoke(target) else method.invoke(target, *args)
+        } catch (e: InvocationTargetException) {
+            throw e.targetException
+        }
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer()
+
+        @AfterAll
+        @JvmStatic
+        fun afterAll() {
+            mysql.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Every terminal operation in the JDBC module goes through `observe {}`, which sets up the `SpringJdbcKueryClient.sqlId()` ThreadLocal via `SqlIdInjector` — except `sequence()` / `sequenceMap()`, which bypass `observe` (due to the open question about observation timing for streaming results). As a result, `SpringJdbcKueryClient.sqlId()` returned `null` during statement execution, e.g. when read from a datasource-proxy listener.

Wrapped the stream creation in `SqlIdInjector(sqlId).use { ... }`. The underlying statement is executed eagerly inside `stream()` (`JdbcTemplate.queryForStream`), so this covers the execution point. Observation for sequences remains a TODO as before.

## Tests

Added `SqlIdThreadLocalTest`: the JDBC counterpart of `SqlIdReactorContextTest`, covering all 10 terminal operations. A proxying `DataSource` captures `SpringJdbcKueryClient.sqlId()` at `PreparedStatement#execute*` time. Written test-first: `sequence`/`sequenceMap` captured `null` before the fix.

Related: #345 (both were found while working on review backlog item B7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)