### PR TITLE
Add direct unit tests for StreamCloseableSequence close semantics

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequenceTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequenceTest.kt
@@ -1,0 +1,47 @@
+package dev.hsbrysk.kuery.spring.jdbc.internal
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.stream.Stream
+
+class StreamCloseableSequenceTest {
+    @Test
+    fun `iterator throws ISE when the sequence is already closed`() {
+        val sequence = Stream.of("a", "b").asCloseableSequence()
+        sequence.close()
+
+        assertFailure { sequence.iterator() }
+            .isInstanceOf(IllegalStateException::class)
+            .hasMessage("This sequence is already closed.")
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        val closeCount = AtomicInteger()
+        val sequence = Stream.of("a", "b").onClose { closeCount.incrementAndGet() }.asCloseableSequence()
+
+        sequence.close()
+        sequence.close()
+
+        assertThat(closeCount.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `explicit close after full iteration does not close the stream twice`() {
+        val closeCount = AtomicInteger()
+        val sequence = Stream.of("a", "b").onClose { closeCount.incrementAndGet() }.asCloseableSequence()
+
+        // Reaching the end of the iteration closes the underlying stream.
+        assertThat(sequence.toList()).isEqualTo(listOf("a", "b"))
+        assertThat(closeCount.get()).isEqualTo(1)
+
+        sequence.close()
+
+        assertThat(closeCount.get()).isEqualTo(1)
+    }
+}


### PR DESCRIPTION
## Summary

Adds direct unit tests for `StreamCloseableSequence` (introduced in #334), closing part of the remaining test-gap backlog.

- `iterator()` after `close()` throws `IllegalStateException` ("This sequence is already closed.")
- `close()` is idempotent — the underlying stream's close handler runs exactly once even when `close()` is called twice
- Explicit `close()` after full iteration (which already auto-closes the stream) does not close the stream a second time

These behaviors were previously only exercised indirectly through `SequenceResourceManagementTest` (connection tracking against H2); this adds fast, pure unit coverage against a plain `java.util.stream.Stream`.

Test-only change; no production code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)