### PR TITLE
Seal SqlBuilder and rewrite add/unaryPlus calls on generic receivers

### DIFF
--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/GenericReceiverExtensionTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/GenericReceiverExtensionTest.kt
@@ -1,0 +1,84 @@
+package dev.hsbrysk.kuery.core
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Helpers whose receiver is a type parameter bounded by [SqlBuilder] (the natural way to write
+ * fluent helpers that return the receiver). The IR rewrite must apply even though the static type
+ * of the receiver is not [SqlBuilder] itself.
+ */
+private fun <T : SqlBuilder> T.whereUserId(userId: Int): T {
+    +"WHERE user_id = $userId"
+    return this
+}
+
+private fun <T : SqlBuilder> T.paging(
+    limit: Int,
+    offset: Int,
+): T {
+    add("LIMIT $limit OFFSET $offset")
+    return this
+}
+
+class GenericReceiverExtensionTest {
+    @Test
+    fun `generic receiver helper using unaryPlus`() {
+        val sql = Sql {
+            +"SELECT * FROM users"
+            whereUserId(1)
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                """
+                SELECT * FROM users
+                WHERE user_id = :p0
+                """.trimIndent(),
+                listOf(NamedSqlParameter("p0", 1)),
+            ),
+        )
+    }
+
+    @Test
+    fun `generic receiver helper using add`() {
+        val sql = Sql {
+            +"SELECT * FROM users"
+            paging(limit = 10, offset = 0)
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                """
+                SELECT * FROM users
+                LIMIT :p0 OFFSET :p1
+                """.trimIndent(),
+                listOf(
+                    NamedSqlParameter("p0", 10),
+                    NamedSqlParameter("p1", 0),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `chained generic receiver helpers`() {
+        val sql = Sql {
+            +"SELECT * FROM users"
+            whereUserId(1).paging(limit = 10, offset = 0)
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                """
+                SELECT * FROM users
+                WHERE user_id = :p0
+                LIMIT :p1 OFFSET :p2
+                """.trimIndent(),
+                listOf(
+                    NamedSqlParameter("p0", 1),
+                    NamedSqlParameter("p1", 10),
+                    NamedSqlParameter("p2", 0),
+                ),
+            ),
+        )
+    }
+}

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -18,12 +18,13 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrStringConcatenation
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.classFqName
-import org.jetbrains.kotlin.ir.types.classOrFail
 import org.jetbrains.kotlin.ir.types.typeWith
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.irCastIfNeeded
 import org.jetbrains.kotlin.ir.util.isVararg
+import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
 
 @Suppress("OPT_IN_USAGE")
 class StringInterpolationTransformer(private val pluginContext: IrPluginContext) :
@@ -60,7 +61,9 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
                 .transform(this, null)
 
             val builder = irBuilder(expression)
-            val sqlBuilderClass = temporary.type.classOrFail
+            // Resolve addUnsafe from the called declaration's class (SqlBuilder), because the
+            // receiver's static type may be a type parameter, which has no class.
+            val sqlBuilderClass = expression.symbol.owner.parentAsClass.symbol
             val addUnsafe = sqlBuilderClass.functions.first { it.owner.name.asString() == "addUnsafe" }
             builder.irBlock(resultType = pluginContext.irBuiltIns.unitType) {
                 +temporary
@@ -133,14 +136,15 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
     }
 
     companion object {
+        // Identify the call by its resolved declaration, not by the receiver expression's static
+        // type: the receiver may be typed as a type parameter bounded by SqlBuilder (e.g. a fluent
+        // helper `fun <T : SqlBuilder> T.helper(): T`), and the rewrite must still apply.
         private fun IrCall.isAddOrUnaryPlus(): Boolean {
-            if (dispatchReceiver?.type?.classFqName?.asString() != ClassNames.SQL_BUILDER) {
-                return false
-            }
             when (symbol.owner.name.asString()) {
-                "add", "unaryPlus" -> return true
+                "add", "unaryPlus" -> {}
+                else -> return false
             }
-            return false
+            return symbol.owner.parentClassOrNull?.fqNameWhenAvailable?.asString() == ClassNames.SQL_BUILDER
         }
 
         private fun IrPluginContext.listOfRef(): IrSimpleFunctionSymbol =

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -139,12 +139,10 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
         // Identify the call by its resolved declaration, not by the receiver expression's static
         // type: the receiver may be typed as a type parameter bounded by SqlBuilder (e.g. a fluent
         // helper `fun <T : SqlBuilder> T.helper(): T`), and the rewrite must still apply.
-        private fun IrCall.isAddOrUnaryPlus(): Boolean {
-            when (symbol.owner.name.asString()) {
-                "add", "unaryPlus" -> {}
-                else -> return false
-            }
-            return symbol.owner.parentClassOrNull?.fqNameWhenAvailable?.asString() == ClassNames.SQL_BUILDER
+        private fun IrCall.isAddOrUnaryPlus(): Boolean = when (symbol.owner.name.asString()) {
+            "add", "unaryPlus" ->
+                symbol.owner.parentClassOrNull?.fqNameWhenAvailable?.asString() == ClassNames.SQL_BUILDER
+            else -> false
         }
 
         private fun IrPluginContext.listOfRef(): IrSimpleFunctionSymbol =

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/ClassIds.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/ClassIds.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.name.Name
 
 internal object ClassIds {
     val DEFAULT_SQL_BUILDER = ClassId(
-        FqName("dev.hsbrysk.kuery.core.internal"),
+        FqName("dev.hsbrysk.kuery.core"),
         Name.identifier("DefaultSqlBuilder"),
     )
 }

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilder.kt
@@ -3,9 +3,6 @@ package dev.hsbrysk.kuery.core
 import dev.hsbrysk.kuery.core.internal.DefaultNamedSqlParameter
 import dev.hsbrysk.kuery.core.internal.DefaultSql
 
-// Lives in the same package as SqlBuilder because Kotlin requires direct subclasses of a sealed
-// interface to be declared in the same package. The fully-qualified name of this class is
-// effectively public ABI (see `interpolate`), so it must not move again.
 internal class DefaultSqlBuilder : SqlBuilder {
     private val body = StringBuilder()
     private val parameters = mutableListOf<NamedSqlParameter>()

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilder.kt
@@ -1,10 +1,11 @@
-package dev.hsbrysk.kuery.core.internal
+package dev.hsbrysk.kuery.core
 
-import dev.hsbrysk.kuery.core.DelicateKueryClientApi
-import dev.hsbrysk.kuery.core.NamedSqlParameter
-import dev.hsbrysk.kuery.core.Sql
-import dev.hsbrysk.kuery.core.SqlBuilder
+import dev.hsbrysk.kuery.core.internal.DefaultNamedSqlParameter
+import dev.hsbrysk.kuery.core.internal.DefaultSql
 
+// Lives in the same package as SqlBuilder because Kotlin requires direct subclasses of a sealed
+// interface to be declared in the same package. The fully-qualified name of this class is
+// effectively public ABI (see `interpolate`), so it must not move again.
 internal class DefaultSqlBuilder : SqlBuilder {
     private val body = StringBuilder()
     private val parameters = mutableListOf<NamedSqlParameter>()
@@ -77,7 +78,7 @@ internal class DefaultSqlBuilder : SqlBuilder {
                 "Make sure the Gradle plugin `dev.hsbrysk.kuery-client` is applied to the module " +
                 "containing this call. " +
                 "If it is already applied, this call site is an unsupported usage that the plugin cannot rewrite " +
-                "(e.g. calling through a subtype of SqlBuilder, or via a function/reflection reference). " +
+                "(e.g. calling via a function/reflection reference). " +
                 "See https://kuery-client.hsbrysk.dev/getting-started for setup instructions.",
         )
     }

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
@@ -1,7 +1,6 @@
 package dev.hsbrysk.kuery.core
 
 import dev.hsbrysk.kuery.core.internal.DefaultSql
-import dev.hsbrysk.kuery.core.internal.DefaultSqlBuilder
 
 public interface Sql {
     /**

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
@@ -5,15 +5,12 @@ import org.intellij.lang.annotations.Language
 /**
  * DSL scope for building SQL.
  *
- * This interface is not intended to be implemented by users (e.g. as a test fake).
- * The compiler plugin assumes the receiver is the library's internal implementation:
- * a user implementation fails with [ClassCastException] at runtime, and if the static type
- * of the receiver is a subtype of [SqlBuilder], the rewrite is skipped entirely and the raw
- * interpolated string is passed to [add] — losing the parameter-binding guarantee this
- * library exists to provide.
+ * This interface is sealed because the compiler plugin assumes the receiver is the library's
+ * internal implementation; a user implementation (e.g. a test fake) would fail with
+ * [ClassCastException] at runtime.
  */
 @SqlBuilderMarker
-public interface SqlBuilder {
+public sealed interface SqlBuilder {
     /**
      * Specify the sql you want to execute. Appended to the internally held [StringBuilder].
      * Due to the Kotlin compiler plugin, the string interpolation within the string template passed to

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderAbiTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderAbiTest.kt
@@ -1,4 +1,4 @@
-package dev.hsbrysk.kuery.core.internal
+package dev.hsbrysk.kuery.core
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -23,7 +23,9 @@ class DefaultSqlBuilderAbiTest {
     fun `interpolate signature is frozen`() {
         // Intentionally string literals (not ::class / type references) so that IDE refactorings
         // cannot silently update this test along with the production code.
-        val clazz = Class.forName("dev.hsbrysk.kuery.core.internal.DefaultSqlBuilder")
+        // Moved from `dev.hsbrysk.kuery.core.internal` before v1.0.0 (sealing SqlBuilder requires
+        // the implementation to be in the same package). Frozen at this location from 1.0 onward.
+        val clazz = Class.forName("dev.hsbrysk.kuery.core.DefaultSqlBuilder")
         // Throws NoSuchMethodException if the name or parameter types change.
         val method = clazz.getMethod("interpolate", List::class.java, List::class.java)
 

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderTest.kt
@@ -1,4 +1,4 @@
-package dev.hsbrysk.kuery.core.internal
+package dev.hsbrysk.kuery.core
 
 import assertk.all
 import assertk.assertFailure
@@ -8,8 +8,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.message
-import dev.hsbrysk.kuery.core.NamedSqlParameter
-import dev.hsbrysk.kuery.core.Sql
 import org.junit.jupiter.api.Test
 
 class DefaultSqlBuilderTest {


### PR DESCRIPTION
## Problem

The IR transformer identified `add`/`unaryPlus` calls by the **receiver expression's static type** (`dispatchReceiver.type.classFqName == SqlBuilder`). A natural fluent helper therefore compiled with zero diagnostics but threw at runtime:

```kotlin
fun <T : SqlBuilder> T.whereUserId(userId: Int): T {
    +"WHERE user_id = $userId"   // receiver's static type is T -> rewrite skipped
    return this
}
```

The template was passed through unrewritten and hit `injectByPlugin()`'s `IllegalStateException`, whose message misleadingly suggests the compiler plugin is not applied. The FIR checker (`KUERY_UNSAFE_SQL_STRING`) treats string templates as safe without looking at the receiver type, so there was no compile-time warning either.

## Fix

- **Identify the call by its resolved declaration** (the called function's parent class is `SqlBuilder`), not by the receiver expression's static type. The rewrite now applies to generic/subtype-typed receivers, so helpers like the one above just work. `addUnsafe` is also resolved from the declaration's class, since a type-parameter receiver type has no class.
- **Seal `SqlBuilder`.** The rewrite casts the receiver to `DefaultSqlBuilder`; sealing guarantees that cast is sound by making user implementations impossible (they were already documented as unsupported and broken at runtime — the interface KDoc said so since #356).

Kotlin requires direct subtypes of a sealed interface to be declared in the same package, so `DefaultSqlBuilder` moves from `dev.hsbrysk.kuery.core.internal` to `dev.hsbrysk.kuery.core`. The compiler plugin's `ClassId` and the ABI pin test (`DefaultSqlBuilderAbiTest`) follow. This changes the effectively-public FQCN that compiled artifacts link against — a deliberate pre-1.0 breaking change (no binary compatibility is promised for 0.x; the FQCN is frozen at the new location from 1.0 onward).

The `injectByPlugin()` error message drops the now-impossible "calling through a subtype of SqlBuilder" example.

The public ABI dump is unchanged: `sealed` on an interface is Kotlin-metadata-only and does not alter the JVM-level signature.

## Tests

- Added `GenericReceiverExtensionTest` to the compiler functional-test module (generic receiver with `unaryPlus` / `add` / chained fluent helpers). Written test-first: all three failed with the `IllegalStateException` before the transformer fix.
- The functional-test module compiles with `-Xverify-ir=error`, so the rewrite on generic receivers is also verified against IR consistency.
- Full `./gradlew build` (including Testcontainers-backed integration tests, ktlint, detekt, checkKotlinAbi) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)