### PR TITLE
Remove deprecated Sql.of, Sql.create and NamedSqlParameter.of

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/NamedSqlParameter.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/NamedSqlParameter.kt
@@ -13,19 +13,7 @@ interface NamedSqlParameter {
      */
     val value: Any?
 
-    companion object {
-        /**
-         * Create [NamedSqlParameter]
-         */
-        @Deprecated(
-            message = "Use `dev.hsbrysk.kuery.core.NamedSqlParameter` function instead.",
-            replaceWith = ReplaceWith("NamedSqlParameter(name, value)"),
-        )
-        fun of(
-            name: String,
-            value: Any?,
-        ): NamedSqlParameter = DefaultNamedSqlParameter(name, value)
-    }
+    companion object
 }
 
 /**

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
@@ -14,32 +14,7 @@ interface Sql {
      */
     val parameters: List<NamedSqlParameter>
 
-    companion object {
-        /**
-         * Create [Sql]
-         */
-        @Deprecated(
-            message = "Use `dev.hsbrysk.kuery.core.Sql` function instead.",
-            replaceWith = ReplaceWith("Sql(body, parameters)"),
-        )
-        fun of(
-            body: String,
-            parameters: List<NamedSqlParameter>,
-        ): Sql = DefaultSql(body, parameters.toList())
-
-        /**
-         * Create [Sql] using [SqlBuilder]
-         */
-        @Deprecated(
-            message = "Use `dev.hsbrysk.kuery.core.Sql` function instead.",
-            replaceWith = ReplaceWith("Sql(block)"),
-        )
-        fun create(block: SqlBuilder.() -> Unit): Sql {
-            val builder = DefaultSqlBuilder()
-            block(builder)
-            return builder.build()
-        }
-    }
+    companion object
 }
 
 /**


### PR DESCRIPTION
## Summary

Split out of #332 (1/3) so that the release-prep PR only carries the docs changes.

Delete the deprecated `Sql.of`, `Sql.create`, and `NamedSqlParameter.of` factory methods, superseded by the top-level `Sql(...)` / `NamedSqlParameter(...)` functions, ahead of the 1.0.0 release so the deprecated API does not carry over into the stable API surface. The empty companion objects are kept as future extension points.

Compared to the original commit on #332, the premature `public` modifiers are stripped — they belong to the explicit API mode change (2/3).

## Test plan

- [x] `./gradlew :kuery-client-core:build detektMain detektTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)