### PR TITLE
Fix array binding edge cases: all-null/empty convertible arrays and primitive arrays on R2DBC

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -84,13 +84,26 @@ internal class DefaultSpringJdbcKueryClient(
     // resolve the SQL array type from it, and pgjdbc rejects Object[] outright.
     private fun convertArray(array: Array<*>): Array<*> {
         val converted = array.map { convertElement(it) }
-        if (array.indices.all { converted[it] === array[it] }) {
+        val targetType = componentWriteTarget(array.javaClass.componentType)
+        if (targetType == null && array.indices.all { converted[it] === array[it] }) {
             return array
         }
-        val componentType = converted.mapNotNull { it?.javaClass }.distinct().singleOrNull() ?: Any::class.java
+        val inferredType = converted.mapNotNull { it?.javaClass }.distinct().singleOrNull() ?: Any::class.java
+        val componentType = targetType ?: inferredType
         val result = ReflectArray.newInstance(componentType, array.size)
         converted.forEachIndexed { index, value -> ReflectArray.set(result, index, value) }
         return result as Array<*>
+    }
+
+    // The component type itself carries the conversion intent even when the elements don't
+    // (all-null or empty arrays), e.g. SampleEnum[] must become String[] regardless of contents.
+    private fun componentWriteTarget(componentType: Class<*>): Class<*>? {
+        val targetType = customConversions.getCustomWriteTarget(componentType)
+        return when {
+            targetType.isPresent -> targetType.get()
+            Enum::class.java.isAssignableFrom(componentType) -> String::class.java
+            else -> null
+        }
     }
 
     private fun convertElement(element: Any?): Any? {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/PostgresArrayBindingTest.kt
@@ -87,6 +87,45 @@ class PostgresArrayBindingTest {
         assertThat(stored.toList()).isEqualTo(listOf("a", "b"))
     }
 
+    @Test
+    fun `bind all-null enum array to a native array column`() {
+        val tags = arrayOf<SampleEnum?>(null, null)
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = (record["tags"] as SqlArray).array as Array<*>
+        assertThat(stored.toList()).isEqualTo(listOf(null, null))
+    }
+
+    @Test
+    fun `bind empty enum array to a native array column`() {
+        val tags = arrayOf<SampleEnum>()
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = (record["tags"] as SqlArray).array as Array<*>
+        assertThat(stored.toList()).isEqualTo(emptyList<String>())
+    }
+
+    @Test
+    fun `bind primitive int array to ANY predicate`() {
+        val userIds = intArrayOf(1, 2)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
     companion object {
         private val postgres = PostgresTestContainer()
 

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -82,6 +82,15 @@ internal class DefaultSpringR2dbcKueryClient(
         return when (value) {
             is Collection<*> -> bind(parameter.name, convertCollection(value))
             is Array<*> -> bind(parameter.name, convertArray(value))
+            // R2DBC drivers' array codecs accept only object arrays, so box primitive arrays.
+            // ByteArray is excluded: drivers encode byte[] as a single binary value, not an array.
+            is IntArray -> bind(parameter.name, value.toTypedArray())
+            is LongArray -> bind(parameter.name, value.toTypedArray())
+            is ShortArray -> bind(parameter.name, value.toTypedArray())
+            is DoubleArray -> bind(parameter.name, value.toTypedArray())
+            is FloatArray -> bind(parameter.name, value.toTypedArray())
+            is BooleanArray -> bind(parameter.name, value.toTypedArray())
+            is CharArray -> bind(parameter.name, value.toTypedArray())
             is Enum<*> -> bind(parameter.name, value.name)
             else -> bind(parameter.name, value)
         }
@@ -93,13 +102,26 @@ internal class DefaultSpringR2dbcKueryClient(
     // resolve the SQL array type from it, and pgjdbc rejects Object[] outright.
     private fun convertArray(array: Array<*>): Array<*> {
         val converted = array.map { convertElement(it) }
-        if (array.indices.all { converted[it] === array[it] }) {
+        val targetType = componentWriteTarget(array.javaClass.componentType)
+        if (targetType == null && array.indices.all { converted[it] === array[it] }) {
             return array
         }
-        val componentType = converted.mapNotNull { it?.javaClass }.distinct().singleOrNull() ?: Any::class.java
+        val inferredType = converted.mapNotNull { it?.javaClass }.distinct().singleOrNull() ?: Any::class.java
+        val componentType = targetType ?: inferredType
         val result = ReflectArray.newInstance(componentType, array.size)
         converted.forEachIndexed { index, value -> ReflectArray.set(result, index, value) }
         return result as Array<*>
+    }
+
+    // The component type itself carries the conversion intent even when the elements don't
+    // (all-null or empty arrays), e.g. SampleEnum[] must become String[] regardless of contents.
+    private fun componentWriteTarget(componentType: Class<*>): Class<*>? {
+        val targetType = customConversions.getCustomWriteTarget(componentType)
+        return when {
+            targetType.isPresent -> targetType.get()
+            Enum::class.java.isAssignableFrom(componentType) -> String::class.java
+            else -> null
+        }
     }
 
     private fun convertElement(element: Any?): Any? {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/PostgresArrayBindingTest.kt
@@ -89,6 +89,45 @@ class PostgresArrayBindingTest {
         assertThat(stored.toList()).isEqualTo(listOf("a", "b"))
     }
 
+    @Test
+    fun `bind all-null enum array to a native array column`() = runTest {
+        val tags = arrayOf<SampleEnum?>(null, null)
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = record["tags"] as Array<*>
+        assertThat(stored.toList()).isEqualTo(listOf(null, null))
+    }
+
+    @Test
+    fun `bind empty enum array to a native array column`() = runTest {
+        val tags = arrayOf<SampleEnum>()
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = record["tags"] as Array<*>
+        assertThat(stored.toList()).isEqualTo(emptyList<String>())
+    }
+
+    @Test
+    fun `bind primitive int array to ANY predicate`() = runTest {
+        val userIds = intArrayOf(1, 2)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
     companion object {
         private val postgres = PostgresTestContainer()
 


### PR DESCRIPTION
## Summary

Fixes two low-severity edge cases in array parameter binding (found in an internal implementation review), with regression tests against Postgres in both Spring modules.

### 1. All-null / empty arrays of convertible element types were not converted

`convertArray` decided whether conversion was needed only from the elements. The identity fast-path (`converted[i] === array[i]`) therefore let arrays whose elements carry no type information slip through unconverted:

- `arrayOf<SampleEnum?>(null, null)` reached the driver as `SampleEnum[]` (pgjdbc: `BadSqlGrammarException`, r2dbc-postgresql: `Cannot encode ... SampleEnum[]`)
- `arrayOf<SampleEnum>()` (empty) likewise

Now the write target is also resolved from the array's **component type** itself (custom write target first, then enum → `String`, mirroring `convertElement`), so e.g. `SampleEnum[]` becomes `String[]` regardless of contents. Arrays with no conversion intent (e.g. `String[]`) keep the identity fast-path and are passed through unchanged.

### 2. Primitive arrays (`IntArray` etc.) failed to encode on R2DBC

Primitive arrays do not match `is Array<*>` and were passed through as-is:

- **JDBC**: works unchanged — pgjdbc supports primitive arrays natively (now pinned by a test)
- **R2DBC**: r2dbc-postgresql's array codec only accepts object arrays and failed with `Cannot encode parameter ([I)`

The R2DBC client now boxes primitive arrays (`IntArray` → `Integer[]`, etc.). `ByteArray` is intentionally excluded: drivers encode `byte[]` as a single binary value (BYTEA), not an array.

## Test plan

- [x] Added reproduction tests first and confirmed they fail without the fix (JDBC: 2 new failures, R2DBC: 3 new failures)
- [x] New tests in `PostgresArrayBindingTest` (both modules): all-null enum array INSERT into `TEXT[]`, empty enum array INSERT, `int` array in an `= ANY(...)` predicate
- [x] Full test suites of both modules, ktlint, detekt all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)