### PR TITLE
Pin R2DBC generatedValues() failure contract with Postgres tests

### DIFF
--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresGeneratedValuesTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresGeneratedValuesTest.kt
@@ -1,0 +1,87 @@
+package dev.hsbrysk.kuery.spring.r2dbc
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.dao.IncorrectResultSizeDataAccessException
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * Pins the failure contract of [dev.hsbrysk.kuery.core.KueryClient.FetchSpec.generatedValues]:
+ * EmptyResultDataAccessException when the driver emits no generated-value rows,
+ * IncorrectResultSizeDataAccessException when it emits more than one.
+ *
+ * These cases are exercised with PostgreSQL because its RETURNING-based generated values actually
+ * emit zero or multiple rows. r2dbc-mysql synthesizes a single lastInsertId row even for UPDATE or
+ * multi-row INSERT, so neither failure path can be reproduced with MySQL.
+ */
+class PostgresGeneratedValuesTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        postgres.databaseClient.sql(
+            """
+            CREATE TABLE users (
+                user_id SERIAL PRIMARY KEY,
+                username VARCHAR(50) NOT NULL,
+                email VARCHAR(100) NOT NULL
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        postgres.databaseClient.sql("DROP TABLE users").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun generatedValues() = runTest {
+        val result = kueryClient
+            .sql { +"INSERT INTO users (username, email) VALUES ('user1', 'user1@example.com')" }
+            .generatedValues("user_id")
+        assertThat(result).isEqualTo(mapOf("user_id" to 1))
+    }
+
+    @Test
+    fun `generatedValues no generated keys`() = runTest {
+        assertFailure {
+            kueryClient
+                .sql { +"UPDATE users SET username = 'updated' WHERE user_id = 1" }
+                .generatedValues("user_id")
+        }.isInstanceOf(EmptyResultDataAccessException::class)
+    }
+
+    @Test
+    fun `generatedValues multiple generated keys`() = runTest {
+        assertFailure {
+            kueryClient
+                .sql {
+                    +"""
+                    INSERT INTO users (username, email) VALUES
+                    ('user1', 'user1@example.com'),
+                    ('user2', 'user2@example.com')
+                    """.trimIndent()
+                }
+                .generatedValues("user_id")
+        }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer()
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            postgres.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Test-only PR. The R2DBC module's `generatedValues()` maps failures as follows, but neither path was covered by tests:

- zero generated-value rows → `EmptyResultDataAccessException(1)` (via `switchIfEmpty`)
- multiple rows → `IncorrectResultSizeDataAccessException` (via `fetch().one()`)

These paths cannot be reproduced with MySQL: r2dbc-mysql synthesizes a single `lastInsertId` row even for UPDATE or multi-row INSERT (verified while working on #345), so with MySQL the driver always emits exactly one row. PostgreSQL's generated values are RETURNING-based and actually emit zero rows (UPDATE matching nothing) or multiple rows (multi-row INSERT), so the contract is pinned with `PostgresGeneratedValuesTest`:

| case | driver emits | expected |
|---|---|---|
| single-row INSERT | 1 row | `mapOf("user_id" to 1)` |
| UPDATE matching no rows | 0 rows | `EmptyResultDataAccessException` |
| 2-row INSERT | 2 rows | `IncorrectResultSizeDataAccessException` |

This is the R2DBC counterpart of the JDBC-side failure tests added in #345, which aligned the JDBC exception types to this same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)