### PR TITLE
Improve the "plugin is not loaded" error message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Integration tests (`kuery-client-spring-data-r2dbc`, `kuery-client-spring-data-j
 
 ### Compiler Plugin (the key mechanism)
 
-`SqlBuilder.add(sql)` and `+"sql"` (i.e., `String.unaryPlus`) are **intentionally broken at runtime** without the compiler plugin — they throw `error("kuery-client-compiler plugin is not loaded...")`. The plugin (`StringInterpolationTransformer`) intercepts calls to these two methods at the IR level and rewrites any `IrStringConcatenation` inside them into a call to `DefaultSqlBuilder.interpolate(fragments, values)`, which performs proper named-parameter binding.
+`SqlBuilder.add(sql)` and `+"sql"` (i.e., `String.unaryPlus`) are **intentionally broken at runtime** without the compiler plugin — they throw an `IllegalStateException` explaining that the compiler plugin must be applied. The plugin (`StringInterpolationTransformer`) intercepts calls to these two methods at the IR level and rewrites any `IrStringConcatenation` inside them into a call to `DefaultSqlBuilder.interpolate(fragments, values)`, which performs proper named-parameter binding.
 
 This means `+"SELECT * FROM users WHERE id = $userId"` becomes equivalent to a parameterized query with `:p0 = userId` — the user never writes placeholders manually.
 

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilder.kt
@@ -66,7 +66,14 @@ internal class DefaultSqlBuilder : SqlBuilder {
         internal const val PARAMETER_NAME_PREFIX = "p"
         internal const val PARAMETER_NAME_PREFIX_WITH_COLON = ":$PARAMETER_NAME_PREFIX"
 
-        fun <T> injectByPlugin(): T =
-            error("kuery-client-compiler plugin is not loaded or you are using an unsupported usage.")
+        fun <T> injectByPlugin(): T = error(
+            "`SqlBuilder.add`/`String.unaryPlus` must be rewritten by the kuery-client compiler plugin, " +
+                "but this call was not. " +
+                "Make sure the Gradle plugin `dev.hsbrysk.kuery-client` is applied to the module " +
+                "containing this call. " +
+                "If it is already applied, this call site is an unsupported usage that the plugin cannot rewrite " +
+                "(e.g. calling through a subtype of SqlBuilder, or via a function/reflection reference). " +
+                "See https://kuery-client.hsbrysk.dev/getting-started for setup instructions.",
+        )
     }
 }

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilderTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilderTest.kt
@@ -1,9 +1,13 @@
 package dev.hsbrysk.kuery.core.internal
 
+import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.message
 import dev.hsbrysk.kuery.core.NamedSqlParameter
 import dev.hsbrysk.kuery.core.Sql
 import org.junit.jupiter.api.Test
@@ -14,6 +18,10 @@ class DefaultSqlBuilderTest {
         assertFailure {
             DefaultSqlBuilder().add("")
         }.isInstanceOf(IllegalStateException::class)
+            .message().isNotNull().all {
+                contains("dev.hsbrysk.kuery-client")
+                contains("https://kuery-client.hsbrysk.dev/")
+            }
     }
 
     @Test
@@ -23,6 +31,10 @@ class DefaultSqlBuilderTest {
                 +""
             }
         }.isInstanceOf(IllegalStateException::class)
+            .message().isNotNull().all {
+                contains("dev.hsbrysk.kuery-client")
+                contains("https://kuery-client.hsbrysk.dev/")
+            }
     }
 
     @Test


### PR DESCRIPTION
## Summary

The `IllegalStateException` thrown when `SqlBuilder.add` / `String.unaryPlus` runs without the compiler plugin transformation is the first error a new user is likely to hit, but it did not explain how to fix it:

> kuery-client-compiler plugin is not loaded or you are using an unsupported usage.

The message now includes:

- the Gradle plugin id (`dev.hsbrysk.kuery-client`) to apply
- a note that if the plugin is already applied, the call site is an unsupported usage the plugin cannot rewrite (e.g. calling through a subtype of `SqlBuilder`, or via a function/reflection reference)
- a link to https://kuery-client.hsbrysk.dev/getting-started

## Test

Extended the existing `DefaultSqlBuilderTest#add` / `#unaryPlus` tests to also assert that the message contains the plugin id and the docs URL (verified they fail before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)