### PR TITLE
Make Sql defensively copy its parameters list

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
@@ -25,7 +25,7 @@ interface Sql {
         fun of(
             body: String,
             parameters: List<NamedSqlParameter>,
-        ): Sql = DefaultSql(body, parameters)
+        ): Sql = DefaultSql(body, parameters.toList())
 
         /**
          * Create [Sql] using [SqlBuilder]
@@ -48,7 +48,7 @@ interface Sql {
 fun Sql(
     body: String,
     parameters: List<NamedSqlParameter> = emptyList(),
-): Sql = DefaultSql(body, parameters)
+): Sql = DefaultSql(body, parameters.toList())
 
 /**
  * Create [Sql] using [SqlBuilder]

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilder.kt
@@ -60,7 +60,7 @@ internal class DefaultSqlBuilder : SqlBuilder {
         }
     }
 
-    fun build(): Sql = DefaultSql(body.toString().trim(), parameters)
+    fun build(): Sql = DefaultSql(body.toString().trim(), parameters.toList())
 
     companion object {
         internal const val PARAMETER_NAME_PREFIX = "p"

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
@@ -21,4 +21,14 @@ class SqlTest {
                 ),
             )
     }
+
+    @Test
+    fun notAffectedByCallerListMutation() {
+        val parameters = mutableListOf(NamedSqlParameter("p0", 1))
+        val sql = Sql("SELECT * FROM some_table WHERE id = :p0", parameters)
+
+        parameters.add(NamedSqlParameter("p1", 2))
+
+        assertThat(sql.parameters).isEqualTo(listOf(NamedSqlParameter("p0", 1)))
+    }
 }

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilderTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilderTest.kt
@@ -97,6 +97,18 @@ class DefaultSqlBuilderTest {
     }
 
     @Test
+    fun buildIsNotAffectedByLaterBind() {
+        val builder = DefaultSqlBuilder().apply {
+            addUnsafe("SELECT * FROM some_table WHERE id = ${bind(1)}")
+        }
+        val sql = builder.build()
+
+        builder.bind(2)
+
+        assertThat(sql.parameters).isEqualTo(listOf(NamedSqlParameter("p0", 1)))
+    }
+
+    @Test
     fun interpolate() {
         assertThat(DefaultSqlBuilder().interpolate(emptyList(), emptyList())).isEqualTo("")
         assertThat(DefaultSqlBuilder().interpolate(listOf("a"), emptyList())).isEqualTo("a")


### PR DESCRIPTION
## Summary

`Sql` is documented as an immutable value, but it held a reference to a mutable parameters list in two places:

- `DefaultSqlBuilder.build()` passed its live `mutableListOf` to `DefaultSql`, so calling `bind()` on the builder after `build()` grew the parameters of the already-built `Sql`.
- The public `Sql(body, parameters)` factory (and the deprecated `Sql.of`) stored the caller's list as-is, so mutating that list afterwards changed the `Sql`.

Since `DefaultSql` is a data class, mutable contents also destabilize `equals`/`hashCode`.

## Changes

- Defensively copy the list with `toList()` at construction (3 call sites).
- Add regression tests written test-first (both failed before the fix):
  - `DefaultSqlBuilderTest.buildIsNotAffectedByLaterBind`
  - `SqlTest.notAffectedByCallerListMutation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)