### PR TITLE
Fix class name typo: KueryClientiIrGenerationExtension

### DIFF
--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerPluginRegistrar.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerPluginRegistrar.kt
@@ -1,7 +1,7 @@
 package dev.hsbrysk.kuery.compiler
 
 import dev.hsbrysk.kuery.compiler.fir.KueryClientFirExtensionRegistrar
-import dev.hsbrysk.kuery.compiler.ir.KueryClientiIrGenerationExtension
+import dev.hsbrysk.kuery.compiler.ir.KueryClientIrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
@@ -17,6 +17,6 @@ class KueryClientCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         FirExtensionRegistrarAdapter.registerExtension(KueryClientFirExtensionRegistrar())
-        IrGenerationExtension.registerExtension(KueryClientiIrGenerationExtension())
+        IrGenerationExtension.registerExtension(KueryClientIrGenerationExtension())
     }
 }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/KueryClientIrGenerationExtension.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/KueryClientIrGenerationExtension.kt
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 
-class KueryClientiIrGenerationExtension : IrGenerationExtension {
+class KueryClientIrGenerationExtension : IrGenerationExtension {
     override fun generate(
         moduleFragment: IrModuleFragment,
         pluginContext: IrPluginContext,


### PR DESCRIPTION
## Summary

Renames `KueryClientiIrGenerationExtension` to `KueryClientIrGenerationExtension` (stray `i` after `Client`), along with its file and the reference in `KueryClientCompilerPluginRegistrar`.

The compiler module is not part of the public ABI contract, so this rename is safe and free to do before v1.0.

## Testing

- `./gradlew :kuery-client-compiler:build :kuery-client-compiler:functional-test:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)