### PR TITLE
Strip lambda artifacts from auto-generated SQL ids

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/SqlIds.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/internal/SqlIds.kt
@@ -17,7 +17,13 @@ public object SqlIds {
     private val SUFFIXES = listOf(
         ".invokeSuspend",
         "${'$'}suspendImpl",
+        // for lambdas compiled as classes (e.g. -Xlambdas=class)
+        ".invoke",
     )
+
+    // Lambdas are compiled via invokedynamic into synthetic methods named `foo$lambda$0`
+    // (nested lambdas repeat the pattern).
+    private val LAMBDA_METHOD_SUFFIX_REGEX = "(\\\$lambda\\\$[0-9]+)+$".toRegex()
 
     /**
      * Uses StackWalker to retrieve the caller.
@@ -46,7 +52,11 @@ public object SqlIds {
             return "UNKNOWN"
         }
 
-        val parts = name.removeSuffixes(SUFFIXES).split("$", ".").filterNot { it.matches(NUMBER_REGEX) }
+        val parts = name
+            .replace(LAMBDA_METHOD_SUFFIX_REGEX, "")
+            .removeSuffixes(SUFFIXES)
+            .split("$", ".")
+            .filterNot { it.matches(NUMBER_REGEX) }
         return if (parts.isEmpty()) {
             "UNKNOWN"
         } else {

--- a/kuery-client-core/src/test/kotlin/com/example/core/ClassA.kt
+++ b/kuery-client-core/src/test/kotlin/com/example/core/ClassA.kt
@@ -19,6 +19,17 @@ internal class ClassA {
         }
     }
 
+    fun sql5(block: SqlBuilder.() -> Unit): String = execute { block.id() }
+
+    // Simulates a class-compiled lambda (e.g. -Xlambdas=class), which has an `invoke` method.
+    fun sql6(block: SqlBuilder.() -> Unit): String = execute(
+        object : () -> String {
+            override fun invoke(): String = block.id()
+        },
+    )
+
+    private fun <T> execute(action: () -> T): T = action()
+
     internal class ClassB {
         fun sql3(block: SqlBuilder.() -> Unit): String = block.id()
 

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
@@ -22,6 +22,8 @@ class SqlIdsTest {
         assertThat(
             ClassA.ClassB.ClassC().sql4 {},
         ).isEqualTo("com.example.core.ClassA.ClassB.ClassC.sql4")
+        assertThat(ClassA().sql5 {}).isEqualTo("com.example.core.ClassA.sql5")
+        assertThat(ClassA().sql6 {}).isEqualTo("com.example.core.ClassA.sql6")
     }
 
     @Test


### PR DESCRIPTION
## Summary

When `client.sql { ... }` is called from inside a non-suspend lambda, the auto-generated sqlId kept a synthetic artifact, unlike the suspend path (where `.invokeSuspend` is already stripped by `SUFFIXES`):

- Kotlin 2.x compiles lambdas via invokedynamic into synthetic methods named `foo$lambda$0`. The existing numeric-part filter drops the `0` but leaves `lambda`, so the id became `com.example.Repo.foo.lambda`.
- Lambdas compiled as classes (e.g. `-Xlambdas=class`, or explicit `object : () -> T` expressions) have an `invoke` method, so the id became `com.example.Repo.foo.invoke`.

Both are inconsistent with the suspend variant, which yields a clean `com.example.Repo.foo`. Since sqlId is used as a metrics/observation tag value, this is worth fixing before v1.0.0 (changing it later would break users' dashboards).

## Changes

- Strip a trailing `(\$lambda\$N)+` method suffix (indy-compiled lambdas, the default since Kotlin 2.0) before the existing suffix removal.
- Add `.invoke` to `SUFFIXES` (class-compiled lambdas).

## Tests

Test-first: added `sql5` (lambda passed to a non-inline higher-order function → reproduced `...sql5.lambda`) and `sql6` (function-type object expression, the same bytecode shape as `-Xlambdas=class` → reproduced `...sql6.invoke`) to `ClassA`, confirmed both failed before the fix, then applied the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)