### PR TITLE
Add statement options coverage for the sequence streaming path

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/StatementOptionsTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/StatementOptionsTest.kt
@@ -65,6 +65,44 @@ class StatementOptionsTest {
     }
 
     @Test
+    fun `fetchSize does not break sequence results`() {
+        val result = kueryClient.sql { +"SELECT * FROM users" }
+            .fetchSize(3)
+            .sequenceMap()
+            .use { it.toList() }
+        assertThat(result).hasSize(10)
+    }
+
+    @Test
+    fun `maxRows limits sequence result size`() {
+        val result = kueryClient.sql { +"SELECT * FROM users" }
+            .maxRows(5)
+            .sequenceMap()
+            .use { it.toList() }
+        assertThat(result).hasSize(5)
+    }
+
+    @Test
+    fun `queryTimeoutSeconds does not break sequence`() {
+        val result = kueryClient.sql { +"SELECT * FROM users" }
+            .queryTimeoutSeconds(10)
+            .sequenceMap()
+            .use { it.toList() }
+        assertThat(result).hasSize(10)
+    }
+
+    @Test
+    fun `chain of options works correctly for sequence`() {
+        val result = kueryClient.sql { +"SELECT * FROM users" }
+            .fetchSize(3)
+            .maxRows(4)
+            .queryTimeoutSeconds(10)
+            .sequenceMap()
+            .use { it.toList() }
+        assertThat(result).hasSize(4)
+    }
+
+    @Test
     fun `options are applied immutably`() {
         val base = kueryClient.sql { +"SELECT * FROM users" }
         val limited = base.maxRows(3)


### PR DESCRIPTION
## Summary

`fetchSize` / `maxRows` / `queryTimeoutSeconds` were only covered through the `list` terminal operations, while the streaming path (`sequenceMap()` / `sequence()`) executes through `JdbcTemplate.queryForStream` instead of `query`. This closes part of the remaining test-gap backlog by adding the same option coverage for the sequence path:

- `fetchSize` does not break sequence results
- `maxRows` limits the sequence result size
- `queryTimeoutSeconds` does not break a normal streaming query
- A chain of all three options works for sequence

Runs on the in-memory H2 database (framework-level behavior, not driver-dependent).

Test-only change; no production code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)