### PR TITLE
Deploy the docs site on release tags instead of every main push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,8 @@ name: Deploy VitePress site to Pages
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
## Summary

Deploying the docs site on every push to `main` meant that any `docs/` change merged to `main` went live immediately — which is why the release-prep docs PR (#332) has to stay unmerged until the release.

Trigger the deployment on `v[0-9]+.[0-9]+.[0-9]+` tag pushes instead:

- Docs changes can merge to `main` at any time; the site is only published together with a release.
- The `{{version}}` placeholder introduced in #332 derives from the latest git tag, so building at tag-push time naturally picks up the version being released (no more post-tag manual re-run of docs.yml).
- `workflow_dispatch` remains for manual deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)