### PR TITLE
Make CloseableSequence iterator idempotent after exhaustion

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequence.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequence.kt
@@ -20,19 +20,30 @@ private class StreamCloseableSequence<T>(private val stream: Stream<T>) : Closea
         check(!closed) { "This sequence is already closed." }
         iterated = true
         val iterator = stream.iterator()
-        // The underlying stream iterator throws NoSuchElementException when exhausted.
-        @Suppress("IteratorNotThrowingNoSuchElementException")
         return object : Iterator<T> {
-            override fun hasNext(): Boolean = closeOnFailure {
-                val hasNext = iterator.hasNext()
-                if (!hasNext) {
-                    close()
+            // Once closed (exhaustion or an explicit close()), never touch the underlying
+            // iterator again: the JDK stream-iterator adapter does not cache exhaustion and
+            // would re-access the already-released resource (e.g. a closed ResultSet).
+            override fun hasNext(): Boolean {
+                if (closed) {
+                    return false
                 }
-                hasNext
+                return closeOnFailure {
+                    val hasNext = iterator.hasNext()
+                    if (!hasNext) {
+                        close()
+                    }
+                    hasNext
+                }
             }
 
-            override fun next(): T = closeOnFailure {
-                iterator.next()
+            override fun next(): T {
+                if (closed) {
+                    throw NoSuchElementException("This sequence has no more elements (already closed).")
+                }
+                return closeOnFailure {
+                    iterator.next()
+                }
             }
         }
     }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequenceTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequenceTest.kt
@@ -4,10 +4,14 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import org.junit.jupiter.api.Test
+import java.util.Spliterators
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Consumer
 import java.util.stream.Stream
+import java.util.stream.StreamSupport
 
 class StreamCloseableSequenceTest {
     @Test
@@ -32,6 +36,29 @@ class StreamCloseableSequenceTest {
     }
 
     @Test
+    fun `hasNext stays false after exhaustion without touching the closed stream`() {
+        val iterator = resultSetLikeStream("a", "b").asCloseableSequence().iterator()
+
+        assertThat(iterator.next()).isEqualTo("a")
+        assertThat(iterator.next()).isEqualTo("b")
+        assertThat(iterator.hasNext()).isFalse()
+
+        // Iterator.hasNext must be idempotent; the JDK stream-iterator adapter does not cache
+        // exhaustion and would re-touch the (already closed) underlying resource.
+        assertThat(iterator.hasNext()).isFalse()
+    }
+
+    @Test
+    fun `next after exhaustion throws NoSuchElementException`() {
+        val iterator = resultSetLikeStream("a").asCloseableSequence().iterator()
+
+        assertThat(iterator.next()).isEqualTo("a")
+        assertThat(iterator.hasNext()).isFalse()
+
+        assertFailure { iterator.next() }.isInstanceOf(NoSuchElementException::class)
+    }
+
+    @Test
     fun `explicit close after full iteration does not close the stream twice`() {
         val closeCount = AtomicInteger()
         val sequence = Stream.of("a", "b").onClose { closeCount.incrementAndGet() }.asCloseableSequence()
@@ -43,5 +70,26 @@ class StreamCloseableSequenceTest {
         sequence.close()
 
         assertThat(closeCount.get()).isEqualTo(1)
+    }
+
+    /**
+     * Models `JdbcTemplate.queryForStream`: a stream backed by a resource (ResultSet) that
+     * throws when accessed after the stream's close handler has run.
+     */
+    private fun resultSetLikeStream(vararg values: String): Stream<String> {
+        var closed = false
+        val spliterator = object : Spliterators.AbstractSpliterator<String>(values.size.toLong(), 0) {
+            private var index = 0
+
+            override fun tryAdvance(action: Consumer<in String>): Boolean {
+                check(!closed) { "The ResultSet is already closed." }
+                if (index >= values.size) {
+                    return false
+                }
+                action.accept(values[index++])
+                return true
+            }
+        }
+        return StreamSupport.stream(spliterator, false).onClose { closed = true }
     }
 }


### PR DESCRIPTION
## Summary

`Iterator.hasNext()` must be idempotent (keep returning `false` once exhausted), but the iterator returned by `StreamCloseableSequence` delegated every call to the underlying stream iterator. The JDK stream-iterator adapter (`Spliterators.iterator`) does not cache exhaustion — each `hasNext()` re-invokes `tryAdvance` on the spliterator. Since the sequence closes the stream when the iteration reaches the end (#334), a second `hasNext()` touched the already-closed `ResultSet` and threw a driver error instead of returning `false`. `next()` after exhaustion likewise surfaced a driver error instead of `NoSuchElementException`.

## Changes

- Guard both iterator methods on the `closed` flag: `hasNext()` returns `false` and `next()` throws `NoSuchElementException` once the sequence is closed (whether by exhaustion or an explicit `close()`), without touching the released resource.
- Added two regression tests using a stream backed by a ResultSet-like resource that throws when accessed after the close handler has run (modeling `JdbcTemplate.queryForStream`). Verified both failed before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)