### PR TITLE
Document the Java 17 requirement

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,6 +33,10 @@ Kotlin version listed in the table below for the kuery-client version you use.
 When a new Kotlin version is released, we follow up with a kuery-client release built against it (as a minor or patch
 release, as long as there are no other breaking changes).
 
+## Java version
+
+Kuery Client is built with a Java 17 toolchain, so Java 17 or later is required at runtime.
+
 ## Compatibility matrix
 
 The following table lists the versions of Kotlin, Spring Boot, and Spring Data that each kuery-client release

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,11 @@ description: Install via Gradle plugin and dependency, then build a KueryClient 
 
 # Getting Started
 
+## Requirements
+
+- Java 17 or later
+- See [Compatibility](/compatibility) for the recommended Kotlin / Spring versions for each release
+
 ## Install
 
 ### Gradle


### PR DESCRIPTION
## Summary

The docs never stated a minimum JDK requirement. Kuery Client is built with a Java 17 toolchain (`build-logic/src/main/kotlin/conventions/kotlin.gradle.kts`), so:

- Add a **Java version** section to `compatibility.md` (Java 17+ required)
- Add a short **Requirements** section at the top of `getting-started.md`, linking to the Compatibility page for the per-release Kotlin / Spring versions

## Verification

- `npm run docs:build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)