### PR TITLE
Close the observation scope before stop in the JDBC observe path

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -219,18 +219,9 @@ internal class DefaultSpringJdbcKueryClient(
         private fun <T> observe(block: () -> T): T {
             return SqlIdInjector(sqlId).use {
                 val observation = observationOrNull() ?: return block()
-
-                observation.start()
-                observation.openScope().use {
-                    try {
-                        block()
-                    } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
-                        observation.error(e)
-                        throw e
-                    } finally {
-                        observation.stop()
-                    }
-                }
+                // Runs start/openScope/error/stop in the documented Micrometer lifecycle order
+                // (the scope is closed before the observation is stopped).
+                observation.observeChecked<T, Throwable>(block)
             }
         }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ObservationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ObservationTest.kt
@@ -1,6 +1,10 @@
 package dev.hsbrysk.kuery.spring.jdbc
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import com.example.spring.jdbc.UserRepository
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationHandler
 import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
 import org.junit.jupiter.api.AfterEach
@@ -111,6 +115,30 @@ class ObservationTest {
             sqlId = "com.example.spring.jdbc.UserRepository.generatedValues",
             sql = "INSERT INTO users (username, email) VALUES (:p0, :p1)",
         )
+    }
+
+    @Test
+    fun `scope is closed before the observation is stopped`() {
+        // The documented Micrometer lifecycle order: close the scope, then stop the observation.
+        val events = mutableListOf<String>()
+        val recordingRegistry = TestObservationRegistry.create().apply {
+            observationConfig().observationHandler(object : ObservationHandler<Observation.Context> {
+                override fun supportsContext(context: Observation.Context): Boolean = true
+
+                override fun onScopeClosed(context: Observation.Context) {
+                    events.add("scopeClosed")
+                }
+
+                override fun onStop(context: Observation.Context) {
+                    events.add("stop")
+                }
+            })
+        }
+        val client = h2.kueryClient(observationRegistry = recordingRegistry)
+
+        UserRepository(client).singleMap(1)
+
+        assertThat(events).isEqualTo(listOf("scopeClosed", "stop"))
     }
 
     private fun assertObservation(


### PR DESCRIPTION
## Summary

The JDBC `observe()` helper hand-rolled the observation lifecycle with `stop()` in a `finally` block *inside* `openScope().use { }`, so the observation was stopped before its scope was closed — the reverse of the documented Micrometer order. Handlers observing `onScopeClosed` / `onStop` saw the events inverted. (The R2DBC side already follows the correct order since #339; this was the remaining JDBC half of that nit.)

## Changes

- Replace the hand-rolled sequence with `Observation.observeChecked(block)`, which runs start → open scope → (error) → close scope → stop in the documented order. 12 lines shorter, same semantics otherwise.
- Added a regression test pinning the event order with a recording `ObservationHandler` (`scopeClosed` before `stop`). Verified it failed with the inverted order before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)