### PR TITLE
Enable explicit API mode and ABI validation for public API modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,9 @@ Kuery Client is a Kotlin SQL client library that enables writing raw SQL using K
 
 # Auto-format
 ./gradlew ktlintFormat
+
+# Update ABI reference dumps (run after changing public API; commit the api/*.api files)
+./gradlew updateKotlinAbi
 ```
 
 Integration tests (`kuery-client-spring-data-r2dbc`, `kuery-client-spring-data-jdbc`) spin up a MySQL container via Testcontainers and require Docker to be running.
@@ -73,6 +76,8 @@ Row mapping uses `DataClassRowMapper` (Spring's data class mapper) for complex t
 ### Build Conventions
 
 All modules apply `conventions.preset.base` (= `conventions.kotlin` + `conventions.ktlint` + `conventions.detekt`). The Kotlin toolchain is Java 17 (Adoptium). `allWarningsAsErrors = true` is enforced. Versions are centralized in `gradle/libs.versions.toml`.
+
+`kuery-client-core`, `kuery-client-spring-data-jdbc`, and `kuery-client-spring-data-r2dbc` additionally apply `conventions.public-api`, which enables Kotlin explicit API mode and KGP built-in ABI validation. `checkKotlinAbi` runs as part of `check`; when the public API changes intentionally, run `./gradlew updateKotlinAbi` and commit the updated `api/*.api` files. Declarations annotated with `@KueryClientInternalApi` are excluded from the ABI dumps and carry no compatibility guarantee.
 
 ### `@DelicateKueryClientApi`
 

--- a/build-logic/src/main/kotlin/conventions/public-api.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/public-api.gradle.kts
@@ -1,0 +1,20 @@
+package conventions
+
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
+plugins {
+    kotlin("jvm")
+}
+
+kotlin {
+    explicitApi()
+
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation {
+        filters {
+            exclude {
+                annotatedWith.add("dev.hsbrysk.kuery.core.KueryClientInternalApi")
+            }
+        }
+    }
+}

--- a/kuery-client-core/api/kuery-client-core.api
+++ b/kuery-client-core/api/kuery-client-core.api
@@ -1,0 +1,120 @@
+public abstract interface class dev/hsbrysk/kuery/core/CloseableSequence : java/lang/AutoCloseable, kotlin/sequences/Sequence {
+}
+
+public abstract interface annotation class dev/hsbrysk/kuery/core/DelicateKueryClientApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class dev/hsbrysk/kuery/core/KueryBlockingClient {
+	public abstract fun sql (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ldev/hsbrysk/kuery/core/KueryBlockingClient$FetchSpec;
+	public abstract fun sql (Lkotlin/jvm/functions/Function1;)Ldev/hsbrysk/kuery/core/KueryBlockingClient$FetchSpec;
+}
+
+public abstract interface class dev/hsbrysk/kuery/core/KueryBlockingClient$FetchSpec {
+	public abstract fun fetchSize (I)Ldev/hsbrysk/kuery/core/KueryBlockingClient$FetchSpec;
+	public abstract fun generatedValues ([Ljava/lang/String;)Ljava/util/Map;
+	public abstract fun list (Lkotlin/reflect/KClass;)Ljava/util/List;
+	public abstract fun listMap ()Ljava/util/List;
+	public abstract fun maxRows (I)Ldev/hsbrysk/kuery/core/KueryBlockingClient$FetchSpec;
+	public abstract fun queryTimeoutSeconds (I)Ldev/hsbrysk/kuery/core/KueryBlockingClient$FetchSpec;
+	public abstract fun rowsUpdated ()J
+	public abstract fun sequence (Lkotlin/reflect/KClass;)Ldev/hsbrysk/kuery/core/CloseableSequence;
+	public abstract fun sequenceMap ()Ldev/hsbrysk/kuery/core/CloseableSequence;
+	public abstract fun single (Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public abstract fun singleMap ()Ljava/util/Map;
+	public abstract fun singleMapOrNull ()Ljava/util/Map;
+	public abstract fun singleOrNull (Lkotlin/reflect/KClass;)Ljava/lang/Object;
+}
+
+public abstract interface class dev/hsbrysk/kuery/core/KueryClient {
+	public abstract fun sql (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ldev/hsbrysk/kuery/core/KueryClient$FetchSpec;
+	public abstract fun sql (Lkotlin/jvm/functions/Function1;)Ldev/hsbrysk/kuery/core/KueryClient$FetchSpec;
+}
+
+public abstract interface class dev/hsbrysk/kuery/core/KueryClient$FetchSpec {
+	public abstract fun fetchSize (I)Ldev/hsbrysk/kuery/core/KueryClient$FetchSpec;
+	public abstract fun flow (Lkotlin/reflect/KClass;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun flowMap ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun generatedValues ([Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun list (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listMap (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun rowsUpdated (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun single (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun singleMap (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun singleMapOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun singleOrNull (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface annotation class dev/hsbrysk/kuery/core/KueryClientInternalApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class dev/hsbrysk/kuery/core/NamedSqlParameter {
+	public static final field Companion Ldev/hsbrysk/kuery/core/NamedSqlParameter$Companion;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getValue ()Ljava/lang/Object;
+}
+
+public final class dev/hsbrysk/kuery/core/NamedSqlParameter$Companion {
+}
+
+public final class dev/hsbrysk/kuery/core/NamedSqlParameterKt {
+	public static final fun NamedSqlParameter (Ljava/lang/String;Ljava/lang/Object;)Ldev/hsbrysk/kuery/core/NamedSqlParameter;
+}
+
+public abstract interface class dev/hsbrysk/kuery/core/Sql {
+	public static final field Companion Ldev/hsbrysk/kuery/core/Sql$Companion;
+	public abstract fun getBody ()Ljava/lang/String;
+	public abstract fun getParameters ()Ljava/util/List;
+}
+
+public final class dev/hsbrysk/kuery/core/Sql$Companion {
+}
+
+public abstract interface class dev/hsbrysk/kuery/core/SqlBuilder {
+	public abstract fun add (Ljava/lang/String;)V
+	public abstract fun addUnsafe (Ljava/lang/String;)V
+	public abstract fun bind (Ljava/lang/Object;)Ljava/lang/String;
+	public abstract fun unaryPlus (Ljava/lang/String;)V
+}
+
+public final class dev/hsbrysk/kuery/core/SqlBuilderHelpersKt {
+	public static final fun values (Ldev/hsbrysk/kuery/core/SqlBuilder;Ljava/util/List;)V
+	public static final fun values (Ldev/hsbrysk/kuery/core/SqlBuilder;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface annotation class dev/hsbrysk/kuery/core/SqlBuilderMarker : java/lang/annotation/Annotation {
+}
+
+public final class dev/hsbrysk/kuery/core/SqlKt {
+	public static final fun Sql (Ljava/lang/String;Ljava/util/List;)Ldev/hsbrysk/kuery/core/Sql;
+	public static final fun Sql (Lkotlin/jvm/functions/Function1;)Ldev/hsbrysk/kuery/core/Sql;
+	public static synthetic fun Sql$default (Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ldev/hsbrysk/kuery/core/Sql;
+}
+
+public final class dev/hsbrysk/kuery/core/observation/KueryClientFetchContext : io/micrometer/observation/Observation$Context {
+	public fun <init> (Ljava/lang/String;Ldev/hsbrysk/kuery/core/Sql;)V
+	public final fun getSql ()Ldev/hsbrysk/kuery/core/Sql;
+	public final fun getSqlId ()Ljava/lang/String;
+}
+
+public abstract interface class dev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention : io/micrometer/observation/ObservationConvention {
+	public static final field Companion Ldev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention$Companion;
+	public fun getName ()Ljava/lang/String;
+	public fun supportsContext (Lio/micrometer/observation/Observation$Context;)Z
+}
+
+public final class dev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention$Companion {
+	public final fun default ()Ldev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention;
+}
+
+public final class dev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention$DefaultImpls {
+	public static fun getName (Ldev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention;)Ljava/lang/String;
+	public static fun supportsContext (Ldev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention;Lio/micrometer/observation/Observation$Context;)Z
+}
+
+public class dev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentation : java/lang/Enum, io/micrometer/observation/docs/ObservationDocumentation {
+	public static final field FETCH Ldev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentation;
+	public static fun values ()[Ldev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentation;
+}
+

--- a/kuery-client-core/build.gradle.kts
+++ b/kuery-client-core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("conventions.preset.base")
+    id("conventions.public-api")
     id("conventions.maven-publish")
     id("conventions.jmh")
 }

--- a/kuery-client-core/src/jmh/kotlin/com/example/core/MockKueryClient.kt
+++ b/kuery-client-core/src/jmh/kotlin/com/example/core/MockKueryClient.kt
@@ -1,9 +1,11 @@
 package com.example.core
 
+import dev.hsbrysk.kuery.core.KueryClientInternalApi
 import dev.hsbrysk.kuery.core.Sql
 import dev.hsbrysk.kuery.core.SqlBuilder
 import dev.hsbrysk.kuery.core.internal.SqlIds.id
 
+@OptIn(KueryClientInternalApi::class)
 class MockKueryClient {
     fun sql(
         sqlId: String,

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/CloseableSequence.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/CloseableSequence.kt
@@ -18,6 +18,6 @@ package dev.hsbrysk.kuery.core
  * Like ordinary [Sequence]s (and the underlying JDBC resources), this sequence is not thread-safe;
  * obtain and iterate it on a single thread.
  */
