### PR TITLE
Add KUERY_BIND_CALL_IN_SQL_TEMPLATE compiler warning

### DIFF
--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/BindCallInSqlTemplateChecker.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/BindCallInSqlTemplateChecker.kt
@@ -1,0 +1,47 @@
+package dev.hsbrysk.kuery.compiler.fir
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.visitors.FirVisitorVoid
+
+/**
+ * Reports [KueryClientDiagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE] when `SqlBuilder.bind()` is called
+ * anywhere inside the SQL string argument of `add()` / `unaryPlus`. The IR transformation converts every
+ * interpolated value into a bind parameter, so the placeholder name returned by `bind()` would itself be
+ * re-bound as a new parameter value and the SQL would compare against the literal string ":pN".
+ * `bind()` is only meaningful together with `addUnsafe()`, which is not transformed.
+ */
+internal object BindCallInSqlTemplateChecker : FirFunctionCallChecker(MppCheckerKind.Common) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: FirFunctionCall) {
+        val sqlArgument = SqlBuilderCalls.sqlArgumentOrNull(expression) ?: return
+        collectBindCalls(sqlArgument).forEach {
+            reporter.reportOn(it.source ?: expression.source, KueryClientDiagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE)
+        }
+    }
+
+    private fun collectBindCalls(sqlArgument: FirExpression): List<FirFunctionCall> {
+        val found = mutableListOf<FirFunctionCall>()
+        sqlArgument.accept(
+            object : FirVisitorVoid() {
+                override fun visitElement(element: FirElement) {
+                    if (
+                        element is FirFunctionCall &&
+                        element.calleeReference.toResolvedCallableSymbol()?.callableId == SqlBuilderCalls.BIND
+                    ) {
+                        found.add(element)
+                    }
+                    element.acceptChildren(this)
+                }
+            },
+        )
+        return found
+    }
+}

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientDiagnostics.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientDiagnostics.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.psi.KtExpression
 internal object KueryClientDiagnostics : KtDiagnosticsContainer() {
     // The property name is the diagnostic name, i.e. the key for @Suppress and -Xwarning-level.
     val KUERY_UNSAFE_SQL_STRING by warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
+    val KUERY_BIND_CALL_IN_SQL_TEMPLATE by warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
 
     override fun getRendererFactory(): BaseDiagnosticRendererFactory = KueryClientDiagnosticRenderers
 }
@@ -24,6 +25,15 @@ internal object KueryClientDiagnosticRenderers : BaseDiagnosticRendererFactory()
                 "as raw SQL (SQL injection risk). Pass a string literal/template directly, or use addUnsafe() " +
                 "with bind() for dynamically built SQL. If this is intentional, annotate the enclosing " +
                 "declaration with @Suppress(\"KUERY_UNSAFE_SQL_STRING\").",
+        )
+        map.put(
+            KueryClientDiagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE,
+            "bind() must not be called inside a string template passed to add()/unaryPlus. The compiler " +
+                "plugin already converts every interpolated value into a bind parameter, so the placeholder " +
+                "name returned by bind() would itself be re-bound as a new parameter value and the SQL would " +
+                "compare against the literal string ':pN'. Interpolate the value directly (\$value instead " +
+                "of \${bind(value)}), or use addUnsafe() when you need bind(). If this is intentional, " +
+                "annotate the enclosing declaration with @Suppress(\"KUERY_BIND_CALL_IN_SQL_TEMPLATE\").",
         )
     }
 }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientFirExtensionRegistrar.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientFirExtensionRegistrar.kt
