### PR TITLE
Pin the JVM-level ABI of DefaultSqlBuilder.interpolate

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilder.kt
@@ -28,6 +28,11 @@ internal class DefaultSqlBuilder : SqlBuilder {
     }
 
     /**
+     * This method is effectively public ABI even though the class is internal: the compiler plugin
+     * rewrites string interpolation in user code into a direct call to this exact method, so every
+     * compiled user artifact links against it. Its name, signature, and class location must not
+     * change (guarded by `DefaultSqlBuilderAbiTest`).
+     *
      * @param fragments It refers to string parts.
      * @param values It refers to the values of string interpolation.
      * e.g.

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilderAbiTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/DefaultSqlBuilderAbiTest.kt
@@ -1,0 +1,36 @@
+package dev.hsbrysk.kuery.core.internal
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Modifier
+
+/**
+ * `DefaultSqlBuilder.interpolate` is effectively public ABI even though the class is internal:
+ * the compiler plugin rewrites string interpolation in user code into a `CHECKCAST` to this class
+ * followed by an `INVOKEVIRTUAL` of this exact method, so every compiled user artifact links
+ * against it. Because the class is internal, it is outside the scope of the Kotlin ABI validation
+ * that guards the public API. This test pins the JVM-level contract instead.
+ *
+ * If this test fails, you are about to break binary compatibility with every artifact compiled
+ * by an older version of the compiler plugin (`NoSuchMethodError` / `ClassNotFoundException` at
+ * runtime). Do not rename, move, or change the signature of `interpolate`.
+ */
+class DefaultSqlBuilderAbiTest {
+    @Test
+    fun `interpolate signature is frozen`() {
+        // Intentionally string literals (not ::class / type references) so that IDE refactorings
+        // cannot silently update this test along with the production code.
+        val clazz = Class.forName("dev.hsbrysk.kuery.core.internal.DefaultSqlBuilder")
+        // Throws NoSuchMethodException if the name or parameter types change.
+        val method = clazz.getMethod("interpolate", List::class.java, List::class.java)
+
+        // CHECKCAST + INVOKEVIRTUAL require the class and method to be public at the JVM level.
+        assertThat(Modifier.isPublic(clazz.modifiers)).isTrue()
+        assertThat(Modifier.isPublic(method.modifiers)).isTrue()
+        assertThat(Modifier.isStatic(method.modifiers)).isFalse()
+        assertThat(method.returnType).isEqualTo(String::class.java)
+    }
+}


### PR DESCRIPTION
## Summary

`DefaultSqlBuilder.interpolate` is effectively public ABI even though the class is internal: the compiler plugin rewrites string interpolation in user code into a `CHECKCAST` to this class followed by an `INVOKEVIRTUAL` of this exact method, so every compiled user artifact links against it. Because the class is internal, it is outside the scope of the Kotlin ABI validation that guards the public API — renaming, moving, or changing the signature of `interpolate` would cause `NoSuchMethodError` / `ClassNotFoundException` at runtime for artifacts compiled by an older version of the compiler plugin.

This PR:
- Documents the freeze policy in the KDoc of `interpolate`.
- Adds `DefaultSqlBuilderAbiTest`, a reflection-based test that pins the class location (FQCN as a string literal, so IDE refactorings cannot silently update it), method name, parameter types, return type, and JVM-level visibility.

No production behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)