### PR TITLE
Restrict compiler plugin injection to JVM compilations

### DIFF
--- a/kuery-client-gradle-plugin/src/main/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePlugin.kt
+++ b/kuery-client-gradle-plugin/src/main/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePlugin.kt
@@ -3,6 +3,7 @@ package dev.hsbrysk.kuery.gradle
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
@@ -18,6 +19,12 @@ class KueryClientGradlePlugin : KotlinCompilerPluginSupportPlugin {
         version = BuildConfig.VERSION,
     )
 
+    // kuery-client-core is a JVM-only library, so the compiler plugin is only meaningful
+    // for JVM compilations. Without this restriction, in a multiplatform project the plugin
+    // would also be injected into JS/Native/wasm compilations.
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean =
-        kotlinCompilation.target.project.plugins.hasPlugin(KueryClientGradlePlugin::class.java)
+        when (kotlinCompilation.target.platformType) {
+            KotlinPlatformType.jvm, KotlinPlatformType.androidJvm -> true
+            else -> false
+        }
 }

--- a/kuery-client-gradle-plugin/src/test/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePluginTest.kt
+++ b/kuery-client-gradle-plugin/src/test/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePluginTest.kt
@@ -1,0 +1,31 @@
+package dev.hsbrysk.kuery.gradle
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import io.mockk.every
+import io.mockk.mockk
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class KueryClientGradlePluginTest {
+    private val plugin = KueryClientGradlePlugin()
+
+    @ParameterizedTest
+    @EnumSource(KotlinPlatformType::class, names = ["jvm", "androidJvm"])
+    fun `applicable to JVM compilations`(platformType: KotlinPlatformType) {
+        assertThat(plugin.isApplicable(compilation(platformType))).isTrue()
+    }
+
+    @ParameterizedTest
+    @EnumSource(KotlinPlatformType::class, names = ["jvm", "androidJvm"], mode = EnumSource.Mode.EXCLUDE)
+    fun `not applicable to non-JVM compilations`(platformType: KotlinPlatformType) {
+        assertThat(plugin.isApplicable(compilation(platformType))).isFalse()
+    }
+
+    private fun compilation(platformType: KotlinPlatformType): KotlinCompilation<*> = mockk {
+        every { target.platformType } returns platformType
+    }
+}


### PR DESCRIPTION
## Summary

`KueryClientGradlePlugin.isApplicable()` only checked that the Gradle plugin was applied to the project — which is always true by the time KGP invokes this hook, making it effectively an unconditional `true`.

As a result, in a Kotlin Multiplatform project the compiler plugin was also injected into JS/Native/wasm compilations, where `kuery-client-core` (a JVM-only library) can never be on the classpath. In the common case this only adds useless IR-visiting overhead to those compilations, but if the transformer ever matched a call site there, it would fail with an obscure internal error (`finderForBuiltins().findClass` returning null on a `checkNotNull`).

Now the plugin is applied only to `jvm` / `androidJvm` compilations, the standard pattern for compiler plugins backing JVM-only libraries.

This is technically a behavior change (the plugin no longer lands on non-JVM compilations), but no meaningful code could run there, so it is not observable in practice — and pre-1.0 is the right time to pin this down.

## Test

Added `KueryClientGradlePluginTest` covering all `KotlinPlatformType` values: `jvm` / `androidJvm` are applicable, everything else (`common`, `js`, `native`, `wasm`) is not. Verified the non-JVM cases fail against the previous implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)