### PR TITLE
Correct KDoc on sequence close guarantees and null scalar elements

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/CloseableSequence.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/CloseableSequence.kt
@@ -3,9 +3,11 @@ package dev.hsbrysk.kuery.core
 /**
  * A [Sequence] backed by an underlying resource (e.g., an open JDBC ResultSet) that must be released.
  *
- * The resource is closed automatically when the iteration reaches the end, or when an exception is
- * thrown during the iteration. If you stop iterating midway (e.g., with `take` or `first`), close it
- * explicitly with [close], typically via [use]:
+ * The resource is closed automatically when the iteration reaches the end, or when fetching the
+ * next element (i.e., [Iterator.hasNext] / [Iterator.next]) throws. It is NOT closed when your own
+ * code processing the elements throws, or when you stop iterating midway (e.g., with `take` or
+ * `first`). Unless you fully iterate the sequence, close it explicitly with [close], typically
+ * via [use]:
  *
  * ```kotlin
  * client.sql { +"SELECT * FROM users" }.sequence<User>().use { seq ->

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
@@ -66,22 +66,30 @@ public interface KueryBlockingClient {
 
         /**
          * Receives the results of multiple rows converted to the specified type.
+         *
+         * When fetching a simple scalar type from a single-column query, SQL NULL is kept as a null
+         * element even though this cannot be expressed in the `List<T>` type.
          */
         public fun <T : Any> list(returnType: KClass<T>): List<T>
 
         /**
          * Receives the results of multiple rows as a sequence of maps.
          * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active transaction.
-         * It is closed automatically when fully iterated or when an exception is thrown during the iteration.
-         * If you stop iterating midway, close it explicitly (e.g., with [use]). It can be iterated only once.
+         * It is closed automatically when fully iterated or when fetching the next element throws; exceptions
+         * thrown by your own processing code do not close it. Unless you fully iterate the sequence, close it
+         * explicitly (e.g., with [use]). It can be iterated only once. See [CloseableSequence].
          */
         public fun sequenceMap(): CloseableSequence<Map<String, Any?>>
 
         /**
          * Receives the results of multiple rows converted to the specified type as a sequence.
          * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active transaction.
-         * It is closed automatically when fully iterated or when an exception is thrown during the iteration.
-         * If you stop iterating midway, close it explicitly (e.g., with [use]). It can be iterated only once.
+         * It is closed automatically when fully iterated or when fetching the next element throws; exceptions
+         * thrown by your own processing code do not close it. Unless you fully iterate the sequence, close it
+         * explicitly (e.g., with [use]). It can be iterated only once. See [CloseableSequence].
+         *
+         * When fetching a simple scalar type from a single-column query, SQL NULL is kept as a null
+         * element even though this cannot be expressed in the `CloseableSequence<T>` type.
          */
         public fun <T : Any> sequence(returnType: KClass<T>): CloseableSequence<T>
 

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
@@ -57,6 +57,9 @@ public interface KueryClient {
 
         /**
          * Receives the results of multiple rows converted to the specified type.
+         *
+         * When fetching a simple scalar type from a single-column query, SQL NULL is kept as a null
+         * element even though this cannot be expressed in the `List<T>` type.
          */
         public suspend fun <T : Any> list(returnType: KClass<T>): List<T>
 
@@ -67,6 +70,9 @@ public interface KueryClient {
 
         /**
          * Receives the results of multiple rows converted to the specified type.
+         *
+         * When fetching a simple scalar type from a single-column query, SQL NULL is kept as a null
+         * element even though this cannot be expressed in the `Flow<T>` type.
          */
         public fun <T : Any> flow(returnType: KClass<T>): Flow<T>
 


### PR DESCRIPTION
## Summary

KDoc-only changes fixing two contract-documentation gaps found in the R12 review. No runtime change.

### Sequence close guarantees were overpromised

`CloseableSequence` (and the `sequence()` / `sequenceMap()` KDoc) claimed the resource is closed "when an exception is thrown during the iteration". In reality only failures thrown by `hasNext()` / `next()` themselves close it — an exception thrown by the consumer's own processing code (e.g. inside a `forEach` body) leaks the ResultSet. The KDoc now states the actual guarantee and steers toward `use {}` for anything short of a guaranteed full iteration.

### Null scalar elements were undocumented

Since #344, `list()` / `flow()` / `sequence()` keep SQL NULL as a null element when fetching a simple scalar type from a single-column query (e.g. `SELECT nullable_col ...` as `List<Int>`), consistently across both modules. The `List<T>` / `Flow<T>` / `CloseableSequence<T>` signatures cannot express this, so it is now called out in the KDoc of each operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)