@@ -15,6 +15,7 @@ class KueryClientFirExtensionRegistrar : FirExtensionRegistrar() {
 
 internal class KueryClientFirCheckersExtension(session: FirSession) : FirAdditionalCheckersExtension(session) {
     override val expressionCheckers: ExpressionCheckers = object : ExpressionCheckers() {
-        override val functionCallCheckers: Set<FirFunctionCallChecker> = setOf(UnsafeSqlStringChecker)
+        override val functionCallCheckers: Set<FirFunctionCallChecker> =
+            setOf(UnsafeSqlStringChecker, BindCallInSqlTemplateChecker)
     }
 }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/SqlBuilderCalls.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/SqlBuilderCalls.kt
@@ -1,0 +1,28 @@
+package dev.hsbrysk.kuery.compiler.fir
+
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.unwrapArgument
+import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+internal object SqlBuilderCalls {
+    private val SQL_BUILDER_CLASS_ID = ClassId(FqName("dev.hsbrysk.kuery.core"), Name.identifier("SqlBuilder"))
+    private val ADD = CallableId(SQL_BUILDER_CLASS_ID, Name.identifier("add"))
+    private val UNARY_PLUS = CallableId(SQL_BUILDER_CLASS_ID, Name.identifier("unaryPlus"))
+    val BIND = CallableId(SQL_BUILDER_CLASS_ID, Name.identifier("bind"))
+
+    /**
+     * The SQL string argument if [call] is `SqlBuilder.add` / `String.unaryPlus` (the calls processed by
+     * [dev.hsbrysk.kuery.compiler.ir.StringInterpolationTransformer]), otherwise null.
+     */
+    fun sqlArgumentOrNull(call: FirFunctionCall): FirExpression? =
+        when (call.calleeReference.toResolvedCallableSymbol()?.callableId) {
+            ADD -> call.argumentList.arguments.firstOrNull()?.unwrapArgument()
+            UNARY_PLUS -> call.extensionReceiver
+            else -> null
+        }
+}

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/UnsafeSqlStringChecker.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/UnsafeSqlStringChecker.kt
@@ -15,14 +15,10 @@ import org.jetbrains.kotlin.fir.expressions.FirWhenExpression
 import org.jetbrains.kotlin.fir.expressions.unwrapArgument
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.name.CallableId
-import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 internal object UnsafeSqlStringChecker : FirFunctionCallChecker(MppCheckerKind.Common) {
-    private val SQL_BUILDER_CLASS_ID = ClassId(FqName("dev.hsbrysk.kuery.core"), Name.identifier("SqlBuilder"))
-    private val ADD = CallableId(SQL_BUILDER_CLASS_ID, Name.identifier("add"))
-    private val UNARY_PLUS = CallableId(SQL_BUILDER_CLASS_ID, Name.identifier("unaryPlus"))
     private val ALLOWED_CHAIN_METHODS = setOf(
         CallableId(FqName("kotlin.text"), Name.identifier("trimIndent")),
         CallableId(FqName("kotlin.text"), Name.identifier("trimMargin")),
@@ -30,11 +26,7 @@ internal object UnsafeSqlStringChecker : FirFunctionCallChecker(MppCheckerKind.C
 
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(expression: FirFunctionCall) {
-        val sqlArgument = when (expression.calleeReference.toResolvedCallableSymbol()?.callableId) {
-            ADD -> expression.argumentList.arguments.firstOrNull()?.unwrapArgument() ?: return
-            UNARY_PLUS -> expression.extensionReceiver ?: return
-            else -> return
-        }
+        val sqlArgument = SqlBuilderCalls.sqlArgumentOrNull(expression) ?: return
         if (isCompileTimeSafe(sqlArgument)) {
             return
         }

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/BindCallInSqlTemplateCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/BindCallInSqlTemplateCheckerTest.kt
@@ -1,0 +1,170 @@
+package dev.hsbrysk.kuery.compiler
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCompilerApi::class)
+class BindCallInSqlTemplateCheckerTest {
+    @Test
+    fun `warn when bind is called inside a template passed to unaryPlus`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.DelicateKueryClientApi
+            import dev.hsbrysk.kuery.core.Sql
+
+            @OptIn(DelicateKueryClientApi::class)
+            fun query(id: Int) {
+                Sql { +"SELECT * FROM users WHERE id = ${'$'}{bind(id)}" }
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
+    fun `warn when bind is called inside a template passed to add`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.DelicateKueryClientApi
+            import dev.hsbrysk.kuery.core.Sql
+
+            @OptIn(DelicateKueryClientApi::class)
+            fun query(id: Int) {
+                Sql { add("SELECT * FROM users WHERE id = ${'$'}{bind(id)}") }
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
+    fun `warn when bind is called indirectly inside an interpolated value`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.DelicateKueryClientApi
+            import dev.hsbrysk.kuery.core.Sql
+
+            @OptIn(DelicateKueryClientApi::class)
+            fun query(ids: List<Int>) {
+                Sql { +"SELECT * FROM users WHERE id IN (${'$'}{ids.joinToString(",") { bind(it) }})" }
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
+    fun `warn when bind is called inside a template in an if branch passed to add`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.DelicateKueryClientApi
+            import dev.hsbrysk.kuery.core.Sql
+
+            @OptIn(DelicateKueryClientApi::class)
+            fun query(id: Int) {
+                Sql { add(if (id > 0) "WHERE id = ${'$'}{bind(id)}" else "WHERE TRUE") }
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
+    fun `no warning when bind is used with addUnsafe`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.DelicateKueryClientApi
+            import dev.hsbrysk.kuery.core.Sql
+
+            @OptIn(DelicateKueryClientApi::class)
+            fun query(id: Int, column: String) {
+                Sql { addUnsafe("SELECT * FROM users WHERE ${'$'}column = ${'$'}{bind(id)}") }
+            }
+            """.trimIndent(),
+            allWarningsAsErrors = true,
+        )
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
+    fun `no warning for plain interpolation`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(id: Int) {
+                Sql { +"SELECT * FROM users WHERE id = ${'$'}id" }
+                Sql { add("SELECT * FROM users WHERE id = ${'$'}id") }
+            }
+            """.trimIndent(),
+            allWarningsAsErrors = true,
+        )
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
+    fun `warning can be suppressed by diagnostic name`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.DelicateKueryClientApi
+            import dev.hsbrysk.kuery.core.Sql
+
+            @OptIn(DelicateKueryClientApi::class)
+            @Suppress("$DIAGNOSTIC_NAME")
+            fun query(id: Int) {
+                Sql { +"SELECT * FROM users WHERE id = ${'$'}{bind(id)}" }
+            }
+            """.trimIndent(),
+            allWarningsAsErrors = true,
+        )
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
+    fun `warning becomes an error with -Werror`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.DelicateKueryClientApi
+            import dev.hsbrysk.kuery.core.Sql
+
+            @OptIn(DelicateKueryClientApi::class)
+            fun query(id: Int) {
+                Sql { +"SELECT * FROM users WHERE id = ${'$'}{bind(id)}" }
+            }
+            """.trimIndent(),
+            allWarningsAsErrors = true,
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    private fun compile(
+        source: String,
+        allWarningsAsErrors: Boolean = false,
+    ): JvmCompilationResult = KotlinCompilation().apply {
+        sources = listOf(SourceFile.kotlin("Sample.kt", source))
+        commandLineProcessors = listOf(KueryClientCompilerCommandLineProcessor())
+        compilerPluginRegistrars = listOf(KueryClientCompilerPluginRegistrar())
+        inheritClassPath = true
+        verbose = false
+        this.allWarningsAsErrors = allWarningsAsErrors
+    }.compile()
+
+    companion object {
+        private const val DIAGNOSTIC_NAME = "KUERY_BIND_CALL_IN_SQL_TEMPLATE"
+    }
+}


### PR DESCRIPTION
## Summary

`bind()` called inside a string template passed to `add()` / `unaryPlus` is always broken, silently:

```kotlin
Sql { +"SELECT * FROM users WHERE id = ${bind(id)}" }
```

The IR transformation converts every interpolated value into a bind parameter, so the placeholder name returned by `bind()` (e.g. `":p0"`) is itself re-bound as a new parameter value — the query ends up comparing against the literal string `':p0'` with no error. (`bind()` is only meaningful together with `addUnsafe()`, which is not transformed.)

This PR adds a FIR checker that reports a new `KUERY_BIND_CALL_IN_SQL_TEMPLATE` warning on any `bind()` call inside the SQL argument of `add()` / `unaryPlus`, including indirect calls (e.g. inside a `joinToString` lambda) and templates in `if` / `when` branches. The runtime behavior is intentionally left unchanged.

## Changes

- New `BindCallInSqlTemplateChecker` (FIR) that scans the SQL argument subtree for calls to `SqlBuilder.bind`
- New `KUERY_BIND_CALL_IN_SQL_TEMPLATE` warning (suppressible with `@Suppress`, becomes an error with `-Werror`, same as `KUERY_UNSAFE_SQL_STRING`)
- Extracted the `add()` / `unaryPlus` argument resolution shared by both checkers into `SqlBuilderCalls`

## Not flagged (intended usages)

- `bind()` with `addUnsafe()` — the documented pattern for dynamically built SQL
- `bind()` in a template assigned to a variable that is later passed to `+` / `add()` — the template is outside the transformed argument, so the placeholder string is used as-is (this path is covered by the existing `KUERY_UNSAFE_SQL_STRING` warning; the functional test `mixedOrder` relies on it)

## Testing

- New `BindCallInSqlTemplateCheckerTest` (kctfork): 8 cases — written test-first (5 warn cases confirmed failing before the fix)
- Existing `UnsafeSqlStringCheckerTest` and the functional tests (with `-Xverify-ir=error`) remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)