### PR TITLE
Rewrite nested add/unaryPlus inside string interpolation values

### DIFF
--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
@@ -262,6 +262,65 @@ class StringInterpolationTest {
     }
 
     @Test
+    fun `nested add inside an interpolation value`() {
+        val x = "X"
+        val y = "Y"
+        val sql = Sql {
+            +"A ${run {
+                add("B $x")
+                "v"
+            }} C $y"
+        }
+        // The inner add runs first while the outer template's values are being evaluated,
+        // then the outer template binds the run block's result ("v") as a single value.
+        assertThat(sql).isEqualTo(
+            Sql(
+                "B :p0\nA :p1 C :p2",
+                listOf(
+                    NamedSqlParameter("p0", "X"),
+                    NamedSqlParameter("p1", "v"),
+                    NamedSqlParameter("p2", "Y"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `nested unaryPlus inside an interpolation value`() {
+        val x = "X"
+        val sql = Sql {
+            +"A ${run {
+                +"B $x"
+                "v"
+            }}"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "B :p0\nA :p1",
+                listOf(
+                    NamedSqlParameter("p0", "X"),
+                    NamedSqlParameter("p1", "v"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `string template inside an interpolation value stays a plain concatenation`() {
+        val sql = Sql {
+            +"A ${listOf(1, 2).joinToString(", ") { "n $it" }}"
+        }
+        // The template inside the lambda belongs to the value, not to the SQL text,
+        // so the whole evaluated result is bound as a single parameter.
+        assertThat(sql).isEqualTo(
+            Sql(
+                "A :p0",
+                listOf(NamedSqlParameter("p0", "n 1, n 2")),
+            ),
+        )
+    }
+
+    @Test
     fun `const val string interpolation`() {
         val id = 1
         val sql = Sql {

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -76,7 +76,19 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
     }
 
     override fun visitStringConcatenation(expression: IrStringConcatenation): IrExpression {
-        val current = current ?: return super.visitStringConcatenation(expression)
+        val enclosing = current ?: return super.visitStringConcatenation(expression)
+
+        // The template's values are bound as parameters, not SQL text, so transform them outside
+        // the enclosing add/unaryPlus context: a nested add/unaryPlus inside a value must still be
+        // rewritten (it sets up its own receiver), while a string template inside a value stays a
+        // plain concatenation whose evaluated result is bound as a single value.
+        current = null
+        try {
+            expression.transformChildren(this, null)
+        } finally {
+            current = enclosing
+        }
+
         val builder = irBuilder(expression)
 
         val (fragments, values) = StringConcatenationProcessor(builder).process(expression.arguments).let {
@@ -92,7 +104,7 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
 
         return builder.irCall(interpolate).apply {
             dispatchReceiver = builder.irCastIfNeeded(
-                builder.irGet(current),
+                builder.irGet(enclosing),
                 defaultSqlBuilderClass.typeWith(),
             )
             val regularParams = interpolate.owner.parameters.filter { it.kind == IrParameterKind.Regular }


### PR DESCRIPTION
## Summary

A nested `add`/`unaryPlus` call placed **inside an interpolation value** was never rewritten by the IR transformer:

```kotlin
Sql {
    +"A ${ run { add("B $x"); "v" } } C $y"
}
```

`visitStringConcatenation` built the `interpolate()` call from the raw template arguments without transforming them, so the nested `add` survived to runtime and hit `DefaultSqlBuilder.add`'s "must be rewritten by the compiler plugin" `IllegalStateException` — a misleading message, since the plugin *is* applied. The same nesting as a *direct* argument (`add(run { add(...); "..." })`, supported since #335) works, so moving the block one level into `${...}` flipped it from working to crashing.

## Fix

Transform the template's value sub-expressions with the enclosing add/unaryPlus context cleared:

- a nested `add`/`unaryPlus` sets up its own receiver and is rewritten as usual
- a string template inside a value stays a plain concatenation whose evaluated result is bound as a single value (unchanged behavior, now pinned by a test)

## Tests

- `nested add inside an interpolation value` / `nested unaryPlus inside an interpolation value` — fail with the ISE before the fix (test-first)
- `string template inside an interpolation value stays a plain concatenation` — pins the value-side semantics
- functional-test runs with `-Xverify-ir=error`, so IR tree correctness of the new traversal is verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)