### PR TITLE
Bind null results from WritingConverters as SQL NULL

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -67,7 +67,8 @@ internal class DefaultSpringJdbcKueryClient(
 
         val targetType = customConversions.getCustomWriteTarget(value::class.java)
         if (targetType.isPresent) {
-            return param(parameter.name, checkNotNull(conversionService.convert(value, targetType.get())))
+            // The Converter contract allows a null result; bind it as SQL NULL.
+            return param(parameter.name, conversionService.convert(value, targetType.get()))
         }
 
         return when (value) {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/NullReturningWritingConverterTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/NullReturningWritingConverterTest.kt
@@ -1,0 +1,63 @@
+package dev.hsbrysk.kuery.spring.jdbc
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.WritingConverter
+
+/**
+ * Spring's [Converter] contract allows returning null; a null result must be bound as SQL NULL
+ * (the same way Spring Data itself writes null-converted properties).
+ */
+class NullReturningWritingConverterTest {
+    private val kueryClient = h2.kueryClient(listOf(NullableTextToStringConverter()))
+
+    data class NullableText(val value: String?)
+
+    @WritingConverter
+    class NullableTextToStringConverter : Converter<NullableText, String?> {
+        override fun convert(source: NullableText): String? = source.value
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        h2.setUpForConverterTest()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun testNull() {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${NullableText(null)})"
+        }.rowsUpdated()
+
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun testNonNull() {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${NullableText("hoge")})"
+        }.rowsUpdated()
+
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -76,7 +76,13 @@ internal class DefaultSpringR2dbcKueryClient(
 
         val targetType = customConversions.getCustomWriteTarget(value::class.java)
         if (targetType.isPresent) {
-            return bind(parameter.name, checkNotNull(conversionService.convert(value, targetType.get())))
+            // The Converter contract allows a null result; bind it as SQL NULL of the target type.
+            val converted = conversionService.convert(value, targetType.get())
+            return if (converted != null) {
+                bind(parameter.name, converted)
+            } else {
+                bindNull(parameter.name, targetType.get())
+            }
         }
 
         return when (value) {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/NullReturningWritingConverterTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/NullReturningWritingConverterTest.kt
@@ -1,0 +1,64 @@
+package dev.hsbrysk.kuery.spring.r2dbc
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.WritingConverter
+
+/**
+ * Spring's [Converter] contract allows returning null; a null result must be bound as SQL NULL
+ * (the same way Spring Data itself writes null-converted properties).
+ */
+class NullReturningWritingConverterTest {
+    private val kueryClient = h2.kueryClient(listOf(NullableTextToStringConverter()))
+
+    data class NullableText(val value: String?)
+
+    @WritingConverter
+    class NullableTextToStringConverter : Converter<NullableText, String?> {
+        override fun convert(source: NullableText): String? = source.value
+    }
+
+    @BeforeEach
+    fun beforeEach() = runTest {
+        h2.setUpForConverterTest()
+    }
+
+    @AfterEach
+    fun afterEach() = runTest {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun testNull() = runTest {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${NullableText(null)})"
+        }.rowsUpdated()
+
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun testNonNull() = runTest {
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${NullableText("hoge")})"
+        }.rowsUpdated()
+
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}


### PR DESCRIPTION
## Summary

Spring's `Converter` contract allows returning null — since the JSpecify migration the interface is `Converter<S, T extends @Nullable Object>` and the javadoc notes the result is "potentially null". A Kotlin `Converter<MyType, String?>` (or a Java converter returning `@Nullable String`) is therefore a legitimate way to map a sentinel value to SQL NULL.

The scalar bind path wrapped the conversion result in `checkNotNull`, so such a converter blew up with an opaque `IllegalStateException: Required value was null.` — inconsistently, the collection/array element path (`convertElement`) already tolerated null results.

## Changes

- Bind a null conversion result as SQL NULL, matching how Spring Data itself writes null-converted properties:
  - **JDBC**: drop the `checkNotNull` — `param(name, null)` is the same call the null-value path already uses.
  - **R2DBC**: `bindNull(name, targetType)` — using the converter's target type gives the driver more type information than the generic `Any` used for untyped nulls.
- Added `NullReturningWritingConverterTest` to both modules (H2): a `Converter<NullableText, String?>` whose null result must be stored as NULL, plus a non-null pin. Verified the null cases failed with "Required value was null." before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)