### PR TITLE
Allow Nothing-typed branches in KUERY_UNSAFE_SQL_STRING check

### DIFF
--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/UnsafeSqlStringChecker.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/UnsafeSqlStringChecker.kt
@@ -14,6 +14,8 @@ import org.jetbrains.kotlin.fir.expressions.FirStringConcatenationCall
 import org.jetbrains.kotlin.fir.expressions.FirWhenExpression
 import org.jetbrains.kotlin.fir.expressions.unwrapArgument
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.types.isNothing
+import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -49,10 +51,12 @@ internal object UnsafeSqlStringChecker : FirFunctionCallChecker(MppCheckerKind.C
             expression.calleeReference.toResolvedCallableSymbol()?.callableId in ALLOWED_CHAIN_METHODS &&
                 expression.argumentList.arguments.all { it.unwrapArgument() is FirLiteralExpression } &&
                 expression.extensionReceiver?.let(::isCompileTimeSafe) == true
-        // if / when whose every branch results in a compile-time-safe expression
+        // if / when whose every branch results in a compile-time-safe expression;
+        // a Nothing-typed branch (throw / error(...) etc.) never yields a SQL string, so it is vacuously safe
         is FirWhenExpression ->
             expression.branches.all { branch ->
-                (branch.result.statements.lastOrNull() as? FirExpression)?.let(::isCompileTimeSafe) == true
+                (branch.result.statements.lastOrNull() as? FirExpression)
+                    ?.let { it.resolvedType.isNothing || isCompileTimeSafe(it) } == true
             }
         else -> false
     }

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
@@ -104,6 +104,54 @@ class UnsafeSqlStringCheckerTest {
     }
 
     @Test
+    fun `no warning when a when expression has an error branch`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(sort: String, id: Int) {
+                Sql {
+                    add(
+                        when (sort) {
+                            "name" -> "ORDER BY name"
+                            "created" -> "ORDER BY created_at, id = ${'$'}id"
+                            else -> error("unsupported sort: ${'$'}sort")
+                        },
+                    )
+                }
+            }
+            """.trimIndent(),
+            allWarningsAsErrors = true,
+        )
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
+    fun `no warning when an if expression has a throw branch`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(id: Int) {
+                Sql {
+                    +(
+                        if (id > 0) {
+                            "SELECT * FROM users WHERE id = ${'$'}id"
+                        } else {
+                            throw IllegalArgumentException("id must be positive")
+                        }
+                    )
+                }
+            }
+            """.trimIndent(),
+            allWarningsAsErrors = true,
+        )
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
     fun `warn when an if expression has an unsafe branch`() {
         val result = compile(
             """


### PR DESCRIPTION
## Summary

The `KUERY_UNSAFE_SQL_STRING` FIR checker reported a false positive when an if/when expression passed to `add()` / `unaryPlus` contained a `throw` or `error(...)` branch:

```kotlin
+when (sort) {
    "name" -> "ORDER BY name"
    "created" -> "ORDER BY created_at"
    else -> error("unsupported sort: $sort")  // whole `when` flagged as unsafe
}
```

A branch whose result type is `Nothing` can never produce a SQL string, so it is vacuously safe. The false positive was especially painful with `allWarningsAsErrors = true`, where the exhaustiveness idiom `else -> error(...)` made legitimate code fail to compile, with `@Suppress` as the only escape hatch.

## Changes

- `UnsafeSqlStringChecker`: branch results whose resolved type is `Nothing` are now accepted in the if/when branch check. Checking by type (rather than an allowlist of function names) covers `throw`, `error()`, `TODO()`, and any user-defined `Nothing`-returning function uniformly.
- Added two regression tests (`else -> error(...)` in `when`, `throw` branch in `if`), both compiled with `-Werror` to pin that no warning is emitted. Verified they failed before the fix.

The IR transformer is unchanged — value-producing branches were already converted to bind parameters correctly; only the diagnostic was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)