### PR TITLE
Fix misleading comment on R2DBC SingleColumnRowMapper conversion behavior

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SingleBasicTypeTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SingleBasicTypeTest.kt
@@ -81,6 +81,7 @@ class SingleBasicTypeTest {
             Arguments.of("SELECT '1'", 1, Int::class),
             Arguments.of("SELECT '1'", 1L, Long::class),
             Arguments.of("SELECT 'hoge'", "hoge", String::class),
+            Arguments.of("SELECT 1", "1", String::class),
             Arguments.of("SELECT 'https://example.com'", URI("https://example.com"), URI::class),
             Arguments.of("SELECT 1", true, Boolean::class),
             Arguments.of("SELECT 0", false, Boolean::class),

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -257,8 +257,13 @@ internal class DefaultSpringR2dbcKueryClient(
         }
     }
 
-    // ref: https://github.com/spring-projects/spring-framework/blob/bf06d74879029593b40d3825aca39dad9f229f44/spring-jdbc/src/main/java/org/springframework/jdbc/core/SingleColumnRowMapper.java
-    // However, conversions such as any-to-string or string-to-number are intentionally not implemented.
+    // A Readable-based counterpart of Spring JDBC's SingleColumnRowMapper:
+    // https://github.com/spring-projects/spring-framework/blob/bf06d74879029593b40d3825aca39dad9f229f44/spring-jdbc/src/main/java/org/springframework/jdbc/core/SingleColumnRowMapper.java
+    //
+    // First asks the driver for the value as [requiredType]; when the driver cannot convert it, falls back to
+    // [conversionService] (DefaultConversionService plus user-registered converters). Standard conversions such
+    // as string-to-number and any-to-string are therefore supported, aligning the observable behavior with the
+    // JDBC module. Which of the two paths handles a given conversion is driver-dependent.
     //
     // The R2DBC SPI forbids Result.map mapping functions from returning null, so a SQL NULL value
     // is returned as [NullValue] instead and unwrapped at the terminal operators.

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SingleBasicTypeTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SingleBasicTypeTest.kt
@@ -82,6 +82,7 @@ class SingleBasicTypeTest {
             Arguments.of("SELECT '1'", 1, Int::class),
             Arguments.of("SELECT '1'", 1L, Long::class),
             Arguments.of("SELECT 'hoge'", "hoge", String::class),
+            Arguments.of("SELECT 1", "1", String::class),
             Arguments.of("SELECT 'https://example.com'", URI("https://example.com"), URI::class),
             // Unlike JDBC, this test case does not pass.
             // Arguments.of("SELECT 1", true, Boolean::class),


### PR DESCRIPTION
## Summary

Review finding R3: the comment on the R2DBC module's custom `SingleColumnRowMapper` contradicted the implementation.

The comment claimed conversions such as any-to-string or string-to-number are "intentionally not implemented", but the catch fallback has delegated to the `ConversionService` (built on `DefaultConversionService` plus user-registered converters) since the initial implementation (#119). Both conversions actually work, and `SingleBasicTypeTest` already pins string-to-number (`SELECT '1'` -> `Int`) and string-to-URI through that exact fallback path.

This PR clarifies the spec in the direction of the actual behavior rather than gating the conversions, because gating would:

- regress existing green tests (`SELECT '1'` -> `Int`/`Short`/`Long`, `SELECT '...'` -> `URI`),
- break symmetry with the JDBC module, whose Spring `SingleColumnRowMapper` supports these conversions natively, and
- stop user-registered converters from applying to scalar results.

## Changes

- Rewrite the comment to describe the real two-step lookup: ask the driver for the value as `requiredType` first, then fall back to the `ConversionService`. Note that which path handles a given conversion is driver-dependent.
- Pin the previously untested any-to-string conversion (`SELECT 1` -> `String`) in `SingleBasicTypeTest` for both modules.

No behavior change.

## Testing

- `SingleBasicTypeTest` green on both modules including the new case (R2DBC 11 tests / JDBC 13 tests, 0 failures; MySQL via Testcontainers)
- ktlint / detekt pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)