### PR TITLE
Add observation tests for the SQL failure and cancellation paths

### DIFF
--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationTest.kt
@@ -5,12 +5,22 @@ import assertk.assertions.isInstanceOf
 import com.example.spring.r2dbc.UserRepository
 import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.Result
+import io.r2dbc.spi.Statement
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import org.springframework.dao.DataAccessException
 import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.r2dbc.core.awaitRowsUpdated
+import reactor.core.publisher.Flux
 
 class ObservationTest {
     private val registry = TestObservationRegistry.create()
@@ -126,6 +136,43 @@ class ObservationTest {
             .hasError()
     }
 
+    @Test
+    fun `records error when the sql execution fails`() = runTest {
+        assertFailure {
+            kueryClient.sql { +"SELECT * FROM missing_table" }.listMap()
+        }.isInstanceOf(DataAccessException::class)
+        TestObservationRegistryAssert.assertThat(registry)
+            .doesNotHaveAnyRemainingCurrentObservation()
+            .hasObservationWithNameEqualTo("kuery.client.fetches")
+            .that()
+            .hasBeenStarted()
+            .hasBeenStopped()
+            .hasError()
+    }
+
+    @Test
+    fun `stops the observation without error when the fetch is cancelled`() = runTest {
+        val neverClient = SpringR2dbcKueryClient.builder()
+            .connectionFactory(NeverExecutingConnectionFactory(h2.connectionFactory))
+            .observationRegistry(registry)
+            .build()
+
+        // UNDISPATCHED runs the coroutine up to its first suspension point, so the fetch is
+        // guaranteed to have subscribed (and the observation to have started) before we cancel.
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            neverClient.sql { +"SELECT * FROM users" }.singleMap()
+        }
+        job.cancelAndJoin()
+
+        TestObservationRegistryAssert.assertThat(registry)
+            .doesNotHaveAnyRemainingCurrentObservation()
+            .hasObservationWithNameEqualTo("kuery.client.fetches")
+            .that()
+            .hasBeenStarted()
+            .hasBeenStopped()
+            .doesNotHaveError()
+    }
+
     private fun assertObservation(
         sqlId: String,
         sql: String,
@@ -138,6 +185,48 @@ class ObservationTest {
             .hasHighCardinalityKeyValue("sql", sql)
             .hasBeenStarted()
             .hasBeenStopped()
+    }
+
+    private class NeverExecutingConnectionFactory(private val delegate: ConnectionFactory) :
+        ConnectionFactory by delegate {
+        override fun create(): Publisher<out Connection> = Flux.from(delegate.create())
+            .map { NeverExecutingConnection(it) }
+    }
+
+    private class NeverExecutingConnection(private val delegate: Connection) : Connection by delegate {
+        override fun createStatement(sql: String): Statement = NeverExecutingStatement(delegate.createStatement(sql))
+    }
+
+    // Fluent methods must return `this` (not the delegate) so that execute() below stays wrapped.
+    private class NeverExecutingStatement(private val delegate: Statement) : Statement {
+        override fun add(): Statement = apply { delegate.add() }
+
+        override fun bind(
+            index: Int,
+            value: Any,
+        ): Statement = apply { delegate.bind(index, value) }
+
+        override fun bind(
+            name: String,
+            value: Any,
+        ): Statement = apply { delegate.bind(name, value) }
+
+        override fun bindNull(
+            index: Int,
+            type: Class<*>,
+        ): Statement = apply { delegate.bindNull(index, type) }
+
+        override fun bindNull(
+            name: String,
+            type: Class<*>,
+        ): Statement = apply { delegate.bindNull(name, type) }
+
+        override fun fetchSize(rows: Int): Statement = apply { delegate.fetchSize(rows) }
+
+        override fun returnGeneratedValues(vararg columns: String): Statement =
+            apply { delegate.returnGeneratedValues(*columns) }
+
+        override fun execute(): Publisher<out Result> = Flux.never()
     }
 
     companion object {


### PR DESCRIPTION
## Summary

The R2DBC `observe()` operator (`Mono.usingWhen`, introduced in #339) models three cleanup paths — complete, error, and cancel — but only the success path and the pipeline-generated empty-result error were covered by tests. This closes part of the remaining test-gap backlog by pinning the other two:

- **SQL failure**: a query against a missing table records the error on the observation and stops it (`hasError()` + `hasBeenStopped()`).
- **Cancellation**: cancelling the suspending caller stops the observation without recording an error (`doesNotHaveError()` + `hasBeenStopped()`).

The cancellation test is made deterministic without relying on query timing: a wrapping `ConnectionFactory` returns a `Statement` whose `execute()` returns `Flux.never()`, and the fetch coroutine is launched with `CoroutineStart.UNDISPATCHED` so it is guaranteed to have subscribed (observation started) before `cancelAndJoin()`. The cancel signal therefore always arrives while the query is in flight, exercising `usingWhen`'s cancel cleanup.

Runs on the in-memory H2 database. Test-only change; no production code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)