-interface CloseableSequence<out T> :
+public interface CloseableSequence<out T> :
     Sequence<T>,
     AutoCloseable

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DelicateKueryClientApi.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DelicateKueryClientApi.kt
@@ -7,4 +7,4 @@ package dev.hsbrysk.kuery.core
     message = "This is a delicate API and its use requires care." +
         " Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.",
 )
-annotation class DelicateKueryClientApi
+public annotation class DelicateKueryClientApi

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
@@ -3,14 +3,14 @@ package dev.hsbrysk.kuery.core
 import dev.hsbrysk.kuery.core.KueryBlockingClient.FetchSpec
 import kotlin.reflect.KClass
 
-interface KueryBlockingClient {
+public interface KueryBlockingClient {
     /**
      * Returns a [FetchSpec] to obtain the execution results based on the received [SqlBuilder].
      *
      * @param sqlId An ID that uniquely identifies the query. It is used for purposes such as metrics.
      * @param block [SqlBuilder] for constructing SQL.
      */
-    fun sql(
+    public fun sql(
         sqlId: String,
         block: SqlBuilder.() -> Unit,
     ): FetchSpec
@@ -20,54 +20,54 @@ interface KueryBlockingClient {
      *
      * @param block [SqlBuilder] for constructing SQL.
      */
-    fun sql(block: SqlBuilder.() -> Unit): FetchSpec
+    public fun sql(block: SqlBuilder.() -> Unit): FetchSpec
 
     @Suppress("TooManyFunctions")
-    interface FetchSpec {
+    public interface FetchSpec {
         /**
          * Set the fetch size to use when executing this query.
          */
-        fun fetchSize(fetchSize: Int): FetchSpec
+        public fun fetchSize(fetchSize: Int): FetchSpec
 
         /**
          * Set the maximum number of rows to return from this query.
          */
-        fun maxRows(maxRows: Int): FetchSpec
+        public fun maxRows(maxRows: Int): FetchSpec
 
         /**
          * Set the query timeout (in seconds) for this query.
          */
-        fun queryTimeoutSeconds(queryTimeoutSeconds: Int): FetchSpec
+        public fun queryTimeoutSeconds(queryTimeoutSeconds: Int): FetchSpec
 
         /**
          * Receives the results as a map.
          */
-        fun singleMap(): Map<String, Any?>
+        public fun singleMap(): Map<String, Any?>
 
         /**
          * Receives the results as a map.
          */
-        fun singleMapOrNull(): Map<String, Any?>?
+        public fun singleMapOrNull(): Map<String, Any?>?
 
         /**
          * Receives the results converted to the specified type.
          */
-        fun <T : Any> single(returnType: KClass<T>): T
+        public fun <T : Any> single(returnType: KClass<T>): T
 
         /**
          * Receives the results converted to the specified type.
          */
-        fun <T : Any> singleOrNull(returnType: KClass<T>): T?
+        public fun <T : Any> singleOrNull(returnType: KClass<T>): T?
 
         /**
          * Receives the results of multiple rows as a map.
          */
-        fun listMap(): List<Map<String, Any?>>
+        public fun listMap(): List<Map<String, Any?>>
 
         /**
          * Receives the results of multiple rows converted to the specified type.
          */
-        fun <T : Any> list(returnType: KClass<T>): List<T>
+        public fun <T : Any> list(returnType: KClass<T>): List<T>
 
         /**
          * Receives the results of multiple rows as a sequence of maps.
@@ -75,7 +75,7 @@ interface KueryBlockingClient {
          * It is closed automatically when fully iterated or when an exception is thrown during the iteration.
          * If you stop iterating midway, close it explicitly (e.g., with [use]). It can be iterated only once.
          */
-        fun sequenceMap(): CloseableSequence<Map<String, Any?>>
+        public fun sequenceMap(): CloseableSequence<Map<String, Any?>>
 
         /**
          * Receives the results of multiple rows converted to the specified type as a sequence.
@@ -83,37 +83,37 @@ interface KueryBlockingClient {
          * It is closed automatically when fully iterated or when an exception is thrown during the iteration.
          * If you stop iterating midway, close it explicitly (e.g., with [use]). It can be iterated only once.
          */
-        fun <T : Any> sequence(returnType: KClass<T>): CloseableSequence<T>
+        public fun <T : Any> sequence(returnType: KClass<T>): CloseableSequence<T>
 
         /**
          * Contract for fetching the number of affected rows
          */
-        fun rowsUpdated(): Long
+        public fun rowsUpdated(): Long
 
         /**
          * Receives the values generated on the database side.
          * For example, an auto increment value.
          */
-        fun generatedValues(vararg columns: String): Map<String, Any>
+        public fun generatedValues(vararg columns: String): Map<String, Any>
     }
 }
 
 /**
  * Receives the results converted to the specified type.
  */
-inline fun <reified T : Any> FetchSpec.single(): T = single(T::class)
+public inline fun <reified T : Any> FetchSpec.single(): T = single(T::class)
 
 /**
  * Receives the results converted to the specified type.
  */
-inline fun <reified T : Any> FetchSpec.singleOrNull(): T? = singleOrNull(T::class)
+public inline fun <reified T : Any> FetchSpec.singleOrNull(): T? = singleOrNull(T::class)
 
 /**
  * Receives the results of multiple rows converted to the specified type.
  */
-inline fun <reified T : Any> FetchSpec.list(): List<T> = list(T::class)
+public inline fun <reified T : Any> FetchSpec.list(): List<T> = list(T::class)
 
 /**
  * Receives the results of multiple rows converted to the specified type as a sequence.
  */
-inline fun <reified T : Any> FetchSpec.sequence(): CloseableSequence<T> = sequence(T::class)
+public inline fun <reified T : Any> FetchSpec.sequence(): CloseableSequence<T> = sequence(T::class)

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
@@ -4,14 +4,14 @@ import dev.hsbrysk.kuery.core.KueryClient.FetchSpec
 import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
-interface KueryClient {
+public interface KueryClient {
     /**
      * Returns a [FetchSpec] to obtain the execution results based on the received [SqlBuilder].
      *
      * @param sqlId An ID that uniquely identifies the query. It is used for purposes such as metrics.
      * @param block [SqlBuilder] for constructing SQL.
      */
-    fun sql(
+    public fun sql(
         sqlId: String,
         block: SqlBuilder.() -> Unit,
     ): FetchSpec
@@ -21,84 +21,84 @@ interface KueryClient {
      *
      * @param block [SqlBuilder] for constructing SQL.
      */
-    fun sql(block: SqlBuilder.() -> Unit): FetchSpec
+    public fun sql(block: SqlBuilder.() -> Unit): FetchSpec
 
     @Suppress("TooManyFunctions")
-    interface FetchSpec {
+    public interface FetchSpec {
         /**
          * Set the fetch size to use when executing this query.
          */
-        fun fetchSize(fetchSize: Int): FetchSpec
+        public fun fetchSize(fetchSize: Int): FetchSpec
 
         /**
          * Receives the results as a map.
          */
-        suspend fun singleMap(): Map<String, Any?>
+        public suspend fun singleMap(): Map<String, Any?>
 
         /**
          * Receives the results as a map.
          */
-        suspend fun singleMapOrNull(): Map<String, Any?>?
+        public suspend fun singleMapOrNull(): Map<String, Any?>?
 
         /**
          * Receives the results converted to the specified type.
          */
-        suspend fun <T : Any> single(returnType: KClass<T>): T
+        public suspend fun <T : Any> single(returnType: KClass<T>): T
 
         /**
          * Receives the results converted to the specified type.
          */
-        suspend fun <T : Any> singleOrNull(returnType: KClass<T>): T?
+        public suspend fun <T : Any> singleOrNull(returnType: KClass<T>): T?
 
         /**
          * Receives the results of multiple rows as a map.
          */
-        suspend fun listMap(): List<Map<String, Any?>>
+        public suspend fun listMap(): List<Map<String, Any?>>
 
         /**
          * Receives the results of multiple rows converted to the specified type.
          */
-        suspend fun <T : Any> list(returnType: KClass<T>): List<T>
+        public suspend fun <T : Any> list(returnType: KClass<T>): List<T>
 
         /**
          * Receives the results of multiple rows as a map.
          */
-        fun flowMap(): Flow<Map<String, Any?>>
+        public fun flowMap(): Flow<Map<String, Any?>>
 
         /**
          * Receives the results of multiple rows converted to the specified type.
          */
-        fun <T : Any> flow(returnType: KClass<T>): Flow<T>
+        public fun <T : Any> flow(returnType: KClass<T>): Flow<T>
 
         /**
          * Contract for fetching the number of affected rows
          */
-        suspend fun rowsUpdated(): Long
+        public suspend fun rowsUpdated(): Long
 
         /**
          * Receives the values generated on the database side.
          * For example, an auto increment value.
          */
-        suspend fun generatedValues(vararg columns: String): Map<String, Any>
+        public suspend fun generatedValues(vararg columns: String): Map<String, Any>
     }
 }
 
 /**
  * Receives the results converted to the specified type.
  */
-suspend inline fun <reified T : Any> FetchSpec.single(): T = single(T::class)
+public suspend inline fun <reified T : Any> FetchSpec.single(): T = single(T::class)
 
 /**
  * Receives the results converted to the specified type.
  */
-suspend inline fun <reified T : Any> FetchSpec.singleOrNull(): T? = singleOrNull(T::class)
+public suspend inline fun <reified T : Any> FetchSpec.singleOrNull(): T? = singleOrNull(T::class)
 
 /**
  * Receives the results of multiple rows converted to the specified type.
  */
-suspend inline fun <reified T : Any> FetchSpec.list(): List<T> = list(T::class)
+public suspend inline fun <reified T : Any> FetchSpec.list(): List<T> = list(T::class)
 
 /**
  * Receives the results of multiple rows converted to the specified type.
  */
-inline fun <reified T : Any> FetchSpec.flow(): Flow<T> = flow(T::class)
+public inline fun <reified T : Any> FetchSpec.flow(): Flow<T> = flow(T::class)

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClientInternalApi.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClientInternalApi.kt
@@ -1,0 +1,10 @@
+package dev.hsbrysk.kuery.core
+
+@MustBeDocumented
+@Retention(value = AnnotationRetention.BINARY)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This is an internal Kuery Client API." +
+        " It may be changed or removed without notice, and no compatibility is guaranteed between versions.",
+)
+public annotation class KueryClientInternalApi

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/NamedSqlParameter.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/NamedSqlParameter.kt
@@ -2,24 +2,24 @@ package dev.hsbrysk.kuery.core
 
 import dev.hsbrysk.kuery.core.internal.DefaultNamedSqlParameter
 
-interface NamedSqlParameter {
+public interface NamedSqlParameter {
     /**
      * parameter name
      */
-    val name: String
+    public val name: String
 
     /**
      * value
      */
-    val value: Any?
+    public val value: Any?
 
-    companion object
+    public companion object
 }
 
 /**
  * Create [NamedSqlParameter]
  */
-fun NamedSqlParameter(
+public fun NamedSqlParameter(
     name: String,
     value: Any?,
 ): NamedSqlParameter = DefaultNamedSqlParameter(name, value)

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
@@ -3,24 +3,24 @@ package dev.hsbrysk.kuery.core
 import dev.hsbrysk.kuery.core.internal.DefaultSql
 import dev.hsbrysk.kuery.core.internal.DefaultSqlBuilder
 
-interface Sql {
+public interface Sql {
     /**
      * SQL body
      */
-    val body: String
+    public val body: String
 
     /**
      * SQL parameters
      */
-    val parameters: List<NamedSqlParameter>
+    public val parameters: List<NamedSqlParameter>
 
-    companion object
+    public companion object
 }
 
 /**
  * Create [Sql]
  */
-fun Sql(
+public fun Sql(
     body: String,
     parameters: List<NamedSqlParameter> = emptyList(),
 ): Sql = DefaultSql(body, parameters.toList())
@@ -28,7 +28,7 @@ fun Sql(
 /**
  * Create [Sql] using [SqlBuilder]
  */
-fun Sql(block: SqlBuilder.() -> Unit): Sql {
+public fun Sql(block: SqlBuilder.() -> Unit): Sql {
     val builder = DefaultSqlBuilder()
     block(builder)
     return builder.build()

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
@@ -13,7 +13,7 @@ import org.intellij.lang.annotations.Language
  * library exists to provide.
  */
 @SqlBuilderMarker
-interface SqlBuilder {
+public interface SqlBuilder {
     /**
      * Specify the sql you want to execute. Appended to the internally held [StringBuilder].
      * Due to the Kotlin compiler plugin, the string interpolation within the string template passed to
@@ -24,7 +24,7 @@ interface SqlBuilder {
      * add("SELECT * FROM users WHERE user_id = $userId")
      * ```
      */
-    fun add(@Language("sql") sql: String)
+    public fun add(@Language("sql") sql: String)
 
     /**
      * Specify the sql you want to execute. Appended to the internally held [StringBuilder].
@@ -36,7 +36,7 @@ interface SqlBuilder {
      * +"SELECT * FROM users WHERE user_id = $userId"
      * ```
      */
-    operator fun String.unaryPlus()
+    public operator fun String.unaryPlus()
 
     /**
      * Specify the sql you want to execute. Appended to the internally held [StringBuilder].
@@ -48,12 +48,12 @@ interface SqlBuilder {
      * ```
      */
     @DelicateKueryClientApi
-    fun addUnsafe(@Language("sql") sql: String)
+    public fun addUnsafe(@Language("sql") sql: String)
 
     /**
      * Bind variables to SQL
      * It is intended to be used together with addUnsafe.
      */
     @DelicateKueryClientApi
-    fun bind(parameter: Any?): String
+    public fun bind(parameter: Any?): String
 }

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilderHelpers.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilderHelpers.kt
@@ -1,7 +1,24 @@
 package dev.hsbrysk.kuery.core
 
+/**
+ * Add a `VALUES (...), (...)` clause, binding every element as a parameter.
+ *
+ * ```kotlin
+ * client.sql {
+ *     +"INSERT INTO users (username, email)"
+ *     values(listOf(
+ *         listOf("user1", "user1@example.com"),
+ *         listOf("user2", "user2@example.com"),
+ *     ))
+ * }
+ * ```
+ *
+ * @param input rows of values; each child list corresponds to one row
+ * @throws IllegalArgumentException if [input] is empty, a child list is empty,
+ * or the child lists do not all have the same size
+ */
 @OptIn(DelicateKueryClientApi::class)
-fun SqlBuilder.values(input: List<List<Any?>>) {
+public fun SqlBuilder.values(input: List<List<Any?>>) {
     require(input.isNotEmpty()) { "inputted list is empty" }
     val firstSize = input.first().size
     require(input.all { it.size == firstSize }) { "All inputted child lists must have the same size." }
@@ -15,7 +32,22 @@ fun SqlBuilder.values(input: List<List<Any?>>) {
     addUnsafe("VALUES $placeholders")
 }
 
-fun <T> SqlBuilder.values(
+/**
+ * Add a `VALUES (...), (...)` clause, converting each element of [input] into a row using [transformer].
+ *
+ * ```kotlin
+ * client.sql {
+ *     +"INSERT INTO users (username, email)"
+ *     values(users) { listOf(it.username, it.email) }
+ * }
+ * ```
+ *
+ * @param input objects to insert; each element corresponds to one row
+ * @param transformer converts an element into the list of values for its row
+ * @throws IllegalArgumentException if [input] is empty, [transformer] returns an empty list,
+ * or the returned lists do not all have the same size
+ */
+public fun <T> SqlBuilder.values(
     input: List<T>,
     transformer: (T) -> List<Any?>,
 ) {

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilderMarker.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilderMarker.kt
@@ -1,4 +1,4 @@
 package dev.hsbrysk.kuery.core
 
 @DslMarker
-annotation class SqlBuilderMarker
+public annotation class SqlBuilderMarker

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/SqlIds.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/SqlIds.kt
@@ -1,8 +1,10 @@
 package dev.hsbrysk.kuery.core.internal
 
+import dev.hsbrysk.kuery.core.KueryClientInternalApi
 import dev.hsbrysk.kuery.core.SqlBuilder
 
-object SqlIds {
+@KueryClientInternalApi
+public object SqlIds {
     private val NUMBER_REGEX = "^[0-9]+$".toRegex()
 
     // ClassValue stores the computed id on the block's Class itself instead of referencing
@@ -25,7 +27,7 @@ object SqlIds {
      * multiple call sites, all of them observe the id of whichever call site ran first.
      * Define blocks inline if each call site should get its own id.
      */
-    fun (SqlBuilder.() -> Unit).id(): String = CACHE.get(this.javaClass)
+    public fun (SqlBuilder.() -> Unit).id(): String = CACHE.get(this.javaClass)
 
     private fun callerId(): String {
         val name = StackWalker.getInstance().walk { frames ->

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchContext.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchContext.kt
@@ -8,7 +8,7 @@ import io.micrometer.observation.Observation
 /**
  * [Observation.Context] for [KueryClient] and [KueryBlockingClient]
  */
-class KueryClientFetchContext(
-    val sqlId: String,
-    val sql: Sql,
+public class KueryClientFetchContext(
+    public val sqlId: String,
+    public val sql: Sql,
 ) : Observation.Context()

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention.kt
@@ -9,12 +9,12 @@ import io.micrometer.observation.ObservationConvention
 /**
  * [ObservationConvention] for [KueryClient] and [KueryBlockingClient]
  */
-interface KueryClientFetchObservationConvention : ObservationConvention<KueryClientFetchContext> {
+public interface KueryClientFetchObservationConvention : ObservationConvention<KueryClientFetchContext> {
     override fun getName(): String = "kuery.client.fetches"
 
     override fun supportsContext(context: Observation.Context): Boolean = context is KueryClientFetchContext
 
-    companion object {
-        fun default(): KueryClientFetchObservationConvention = DefaultKueryClientFetchObservationConvention()
+    public companion object {
+        public fun default(): KueryClientFetchObservationConvention = DefaultKueryClientFetchObservationConvention()
     }
 }

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentation.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentation.kt
@@ -11,7 +11,7 @@ import io.micrometer.observation.docs.ObservationDocumentation
 /**
  * [ObservationDocumentation] for [KueryClient] and [KueryBlockingClient]
  */
-enum class KueryClientObservationDocumentation : ObservationDocumentation {
+public enum class KueryClientObservationDocumentation : ObservationDocumentation {
     FETCH {
         override fun getDefaultConvention(): Class<out ObservationConvention<out Observation.Context>> =
             DefaultKueryClientFetchObservationConvention::class.java

--- a/kuery-client-core/src/test/kotlin/com/example/core/ClassA.kt
+++ b/kuery-client-core/src/test/kotlin/com/example/core/ClassA.kt
@@ -1,11 +1,13 @@
 package com.example.core
 
+import dev.hsbrysk.kuery.core.KueryClientInternalApi
 import dev.hsbrysk.kuery.core.SqlBuilder
 import dev.hsbrysk.kuery.core.internal.SqlIds.id
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
+@OptIn(KueryClientInternalApi::class)
 internal class ClassA {
     fun sql1(block: SqlBuilder.() -> Unit): String = block.id()
 

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
 import com.example.core.ClassA
+import dev.hsbrysk.kuery.core.KueryClientInternalApi
 import dev.hsbrysk.kuery.core.SqlBuilder
 import dev.hsbrysk.kuery.core.internal.SqlIds.id
 import dev.hsbrysk.kuery.core.internal.SqlIds.removeSuffixes
@@ -11,6 +12,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import java.lang.ref.WeakReference
 
+@OptIn(KueryClientInternalApi::class)
 class SqlIdsTest {
     @Test
     fun id() {

--- a/kuery-client-spring-data-jdbc/api/kuery-client-spring-data-jdbc.api
+++ b/kuery-client-spring-data-jdbc/api/kuery-client-spring-data-jdbc.api
@@ -1,0 +1,15 @@
+public final class dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClient {
+	public static final field INSTANCE Ldev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClient;
+	public final fun builder ()Ldev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder;
+	public final fun sqlId ()Ljava/lang/String;
+}
+
+public abstract interface class dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder {
+	public abstract fun build ()Ldev/hsbrysk/kuery/core/KueryBlockingClient;
+	public abstract fun converters (Ljava/util/List;)Ldev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder;
+	public abstract fun dataSource (Ljavax/sql/DataSource;)Ldev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder;
+	public abstract fun enableAutoSqlIdGeneration (Z)Ldev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder;
+	public abstract fun observationConvention (Ldev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention;)Ldev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder;
+	public abstract fun observationRegistry (Lio/micrometer/observation/ObservationRegistry;)Ldev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder;
+}
+

--- a/kuery-client-spring-data-jdbc/build.gradle.kts
+++ b/kuery-client-spring-data-jdbc/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("conventions.preset.base")
+    id("conventions.public-api")
     id("conventions.maven-publish")
 }
 

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClient.kt
@@ -2,16 +2,16 @@ package dev.hsbrysk.kuery.spring.jdbc
 
 import dev.hsbrysk.kuery.spring.jdbc.internal.DefaultSpringJdbcKueryClientBuilder
 
-object SpringJdbcKueryClient {
+public object SpringJdbcKueryClient {
     /**
      * Retrieve the running sqlId from thread local.
      */
-    fun sqlId(): String? = sqlIdThreadLocal.get()
+    public fun sqlId(): String? = sqlIdThreadLocal.get()
 
     /**
      * Create [SpringJdbcKueryClientBuilder]
      */
-    fun builder(): SpringJdbcKueryClientBuilder = DefaultSpringJdbcKueryClientBuilder()
+    public fun builder(): SpringJdbcKueryClientBuilder = DefaultSpringJdbcKueryClientBuilder()
 }
 
 private val sqlIdThreadLocal = ThreadLocal<String>()

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder.kt
@@ -5,26 +5,26 @@ import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import io.micrometer.observation.ObservationRegistry
 import javax.sql.DataSource
 
-interface SpringJdbcKueryClientBuilder {
+public interface SpringJdbcKueryClientBuilder {
     /**
      * Set [DataSource]
      */
-    fun dataSource(dataSource: DataSource): SpringJdbcKueryClientBuilder
+    public fun dataSource(dataSource: DataSource): SpringJdbcKueryClientBuilder
 
     /**
      * Set converters
      */
-    fun converters(converters: List<Any>): SpringJdbcKueryClientBuilder
+    public fun converters(converters: List<Any>): SpringJdbcKueryClientBuilder
 
     /**
      * Set [ObservationRegistry]
      */
-    fun observationRegistry(observationRegistry: ObservationRegistry): SpringJdbcKueryClientBuilder
+    public fun observationRegistry(observationRegistry: ObservationRegistry): SpringJdbcKueryClientBuilder
 
     /**
      * Set [KueryClientFetchObservationConvention]
      */
-    fun observationConvention(
+    public fun observationConvention(
         observationConvention: KueryClientFetchObservationConvention,
     ): SpringJdbcKueryClientBuilder
 
@@ -37,10 +37,10 @@ interface SpringJdbcKueryClientBuilder {
      * all of them observe the sqlId of whichever call site ran first.
      * Define blocks inline if each call site should get its own sqlId.
      */
-    fun enableAutoSqlIdGeneration(enableAutoSqlIdGeneration: Boolean): SpringJdbcKueryClientBuilder
+    public fun enableAutoSqlIdGeneration(enableAutoSqlIdGeneration: Boolean): SpringJdbcKueryClientBuilder
 
     /**
      * build [KueryBlockingClient]
      */
-    fun build(): KueryBlockingClient
+    public fun build(): KueryBlockingClient
 }

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -2,6 +2,7 @@ package dev.hsbrysk.kuery.spring.jdbc.internal
 
 import dev.hsbrysk.kuery.core.CloseableSequence
 import dev.hsbrysk.kuery.core.KueryBlockingClient
+import dev.hsbrysk.kuery.core.KueryClientInternalApi
 import dev.hsbrysk.kuery.core.NamedSqlParameter
 import dev.hsbrysk.kuery.core.Sql
 import dev.hsbrysk.kuery.core.SqlBuilder
@@ -28,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 import java.lang.reflect.Array as ReflectArray
 
+@OptIn(KueryClientInternalApi::class)
 internal class DefaultSpringJdbcKueryClient(
     private val jdbcClient: JdbcClient,
     private val conversionService: ConversionService,

--- a/kuery-client-spring-data-r2dbc/api/kuery-client-spring-data-r2dbc.api
+++ b/kuery-client-spring-data-r2dbc/api/kuery-client-spring-data-r2dbc.api
@@ -1,0 +1,16 @@
+public final class dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClient {
+	public static final field INSTANCE Ldev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClient;
+	public final fun builder ()Ldev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder;
+	public final fun getSQL_ID_REACTOR_CONTEXT_KEY ()Ljava/lang/String;
+	public final fun sqlId (Lreactor/util/context/ContextView;)Ljava/lang/String;
+}
+
+public abstract interface class dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder {
+	public abstract fun build ()Ldev/hsbrysk/kuery/core/KueryClient;
+	public abstract fun connectionFactory (Lio/r2dbc/spi/ConnectionFactory;)Ldev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder;
+	public abstract fun converters (Ljava/util/List;)Ldev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder;
+	public abstract fun enableAutoSqlIdGeneration (Z)Ldev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder;
+	public abstract fun observationConvention (Ldev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention;)Ldev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder;
+	public abstract fun observationRegistry (Lio/micrometer/observation/ObservationRegistry;)Ldev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder;
+}
+

--- a/kuery-client-spring-data-r2dbc/build.gradle.kts
+++ b/kuery-client-spring-data-r2dbc/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("conventions.preset.base")
+    id("conventions.public-api")
     id("conventions.maven-publish")
     id("conventions.jmh")
 }

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClient.kt
@@ -3,16 +3,17 @@ package dev.hsbrysk.kuery.spring.r2dbc
 import dev.hsbrysk.kuery.spring.r2dbc.internal.DefaultSpringR2dbcKueryClientBuilder
 import reactor.util.context.ContextView
 
-object SpringR2dbcKueryClient {
-    val SQL_ID_REACTOR_CONTEXT_KEY = "${SpringR2dbcKueryClient::class.java.name}:sqlId"
+public object SpringR2dbcKueryClient {
+    public val SQL_ID_REACTOR_CONTEXT_KEY: String = "${SpringR2dbcKueryClient::class.java.name}:sqlId"
 
     /**
      * Retrieve the current sqlId from reactor context.
      */
-    fun sqlId(context: ContextView): String? = context.getOrEmpty<String>(SQL_ID_REACTOR_CONTEXT_KEY).orElse(null)
+    public fun sqlId(context: ContextView): String? =
+        context.getOrEmpty<String>(SQL_ID_REACTOR_CONTEXT_KEY).orElse(null)
 
     /**
      * Create [SpringR2dbcKueryClientBuilder]
      */
-    fun builder(): SpringR2dbcKueryClientBuilder = DefaultSpringR2dbcKueryClientBuilder()
+    public fun builder(): SpringR2dbcKueryClientBuilder = DefaultSpringR2dbcKueryClientBuilder()
 }

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder.kt
@@ -5,26 +5,26 @@ import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import io.micrometer.observation.ObservationRegistry
 import io.r2dbc.spi.ConnectionFactory
 
-interface SpringR2dbcKueryClientBuilder {
+public interface SpringR2dbcKueryClientBuilder {
     /**
      * Set [ConnectionFactory]
      */
-    fun connectionFactory(connectionFactory: ConnectionFactory): SpringR2dbcKueryClientBuilder
+    public fun connectionFactory(connectionFactory: ConnectionFactory): SpringR2dbcKueryClientBuilder
 
     /**
      * Set converters
      */
-    fun converters(converters: List<Any>): SpringR2dbcKueryClientBuilder
+    public fun converters(converters: List<Any>): SpringR2dbcKueryClientBuilder
 
     /**
      * Set [ObservationRegistry]
      */
-    fun observationRegistry(observationRegistry: ObservationRegistry): SpringR2dbcKueryClientBuilder
+    public fun observationRegistry(observationRegistry: ObservationRegistry): SpringR2dbcKueryClientBuilder
 
     /**
      * Set [KueryClientFetchObservationConvention]
      */
-    fun observationConvention(
+    public fun observationConvention(
         observationConvention: KueryClientFetchObservationConvention,
     ): SpringR2dbcKueryClientBuilder
 
@@ -37,10 +37,10 @@ interface SpringR2dbcKueryClientBuilder {
      * all of them observe the sqlId of whichever call site ran first.
      * Define blocks inline if each call site should get its own sqlId.
      */
-    fun enableAutoSqlIdGeneration(enableAutoSqlIdGeneration: Boolean): SpringR2dbcKueryClientBuilder
+    public fun enableAutoSqlIdGeneration(enableAutoSqlIdGeneration: Boolean): SpringR2dbcKueryClientBuilder
 
     /**
      * Build [KueryClient]
      */
-    fun build(): KueryClient
+    public fun build(): KueryClient
 }

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -1,6 +1,7 @@
 package dev.hsbrysk.kuery.spring.r2dbc.internal
 
 import dev.hsbrysk.kuery.core.KueryClient
+import dev.hsbrysk.kuery.core.KueryClientInternalApi
 import dev.hsbrysk.kuery.core.NamedSqlParameter
 import dev.hsbrysk.kuery.core.Sql
 import dev.hsbrysk.kuery.core.SqlBuilder
@@ -34,6 +35,7 @@ import java.util.function.Function
 import kotlin.reflect.KClass
 import java.lang.reflect.Array as ReflectArray
 
+@OptIn(KueryClientInternalApi::class)
 internal class DefaultSpringR2dbcKueryClient(
     private val databaseClient: DatabaseClient,
     private val conversionService: ConversionService,


### PR DESCRIPTION
## Summary

Split out of #332 (2/3) so that the release-prep PR only carries the docs changes. Rebased onto `main` after #357 (deprecated API removal) merged.

- New `conventions.public-api` convention plugin enabling Kotlin **explicit API mode** and KGP built-in **ABI validation**, applied to the three published API modules: `kuery-client-core`, `kuery-client-spring-data-jdbc`, `kuery-client-spring-data-r2dbc`.
- Commit the ABI reference dumps (`api/*.api`). `checkKotlinAbi` runs as part of `check`, so unintended public API changes fail CI.
- New `@KueryClientInternalApi` opt-in annotation (ERROR level) for declarations that are public only for cross-module use (`SqlIds`); these are excluded from the ABI dumps and carry no compatibility guarantee.
- Add `public` modifiers / explicit return types across the three modules, and KDoc for the `values()` helpers.

Compared to the original commit on #332, this is rebased onto current `main`: the dumps and modifiers now also cover the API added since (e.g. `CloseableSequence` from #334), and the `SqlIds` changes are rebased onto the `ClassValue` implementation from #350.

## Test plan

- [x] `./gradlew build detektMain detektTest` (incl. Testcontainers-based integration tests; `check` includes `checkKotlinAbi`)
- [x] `./gradlew -p examples check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)