### PR TITLE
Apply small cleanups across core, compiler, and r2dbc

### DIFF
--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -50,12 +50,10 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
             )
             current = temporary
 
+            // The SQL argument is the single non-dispatch parameter: `add`'s regular parameter
+            // or `unaryPlus`'s extension receiver.
             val sqlArgumentParameter = expression.symbol.owner.parameters.first {
-                when (expression.symbol.owner.name.asString()) {
-                    "add" -> it.kind == IrParameterKind.Regular
-                    "unaryPlus" -> it.kind == IrParameterKind.ExtensionReceiver
-                    else -> error("Unexpected error") // not happened
-                }
+                it.kind != IrParameterKind.DispatchReceiver
             }
             val sqlArgument = checkNotNull(expression.arguments[sqlArgumentParameter.indexInParameters])
                 .transform(this, null)

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/ClassNames.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/ClassNames.kt
@@ -1,6 +1,5 @@
 package dev.hsbrysk.kuery.compiler.ir.misc
 
 internal object ClassNames {
-    val STRING = checkNotNull(String::class.qualifiedName)
     const val SQL_BUILDER = "dev.hsbrysk.kuery.core.SqlBuilder"
 }

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilder.kt
@@ -63,13 +63,13 @@ internal class DefaultSqlBuilder : SqlBuilder {
         }
     }
 
-    fun build(): Sql = DefaultSql(body.toString().trim(), parameters.toList())
+    fun build(): Sql = DefaultSql(body.trim().toString(), parameters.toList())
 
     companion object {
         internal const val PARAMETER_NAME_PREFIX = "p"
         internal const val PARAMETER_NAME_PREFIX_WITH_COLON = ":$PARAMETER_NAME_PREFIX"
 
-        fun <T> injectByPlugin(): T = error(
+        fun injectByPlugin(): Nothing = error(
             "`SqlBuilder.add`/`String.unaryPlus` must be rewritten by the kuery-client compiler plugin, " +
                 "but this call was not. " +
                 "Make sure the Gradle plugin `dev.hsbrysk.kuery-client` is applied to the module " +

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClient.kt
@@ -9,8 +9,7 @@ public object SpringR2dbcKueryClient {
     /**
      * Retrieve the current sqlId from reactor context.
      */
-    public fun sqlId(context: ContextView): String? =
-        context.getOrEmpty<String>(SQL_ID_REACTOR_CONTEXT_KEY).orElse(null)
+    public fun sqlId(context: ContextView): String? = context.getOrDefault(SQL_ID_REACTOR_CONTEXT_KEY, null)
 
     /**
      * Create [SpringR2dbcKueryClientBuilder]

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -197,7 +197,7 @@ internal class DefaultSpringR2dbcKueryClient(
             // NULL scalar values are kept as null elements, like the JDBC client. The declared
             // element type cannot express this, but type erasure makes it observable the same way.
             @Suppress("UNCHECKED_CAST")
-            return if (mapper is SingleColumnRowMapper<*>) {
+            return if (mapper is SingleColumnRowMapper) {
                 values.map { it.unwrapNullValue<T>() } as List<T>
             } else {
                 values as List<T>
@@ -220,7 +220,7 @@ internal class DefaultSpringR2dbcKueryClient(
             val mapper = mapper(returnType)
             val flow = spec.map(mapper).all().sqlId(sqlId).asFlow()
             @Suppress("UNCHECKED_CAST")
-            return if (mapper is SingleColumnRowMapper<*>) {
+            return if (mapper is SingleColumnRowMapper) {
                 flow.map { it.unwrapNullValue<T>() } as Flow<T>
             } else {
                 flow as Flow<T>
@@ -261,7 +261,7 @@ internal class DefaultSpringR2dbcKueryClient(
                                 registry,
                             )
                             .parentObservation(
-                                contextView.getOrEmpty<Observation>(ObservationThreadLocalAccessor.KEY).orElse(null),
+                                contextView.getOrDefault<Observation>(ObservationThreadLocalAccessor.KEY, null),
                             )
                             .start()
                     },
@@ -311,8 +311,8 @@ internal class DefaultSpringR2dbcKueryClient(
     //
     // The R2DBC SPI forbids Result.map mapping functions from returning null, so a SQL NULL value
     // is returned as [NullValue] instead and unwrapped at the terminal operators.
-    class SingleColumnRowMapper<T : Any>(
-        private val requiredType: Class<T>,
+    class SingleColumnRowMapper(
+        private val requiredType: Class<*>,
         private val conversionService: ConversionService,
     ) : Function<Readable, Any> {
         override fun apply(readable: Readable): Any = try {


### PR DESCRIPTION
## Summary

Behavior-preserving micro-cleanups from the R12 review (finding #15 plus the out-of-scope micro list), bundled into one PR as agreed.

> **Note**: stacked on #384 because the `SingleColumnRowMapper` type-parameter removal touches the `is SingleColumnRowMapper` checks introduced there. GitHub will retarget this PR to `main` automatically once #384 merges.

## Changes

- **compiler**: remove the unreferenced `ClassNames.STRING` constant (dead code, zero references).
- **compiler**: replace the when-in-predicate parameter search (with its unreachable `else`) in `StringInterpolationTransformer` with a direct "single non-dispatch parameter" lookup — `add`'s regular parameter and `unaryPlus`'s extension receiver are both exactly that.
- **core**: `injectByPlugin()` returns `Nothing` instead of an unused `<T>` (internal, no ABI impact — the ABI dump is unchanged).
- **core**: `build()` trims the `StringBuilder` before `toString()`, avoiding a second full copy (the trailing newline from `appendLine` made `trim()` always copy).
- **r2dbc**: `getOrEmpty(...).orElse(null)` → `getOrDefault(..., null)` (2 call sites; Reactor documents the default as `@Nullable`).
- **r2dbc**: the hand-written `SingleColumnRowMapper`'s `<T : Any>` only appeared in the input position, so `Class<*>` suffices.

Not done: the `convertCollection` identity short-circuit listed in the micro backlog — unlike `convertArray` there is no component type to preserve, and detecting "no element changed" requires allocating the mapped list anyway, so it saves nothing.

All module tests, ABI check, ktlint, and detekt pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)