### PR TITLE
Add scalar result tests for enum and custom-converted types

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CodeEnumConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CodeEnumConversionTest.kt
@@ -107,6 +107,24 @@ class CodeEnumConversionTest {
         assertThat(record.stringEnum).isEqualTo(SampleStringCodeEnum.BAR)
     }
 
+    @Test
+    fun testScalar() {
+        kueryClient.sql {
+            +"INSERT INTO code_enum (int_enum, string_enum)"
+            +"VALUES (${SampleIntCodeEnum.HOGE}, ${SampleStringCodeEnum.BAR})"
+        }.rowsUpdated()
+
+        val intEnum: SampleIntCodeEnum = kueryClient.sql {
+            +"SELECT int_enum FROM code_enum"
+        }.single()
+        assertThat(intEnum).isEqualTo(SampleIntCodeEnum.HOGE)
+
+        val stringEnum: SampleStringCodeEnum = kueryClient.sql {
+            +"SELECT string_enum FROM code_enum"
+        }.single()
+        assertThat(stringEnum).isEqualTo(SampleStringCodeEnum.BAR)
+    }
+
     companion object {
         private val h2 = H2TestDatabase()
     }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/EnumConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/EnumConversionTest.kt
@@ -44,6 +44,18 @@ class EnumConversionTest {
     }
 
     @Test
+    fun testScalar() {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
+        }.rowsUpdated()
+
+        val result: SampleEnum = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single()
+        assertThat(result).isEqualTo(SampleEnum.HOGE)
+    }
+
+    @Test
     fun testInCollection() {
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CodeEnumConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CodeEnumConversionTest.kt
@@ -109,6 +109,24 @@ class CodeEnumConversionTest {
         assertThat(record.stringEnum).isEqualTo(SampleStringCodeEnum.BAR)
     }
 
+    @Test
+    fun testScalar() = runTest {
+        kueryClient.sql {
+            +"INSERT INTO code_enum (int_enum, string_enum)"
+            +"VALUES (${SampleIntCodeEnum.HOGE}, ${SampleStringCodeEnum.BAR})"
+        }.rowsUpdated()
+
+        val intEnum: SampleIntCodeEnum = kueryClient.sql {
+            +"SELECT int_enum FROM code_enum"
+        }.single()
+        assertThat(intEnum).isEqualTo(SampleIntCodeEnum.HOGE)
+
+        val stringEnum: SampleStringCodeEnum = kueryClient.sql {
+            +"SELECT string_enum FROM code_enum"
+        }.single()
+        assertThat(stringEnum).isEqualTo(SampleStringCodeEnum.BAR)
+    }
+
     companion object {
         private val h2 = H2TestDatabase()
     }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/EnumConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/EnumConversionTest.kt
@@ -45,6 +45,18 @@ class EnumConversionTest {
     }
 
     @Test
+    fun testScalar() = runTest {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
+        }.rowsUpdated()
+
+        val result: SampleEnum = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single()
+        assertThat(result).isEqualTo(SampleEnum.HOGE)
+    }
+
+    @Test
     fun testInCollection() = runTest {
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"


### PR DESCRIPTION
## Summary

Enum and custom-converted types were only tested through data-class row mapping (`DataClassRowMapper`); reading them as scalar results — which goes through `SingleColumnRowMapper` and, in the R2DBC module, its `ConversionService` fallback path (the `catch` branch when the driver cannot convert the column value) — had no coverage. This closes part of the remaining test-gap backlog:

- `EnumConversionTest` (both modules): `single<SampleEnum>()` reading a VARCHAR column as a plain enum (String → enum via the default conversion service).
- `CodeEnumConversionTest` (both modules): `single<SampleIntCodeEnum>()` / `single<SampleStringCodeEnum>()` reading INT / VARCHAR columns through user-registered `ReadingConverter`s.

All cases pass against the current implementation (behavior-pinning tests, symmetric across JDBC and R2DBC). Runs on the in-memory H2 database.

Test-only change; no production code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)