### PR TITLE
Preserve runtime component type when binding array parameters

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -26,6 +26,7 @@ import org.springframework.jdbc.core.simple.JdbcClient.StatementSpec
 import org.springframework.jdbc.support.GeneratedKeyHolder
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
+import java.lang.reflect.Array as ReflectArray
 
 internal class DefaultSpringJdbcKueryClient(
     private val jdbcClient: JdbcClient,
@@ -75,31 +76,32 @@ internal class DefaultSpringJdbcKueryClient(
         }
     }
 
-    private fun convertCollection(collection: Collection<*>): Collection<*> = collection.map {
-        if (it == null) {
-            null
-        } else {
-            val targetType = customConversions.getCustomWriteTarget(it::class.java)
-            when {
-                targetType.isPresent -> conversionService.convert(it, targetType.get())
-                it is Enum<*> -> it.name
-                else -> it
-            }
+    private fun convertCollection(collection: Collection<*>): Collection<*> = collection.map { convertElement(it) }
+
+    // The runtime component type must be preserved (e.g. String[] stays String[]); drivers
+    // resolve the SQL array type from it, and pgjdbc rejects Object[] outright.
+    private fun convertArray(array: Array<*>): Array<*> {
+        val converted = array.map { convertElement(it) }
+        if (array.indices.all { converted[it] === array[it] }) {
+            return array
         }
+        val componentType = converted.mapNotNull { it?.javaClass }.distinct().singleOrNull() ?: Any::class.java
+        val result = ReflectArray.newInstance(componentType, array.size)
+        converted.forEachIndexed { index, value -> ReflectArray.set(result, index, value) }
+        return result as Array<*>
     }
 
-    private fun convertArray(array: Array<*>): Array<*> = array.map {
-        if (it == null) {
-            null
-        } else {
-            val targetType = customConversions.getCustomWriteTarget(it::class.java)
-            when {
-                targetType.isPresent -> conversionService.convert(it, targetType.get())
-                it is Enum<*> -> it.name
-                else -> it
-            }
+    private fun convertElement(element: Any?): Any? {
+        if (element == null) {
+            return null
         }
-    }.toTypedArray()
+        val targetType = customConversions.getCustomWriteTarget(element::class.java)
+        return when {
+            targetType.isPresent -> conversionService.convert(element, targetType.get())
+            element is Enum<*> -> element.name
+            else -> element
+        }
+    }
 
     @Suppress("TooManyFunctions")
     inner class FetchSpec(

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/PostgresArrayBindingTest.kt
@@ -1,0 +1,80 @@
+package dev.hsbrysk.kuery.spring.jdbc
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.sql.Array as SqlArray
+
+class PostgresArrayBindingTest {
+    private val kueryClient = postgres.kueryClient()
+
+    enum class SampleEnum {
+        HOGE,
+        FUGA,
+    }
+
+    @BeforeEach
+    fun setUp() {
+        postgres.jdbcClient.sql(
+            """
+            CREATE TABLE users (
+                user_id SERIAL PRIMARY KEY,
+                username VARCHAR(50) NOT NULL,
+                tags TEXT[]
+            )
+            """.trimIndent(),
+        ).update()
+        postgres.jdbcClient.sql("INSERT INTO users (username) VALUES ('HOGE'), ('FUGA'), ('PIYO')").update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        postgres.jdbcClient.sql("DROP TABLE users").update()
+    }
+
+    @Test
+    fun `bind array to ANY predicate`() {
+        val usernames = arrayOf("HOGE", "FUGA")
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind enum array to ANY predicate`() {
+        val usernames = arrayOf(SampleEnum.HOGE, SampleEnum.FUGA)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind array to a native array column`() {
+        val tags = arrayOf("a", "b")
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = (record["tags"] as SqlArray).array as Array<*>
+        assertThat(stored.toList()).isEqualTo(listOf("a", "b"))
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer()
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            postgres.close()
+        }
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/PostgresArrayBindingTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.WritingConverter
 import java.sql.Array as SqlArray
 
 class PostgresArrayBindingTest {
@@ -14,6 +16,13 @@ class PostgresArrayBindingTest {
     enum class SampleEnum {
         HOGE,
         FUGA,
+    }
+
+    data class StringWrapper(val value: String)
+
+    @WritingConverter
+    class StringWrapperToStringConverter : Converter<StringWrapper, String> {
+        override fun convert(source: StringWrapper): String = source.value
     }
 
     @BeforeEach
@@ -47,6 +56,16 @@ class PostgresArrayBindingTest {
     @Test
     fun `bind enum array to ANY predicate`() {
         val usernames = arrayOf(SampleEnum.HOGE, SampleEnum.FUGA)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind custom-converted array to ANY predicate`() {
+        val kueryClient = postgres.kueryClient(listOf(StringWrapperToStringConverter()))
+        val usernames = arrayOf(StringWrapper("HOGE"), StringWrapper("FUGA"))
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
             .listMap()

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -32,6 +32,7 @@ import reactor.core.publisher.Mono
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Function
 import kotlin.reflect.KClass
+import java.lang.reflect.Array as ReflectArray
 
 internal class DefaultSpringR2dbcKueryClient(
     private val databaseClient: DatabaseClient,
@@ -84,31 +85,32 @@ internal class DefaultSpringR2dbcKueryClient(
         }
     }
 
-    private fun convertCollection(collection: Collection<*>): Collection<*> = collection.map {
-        if (it == null) {
-            null
-        } else {
-            val targetType = customConversions.getCustomWriteTarget(it::class.java)
-            when {
-                targetType.isPresent -> conversionService.convert(it, targetType.get())
-                it is Enum<*> -> it.name
-                else -> it
-            }
+    private fun convertCollection(collection: Collection<*>): Collection<*> = collection.map { convertElement(it) }
+
+    // The runtime component type must be preserved (e.g. String[] stays String[]); drivers
+    // resolve the SQL array type from it, and pgjdbc rejects Object[] outright.
+    private fun convertArray(array: Array<*>): Array<*> {
+        val converted = array.map { convertElement(it) }
+        if (array.indices.all { converted[it] === array[it] }) {
+            return array
         }
+        val componentType = converted.mapNotNull { it?.javaClass }.distinct().singleOrNull() ?: Any::class.java
+        val result = ReflectArray.newInstance(componentType, array.size)
+        converted.forEachIndexed { index, value -> ReflectArray.set(result, index, value) }
+        return result as Array<*>
     }
 
-    private fun convertArray(array: Array<*>): Array<*> = array.map {
-        if (it == null) {
-            null
-        } else {
-            val targetType = customConversions.getCustomWriteTarget(it::class.java)
-            when {
-                targetType.isPresent -> conversionService.convert(it, targetType.get())
-                it is Enum<*> -> it.name
-                else -> it
-            }
+    private fun convertElement(element: Any?): Any? {
+        if (element == null) {
+            return null
         }
-    }.toTypedArray()
+        val targetType = customConversions.getCustomWriteTarget(element::class.java)
+        return when {
+            targetType.isPresent -> conversionService.convert(element, targetType.get())
+            element is Enum<*> -> element.name
+            else -> element
+        }
+    }
 
     @Suppress("TooManyFunctions")
     inner class FetchSpec(

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresArrayBindingTest.kt
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.WritingConverter
 import org.springframework.r2dbc.core.awaitRowsUpdated
 
 class PostgresArrayBindingTest {
@@ -15,6 +17,13 @@ class PostgresArrayBindingTest {
     enum class SampleEnum {
         HOGE,
         FUGA,
+    }
+
+    data class StringWrapper(val value: String)
+
+    @WritingConverter
+    class StringWrapperToStringConverter : Converter<StringWrapper, String> {
+        override fun convert(source: StringWrapper): String = source.value
     }
 
     @BeforeEach
@@ -49,6 +58,16 @@ class PostgresArrayBindingTest {
     @Test
     fun `bind enum array to ANY predicate`() = runTest {
         val usernames = arrayOf(SampleEnum.HOGE, SampleEnum.FUGA)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind custom-converted array to ANY predicate`() = runTest {
+        val kueryClient = postgres.kueryClient(listOf(StringWrapperToStringConverter()))
+        val usernames = arrayOf(StringWrapper("HOGE"), StringWrapper("FUGA"))
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
             .listMap()

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresArrayBindingTest.kt
@@ -1,0 +1,82 @@
+package dev.hsbrysk.kuery.spring.r2dbc
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+class PostgresArrayBindingTest {
+    private val kueryClient = postgres.kueryClient()
+
+    enum class SampleEnum {
+        HOGE,
+        FUGA,
+    }
+
+    @BeforeEach
+    fun setUp() = runTest {
+        postgres.databaseClient.sql(
+            """
+            CREATE TABLE users (
+                user_id SERIAL PRIMARY KEY,
+                username VARCHAR(50) NOT NULL,
+                tags TEXT[]
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+        postgres.databaseClient.sql("INSERT INTO users (username) VALUES ('HOGE'), ('FUGA'), ('PIYO')")
+            .fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        postgres.databaseClient.sql("DROP TABLE users").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `bind array to ANY predicate`() = runTest {
+        val usernames = arrayOf("HOGE", "FUGA")
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind enum array to ANY predicate`() = runTest {
+        val usernames = arrayOf(SampleEnum.HOGE, SampleEnum.FUGA)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind array to a native array column`() = runTest {
+        val tags = arrayOf("a", "b")
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = record["tags"] as Array<*>
+        assertThat(stored.toList()).isEqualTo(listOf("a", "b"))
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer()
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            postgres.close()
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`convertArray()` in both Spring modules rebuilt every array parameter via `.toTypedArray()`, erasing the runtime component type to `Object[]`. This broke array binding even where the underlying stack natively supports it.

Measured on PostgreSQL (postgres:16 via Testcontainers):

- **JDBC**: every array binding failed with `PSQLException: An instance of [Ljava.lang.Object; cannot be cast to Types.ARRAY`. Passing a typed array (`String[]`) to plain Spring `JdbcClient` works fine for both `= ANY(:param)` and `TEXT[]` columns — so the type erasure in Kuery Client was the sole cause.
- **R2DBC**: happened to work because r2dbc-postgresql infers the element type even from `Object[]`, but relying on that is fragile.

(On MySQL, array binding fails regardless — MySQL has no array type, and Spring only expands `Collection` into IN-clause placeholders. That remains unchanged and is expected.)

## Fix

- Pass the original array instance through untouched when no element needs conversion (`String[]` stays `String[]`).
- When elements are converted (enum → name, custom conversions), rebuild the array with the converted element type (`Array<MyEnum>` becomes `String[]`).
- Share the element conversion logic between `convertCollection()` and `convertArray()` via `convertElement()`.

Arrays intentionally keep their array semantics (PostgreSQL `= ANY` / array columns) and are NOT expanded into IN-clause placeholders — IN expansion is Spring's contract for `Collection`, so callers who want it should pass a `Collection`.

## Tests

New `PostgresArrayBindingTest` in both modules (`= ANY` with `String[]`, `= ANY` with an enum array, INSERT/SELECT on a `TEXT[]` column). Written test-first: the JDBC cases reproduced the `Object[]` failure before the fix; the R2DBC cases pin the previously-working behavior as regression guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)