### PR TITLE
Document that SqlBuilder is not intended to be user-implemented

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
@@ -2,6 +2,16 @@ package dev.hsbrysk.kuery.core
 
 import org.intellij.lang.annotations.Language
 
+/**
+ * DSL scope for building SQL.
+ *
+ * This interface is not intended to be implemented by users (e.g. as a test fake).
+ * The compiler plugin assumes the receiver is the library's internal implementation:
+ * a user implementation fails with [ClassCastException] at runtime, and if the static type
+ * of the receiver is a subtype of [SqlBuilder], the rewrite is skipped entirely and the raw
+ * interpolated string is passed to [add] — losing the parameter-binding guarantee this
+ * library exists to provide.
+ */
 @SqlBuilderMarker
 interface SqlBuilder {
     /**


### PR DESCRIPTION
## Summary

The compiler plugin casts the receiver of `add` / `unaryPlus` to the internal `DefaultSqlBuilder`, so a user implementation of `SqlBuilder` (e.g. a test fake) fails with `ClassCastException` at runtime. Worse, when the static type of the receiver is a subtype of `SqlBuilder`, the rewrite is skipped entirely and the raw interpolated string reaches `add` — losing the parameter-binding guarantee this library exists to provide.

This PR states in the interface KDoc that `SqlBuilder` is not intended to be implemented by users. (We deliberately chose not to seal the interface.)

KDoc only, no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)