### PR TITLE
Apply enum/custom conversions inside composite IN rows

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -78,6 +78,9 @@ internal class DefaultSpringJdbcKueryClient(
         }
     }
 
+    // NOTE: The conversion helpers below (convertCollection / convertArray / componentWriteTarget /
+    // convertElement) are intentionally duplicated in DefaultSpringR2dbcKueryClient; there is no
+    // shared Spring-dependent module to host them. Keep both copies in sync.
     private fun convertCollection(collection: Collection<*>): Collection<*> = collection.map { convertElement(it) }
 
     // The runtime component type must be preserved (e.g. String[] stays String[]); drivers
@@ -113,6 +116,8 @@ internal class DefaultSpringJdbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(element::class.java)
         return when {
             targetType.isPresent -> conversionService.convert(element, targetType.get())
+            // composite IN `(a, b) IN ($pairs)` passes each row as an Object[] entry in a Collection
+            element is Array<*> -> convertArray(element)
             element is Enum<*> -> element.name
             else -> element
         }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CollectionConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CollectionConversionTest.kt
@@ -57,6 +57,23 @@ class CollectionConversionTest {
         assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
     }
 
+    @Test
+    fun testCompositeIn() {
+        kueryClient.sql {
+            +"""
+            INSERT INTO converter (text) VALUES
+            ('text1'),
+            ('text2');
+            """.trimIndent()
+        }.rowsUpdated()
+
+        val result = kueryClient.sql {
+            val pairs = listOf(arrayOf<Any>(1L, StringWrapper("text1")))
+            +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1")))
+    }
+
     companion object {
         private val h2 = H2TestDatabase()
     }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/EnumConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/EnumConversionTest.kt
@@ -67,6 +67,19 @@ class EnumConversionTest {
         assertThat(record.text).isEqualTo(SampleEnum.HOGE)
     }
 
+    @Test
+    fun testCompositeIn() {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
+        }.rowsUpdated()
+
+        val record: Record = kueryClient.sql {
+            val pairs = listOf(arrayOf<Any>(1L, SampleEnum.HOGE))
+            +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"
+        }.single()
+        assertThat(record.text).isEqualTo(SampleEnum.HOGE)
+    }
+
     companion object {
         private val h2 = H2TestDatabase()
     }

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -96,6 +96,9 @@ internal class DefaultSpringR2dbcKueryClient(
         }
     }
 
+    // NOTE: The conversion helpers below (convertCollection / convertArray / componentWriteTarget /
+    // convertElement) are intentionally duplicated in DefaultSpringJdbcKueryClient; there is no
+    // shared Spring-dependent module to host them. Keep both copies in sync.
     private fun convertCollection(collection: Collection<*>): Collection<*> = collection.map { convertElement(it) }
 
     // The runtime component type must be preserved (e.g. String[] stays String[]); drivers
@@ -131,6 +134,8 @@ internal class DefaultSpringR2dbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(element::class.java)
         return when {
             targetType.isPresent -> conversionService.convert(element, targetType.get())
+            // composite IN `(a, b) IN ($pairs)` passes each row as an Object[] entry in a Collection
+            element is Array<*> -> convertArray(element)
             element is Enum<*> -> element.name
             else -> element
         }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CollectionConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CollectionConversionTest.kt
@@ -58,6 +58,23 @@ class CollectionConversionTest {
         assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
     }
 
+    @Test
+    fun testCompositeIn() = runTest {
+        kueryClient.sql {
+            +"""
+            INSERT INTO converter (text) VALUES
+            ('text1'),
+            ('text2');
+            """.trimIndent()
+        }.rowsUpdated()
+
+        val result = kueryClient.sql {
+            val pairs = listOf(arrayOf<Any>(1L, StringWrapper("text1")))
+            +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1")))
+    }
+
     companion object {
         private val h2 = H2TestDatabase()
     }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/EnumConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/EnumConversionTest.kt
@@ -68,6 +68,19 @@ class EnumConversionTest {
         assertThat(record.text).isEqualTo(SampleEnum.HOGE)
     }
 
+    @Test
+    fun testCompositeIn() = runTest {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
+        }.rowsUpdated()
+
+        val record: Record = kueryClient.sql {
+            val pairs = listOf(arrayOf<Any>(1L, SampleEnum.HOGE))
+            +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"
+        }.single()
+        assertThat(record.text).isEqualTo(SampleEnum.HOGE)
+    }
+
     companion object {
         private val h2 = H2TestDatabase()
     }


### PR DESCRIPTION
## Summary

Spring officially supports composite IN predicates — `(a, b) IN (:pairs)` with a `Collection<Object[]>` parameter, expanded into row placeholders `(?, ?), (?, ?)` — but `convertElement` did not recurse into the `Object[]` entries. Enums and custom-converted types inside a row therefore reached the driver unconverted:

```kotlin
val pairs = listOf(arrayOf<Any>(1L, Status.ACTIVE))
+"SELECT * FROM t WHERE (id, status) IN ($pairs)"
```

- **JDBC**: the raw enum object was Java-serialized by the driver (H2: data conversion error / `NotSerializableException` for custom types)
- **R2DBC**: `Cannot encode parameter of type ...`

Scalar (`= $enum`) and flat collection (`IN (${listOf(enum)})`, fixed in #333) cases already worked; composite rows were the remaining gap.

## Changes

- `convertElement` in both modules now routes `Array<*>` elements through `convertArray`, which already applies element conversions and preserves component types (identity pass-through when no conversion is needed).
- Added `testCompositeIn` regression tests to `EnumConversionTest` and `CollectionConversionTest` in both modules (H2, following the test-matrix-by-layer convention). Verified all four failed before the fix.
- Added a keep-in-sync mirror note to the conversion helpers, which are intentionally duplicated between the jdbc and r2dbc modules (no shared Spring-dependent module to host them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)