### PR TITLE
Document that streaming terminal operations are not observed

### DIFF
--- a/docs/observation.md
+++ b/docs/observation.md
@@ -146,3 +146,17 @@ class UserRepository(private val kueryClient: KueryClient) {
     }
 }
 ```
+
+## Streaming operations are not observed
+
+Observation is not recorded for the streaming terminal operations:
+
+- `flow()` / `flowMap()` (kuery-client-spring-data-r2dbc)
+- `sequence()` / `sequenceMap()` (kuery-client-spring-data-jdbc)
+
+These operations return before the query results are consumed, so there is no obvious point at which the observation
+should stop. Both "until the stream terminates" and "until the first element arrives" are reasonable but different
+semantics. Until this is settled, these operations simply do not record metrics.
+
+If you need metrics for such a query, use `list()` / `listMap()` instead, or measure the consumption of the stream
+yourself.


### PR DESCRIPTION
## Summary

Adds a "Streaming operations are not observed" section to `docs/observation.md`, documenting that the streaming terminal operations do not record Micrometer Observation metrics:

- `flow()` / `flowMap()` (kuery-client-spring-data-r2dbc)
- `sequence()` / `sequenceMap()` (kuery-client-spring-data-jdbc)

This has always been the behavior — both client implementations carry TODO comments explaining that the stop semantics for a lazily-consumed stream are unsettled ("until the stream terminates" vs "until the first element arrives"). This PR documents it as a known limitation and suggests `list()` / `listMap()` or manual measurement as alternatives.

Docs-only change; no runtime behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)