### PR TITLE
Fold trimIndent/trimMargin on SQL templates at compile time

### DIFF
--- a/docs/compiler-safety-check.md
+++ b/docs/compiler-safety-check.md
@@ -37,7 +37,10 @@ In contrast, the following forms are accepted. The SQL string is fully determine
 time, so any interpolation in it is rewritten into bind parameters:
 
 - A string literal / string template: `"SELECT ... $id"`
-- `trimIndent()` / `trimMargin()` called on one (with literal-only arguments)
+- `trimIndent()` / `trimMargin()` called on one (with literal-only arguments) — these are also
+  computed at compile time by the plugin, so they add no runtime cost (in the rare cases where
+  equivalence cannot be guaranteed, e.g. a `trimMargin` prefix containing `:`, the plugin leaves
+  the call as-is and it runs at runtime as before)
 - A reference to a `const val`
 - An `if` / `when` expression whose every branch is one of the above (each branch is checked
   recursively): `if (asc) "ORDER BY id" else "ORDER BY id DESC"`. A branch that only throws —

--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/TrimFoldingTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/TrimFoldingTest.kt
@@ -1,0 +1,228 @@
+package dev.hsbrysk.kuery.core
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioral equivalence of the compile-time trimIndent/trimMargin folding: whether a case is
+ * folded by the plugin or falls back to runtime trimming, the resulting [Sql] must be identical
+ * to what runtime trimming has always produced. Proof that folding actually fires is covered by
+ * `TrimFoldingBytecodeTest` in the compiler module.
+ */
+class TrimFoldingTest {
+    @Test
+    fun `trimIndent with values mid-line`() {
+        val name = "n"
+        val age = 18
+        val sql = Sql {
+            add(
+                """
+                UPDATE user
+                SET name = $name, age = $age
+                WHERE id = ${1}
+                """.trimIndent(),
+            )
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "UPDATE user\nSET name = :p0, age = :p1\nWHERE id = :p2",
+                listOf(
+                    NamedSqlParameter("p0", name),
+                    NamedSqlParameter("p1", age),
+                    NamedSqlParameter("p2", 1),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `trimIndent with values at line start and line end`() {
+        val a = "A"
+        val b = "B"
+        val sql = Sql {
+            +"""
+            $a AND x
+            y = $b
+            """.trimIndent()
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                ":p0 AND x\ny = :p1",
+                listOf(NamedSqlParameter("p0", a), NamedSqlParameter("p1", b)),
+            ),
+        )
+    }
+
+    @Test
+    fun `trimIndent with a blank line in the middle`() {
+        val a = "A"
+        val sql = Sql {
+            +"""
+            a = $a
+
+            b
+            """.trimIndent()
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "a = :p0\n\nb",
+                listOf(NamedSqlParameter("p0", a)),
+            ),
+        )
+    }
+
+    @Test
+    fun `trimIndent with consecutive values`() {
+        val a = "A"
+        val b = "B"
+        val sql = Sql {
+            +"""
+            a
+            $a$b c
+            """.trimIndent()
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "a\n:p0:p1 c",
+                listOf(NamedSqlParameter("p0", a), NamedSqlParameter("p1", b)),
+            ),
+        )
+    }
+
+    @Test
+    fun `trimIndent on a constant string`() {
+        val sql = Sql {
+            add(
+                """
+                SELECT *
+                FROM user
+                """.trimIndent(),
+            )
+        }
+        assertThat(sql).isEqualTo(Sql("SELECT *\nFROM user"))
+    }
+
+    @Test
+    fun `trimMargin with the default prefix`() {
+        val a = "A"
+        val sql = Sql {
+            +"""
+            |SELECT *
+            |WHERE id = $a
+            """.trimMargin()
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "SELECT *\nWHERE id = :p0",
+                listOf(NamedSqlParameter("p0", a)),
+            ),
+        )
+    }
+
+    @Test
+    fun `trimMargin with a literal prefix`() {
+        val a = "A"
+        val sql = Sql {
+            +"""
+            > SELECT *
+            > WHERE id = $a
+            """.trimMargin("> ")
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "SELECT *\nWHERE id = :p0",
+                listOf(NamedSqlParameter("p0", a)),
+            ),
+        )
+    }
+
+    @Test
+    fun `trimMargin with a colon prefix falls back to runtime trimming`() {
+        // A ':' prefix could match into the runtime ':pN' placeholders, so the plugin must not
+        // fold it. The runtime behavior (margin stripped from the line below) is preserved.
+        val a = "A"
+        val sql = Sql {
+            +"""
+            :x = $a
+            """.trimMargin(":")
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "x = :p0",
+                listOf(NamedSqlParameter("p0", a)),
+            ),
+        )
+    }
+
+    @Suppress("KUERY_UNSAFE_SQL_STRING")
+    @Test
+    fun `trimIndent on a variable falls back to runtime trimming`() {
+        val s = "\n    SELECT 1\n"
+        val sql = Sql {
+            add(s.trimIndent())
+        }
+        assertThat(sql).isEqualTo(Sql("SELECT 1"))
+    }
+
+    @Test
+    fun `trimIndent inside a when branch`() {
+        val a = "A"
+
+        fun build(flag: Boolean) = Sql {
+            add(
+                when (flag) {
+                    true ->
+                        """
+                        SELECT *
+                        WHERE id = $a
+                        """.trimIndent()
+                    false -> "SELECT 1"
+                },
+            )
+        }
+        assertThat(build(true)).isEqualTo(
+            Sql(
+                "SELECT *\nWHERE id = :p0",
+                listOf(NamedSqlParameter("p0", a)),
+            ),
+        )
+        assertThat(build(false)).isEqualTo(Sql("SELECT 1"))
+    }
+
+    @Test
+    fun `nested add inside an interpolation value of a trimmed template`() {
+        val x = "X"
+        val sql = Sql {
+            +"""
+            A ${run {
+                add("B $x")
+                "v"
+            }}
+            """.trimIndent()
+        }
+        // The inner add runs first while the outer template's values are being evaluated,
+        // then the outer (folded) template binds the run block's result as a single value.
+        assertThat(sql).isEqualTo(
+            Sql(
+                "B :p0\nA :p1",
+                listOf(NamedSqlParameter("p0", x), NamedSqlParameter("p1", "v")),
+            ),
+        )
+    }
+
+    @Test
+    fun `literal trimIndent inside an interpolation value stays a bound value`() {
+        val x = "X"
+        val sql = Sql {
+            +"a ${" x".trimIndent()} b $x"
+        }
+        // The trim call belongs to the value, so it must not be folded into SQL text.
+        assertThat(sql).isEqualTo(
+            Sql(
+                "a :p0 b :p1",
+                listOf(NamedSqlParameter("p0", "x"), NamedSqlParameter("p1", x)),
+            ),
+        )
+    }
+}

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrVariable
@@ -83,22 +84,32 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
         // the enclosing add/unaryPlus context: a nested add/unaryPlus inside a value must still be
         // rewritten (it sets up its own receiver), while a string template inside a value stays a
         // plain concatenation whose evaluated result is bound as a single value.
-        current = null
-        try {
+        withoutCurrent {
             expression.transformChildren(this, null)
+        }
+
+        val (fragments, values) = StringConcatenationProcessor.process(expression.arguments)
+        return irInterpolateCall(irBuilder(expression), enclosing, fragments, values)
+    }
+
+    // Transform an expression outside the enclosing add/unaryPlus context (see
+    // visitStringConcatenation for why values must be transformed without it).
+    private inline fun <T> withoutCurrent(block: () -> T): T {
+        val previous = current
+        current = null
+        return try {
+            block()
         } finally {
-            current = enclosing
+            current = previous
         }
+    }
 
-        val builder = irBuilder(expression)
-
-        val (fragments, values) = StringConcatenationProcessor(builder).process(expression.arguments).let {
-            Pair(
-                builder.irListOf(pluginContext.irBuiltIns.stringType, it.first),
-                builder.irListOf(pluginContext.irBuiltIns.anyType, it.second),
-            )
-        }
-
+    private fun irInterpolateCall(
+        builder: DeclarationIrBuilder,
+        enclosing: IrVariable,
+        fragments: List<String>,
+        values: List<IrExpression>,
+    ): IrExpression {
         val defaultSqlBuilderClass =
             checkNotNull(pluginContext.finderForBuiltins().findClass(ClassIds.DEFAULT_SQL_BUILDER))
         val interpolate = defaultSqlBuilderClass.functions.first { it.owner.name.asString() == "interpolate" }
@@ -109,8 +120,9 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
                 defaultSqlBuilderClass.typeWith(),
             )
             val regularParams = interpolate.owner.parameters.filter { it.kind == IrParameterKind.Regular }
-            arguments[regularParams[0]] = fragments
-            arguments[regularParams[1]] = values
+            arguments[regularParams[0]] =
+                builder.irListOf(pluginContext.irBuiltIns.stringType, fragments.map { builder.irString(it) })
+            arguments[regularParams[1]] = builder.irListOf(pluginContext.irBuiltIns.anyType, values)
         }
     }
 

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -4,6 +4,8 @@ import dev.hsbrysk.kuery.compiler.ir.misc.CallableIds
 import dev.hsbrysk.kuery.compiler.ir.misc.ClassIds
 import dev.hsbrysk.kuery.compiler.ir.misc.ClassNames
 import dev.hsbrysk.kuery.compiler.ir.misc.StringConcatenationProcessor
+import dev.hsbrysk.kuery.compiler.ir.misc.TrimFolding
+import dev.hsbrysk.kuery.compiler.ir.misc.TrimOperation
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
@@ -15,6 +17,8 @@ import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrConstKind
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrStringConcatenation
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
@@ -37,7 +41,7 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
 
     override fun visitCall(expression: IrCall): IrExpression {
         if (!expression.isAddOrUnaryPlus()) {
-            return super.visitCall(expression)
+            return foldTrimCallOrNull(expression) ?: super.visitCall(expression)
         }
 
         // Save/restore so that a nested add/unaryPlus inside the argument expression
@@ -90,6 +94,59 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
 
         val (fragments, values) = StringConcatenationProcessor.process(expression.arguments)
         return irInterpolateCall(irBuilder(expression), enclosing, fragments, values)
+    }
+
+    /**
+     * Folds a `trimIndent()` / `trimMargin(...)` call on a SQL string inside an add/unaryPlus
+     * argument at compile time, so no trim runs at runtime on the placeholder-interpolated
+     * string. Returns null when the call is not such a trim or when equivalence cannot be
+     * guaranteed (non-literal receiver or margin prefix, prefix that could match into `:pN`,
+     * etc.), in which case the caller leaves the call in place and it trims at runtime as
+     * before.
+     */
+    private fun foldTrimCallOrNull(expression: IrCall): IrExpression? {
+        val enclosing = current ?: return null
+        val operation = expression.trimOperationOrNull() ?: return null
+        val receiverParameter = expression.symbol.owner.parameters.firstOrNull {
+            it.kind == IrParameterKind.ExtensionReceiver
+        } ?: return null
+        return when (val receiver = expression.arguments[receiverParameter.indexInParameters]) {
+            is IrConst -> {
+                if (receiver.kind != IrConstKind.String) {
+                    return null
+                }
+                // A constant receiver has no values to bind; apply the trim directly. A failing
+                // trim (blank trimMargin prefix) must keep throwing at runtime, so fall back.
+                val folded = runCatching { operation.apply(receiver.value as String) }.getOrElse { return null }
+                irBuilder(expression).irString(folded)
+            }
+            is IrStringConcatenation -> {
+                // Check foldability on the arguments *before* transforming them, so that on
+                // fallback the IR is left completely untouched. The IrConst-or-not classification
+                // that `process` relies on is invariant under the transformation.
+                val (fragments, rawValues) = StringConcatenationProcessor.process(receiver.arguments)
+                val folded = TrimFolding.foldOrNull(fragments, rawValues.size, operation) ?: return null
+                // Same reasoning as in visitStringConcatenation: values are bound as parameters,
+                // so transform them outside the enclosing add/unaryPlus context.
+                val values = withoutCurrent { rawValues.map { it.transform(this, null) } }
+                irInterpolateCall(irBuilder(expression), enclosing, folded, values)
+            }
+            else -> null
+        }
+    }
+
+    private fun IrCall.trimOperationOrNull(): TrimOperation? = when (symbol.owner.fqNameWhenAvailable) {
+        TRIM_INDENT_FQ_NAME -> TrimOperation.TrimIndent
+        TRIM_MARGIN_FQ_NAME -> {
+            val prefixParameter = symbol.owner.parameters.first { it.kind == IrParameterKind.Regular }
+            when (val prefix = arguments[prefixParameter.indexInParameters]) {
+                // Omitted argument: the declaration's default, `"|"`.
+                null -> TrimOperation.TrimMargin("|")
+                is IrConst -> (prefix.value as? String)?.let { TrimOperation.TrimMargin(it) }
+                else -> null
+            }
+        }
+        else -> null
     }
 
     // Transform an expression outside the enclosing add/unaryPlus context (see
@@ -146,6 +203,9 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
     }
 
     companion object {
+        private val TRIM_INDENT_FQ_NAME = CallableIds.TRIM_INDENT.asSingleFqName()
+        private val TRIM_MARGIN_FQ_NAME = CallableIds.TRIM_MARGIN.asSingleFqName()
+
         // Identify the call by its resolved declaration, not by the receiver expression's static
         // type: the receiver may be typed as a type parameter bounded by SqlBuilder (e.g. a fluent
         // helper `fun <T : SqlBuilder> T.helper(): T`), and the rewrite must still apply.

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/StringInterpolationTransformer.kt
@@ -111,28 +111,42 @@ class StringInterpolationTransformer(private val pluginContext: IrPluginContext)
             it.kind == IrParameterKind.ExtensionReceiver
         } ?: return null
         return when (val receiver = expression.arguments[receiverParameter.indexInParameters]) {
-            is IrConst -> {
-                if (receiver.kind != IrConstKind.String) {
-                    return null
-                }
-                // A constant receiver has no values to bind; apply the trim directly. A failing
-                // trim (blank trimMargin prefix) must keep throwing at runtime, so fall back.
-                val folded = runCatching { operation.apply(receiver.value as String) }.getOrElse { return null }
-                irBuilder(expression).irString(folded)
-            }
-            is IrStringConcatenation -> {
-                // Check foldability on the arguments *before* transforming them, so that on
-                // fallback the IR is left completely untouched. The IrConst-or-not classification
-                // that `process` relies on is invariant under the transformation.
-                val (fragments, rawValues) = StringConcatenationProcessor.process(receiver.arguments)
-                val folded = TrimFolding.foldOrNull(fragments, rawValues.size, operation) ?: return null
-                // Same reasoning as in visitStringConcatenation: values are bound as parameters,
-                // so transform them outside the enclosing add/unaryPlus context.
-                val values = withoutCurrent { rawValues.map { it.transform(this, null) } }
-                irInterpolateCall(irBuilder(expression), enclosing, folded, values)
-            }
+            is IrConst -> foldConstReceiverOrNull(expression, receiver, operation)
+            is IrStringConcatenation -> foldTemplateReceiverOrNull(expression, receiver, operation, enclosing)
             else -> null
         }
+    }
+
+    private fun foldConstReceiverOrNull(
+        expression: IrCall,
+        receiver: IrConst,
+        operation: TrimOperation,
+    ): IrExpression? {
+        if (receiver.kind != IrConstKind.String) {
+            return null
+        }
+        // A constant receiver has no values to bind; apply the trim directly. A failing trim
+        // (blank trimMargin prefix) must keep throwing at runtime, so fall back.
+        return runCatching { operation.apply(receiver.value as String) }
+            .getOrNull()
+            ?.let { irBuilder(expression).irString(it) }
+    }
+
+    private fun foldTemplateReceiverOrNull(
+        expression: IrCall,
+        receiver: IrStringConcatenation,
+        operation: TrimOperation,
+        enclosing: IrVariable,
+    ): IrExpression? {
+        // Check foldability on the arguments *before* transforming them, so that on fallback the
+        // IR is left completely untouched. The IrConst-or-not classification that `process`
+        // relies on is invariant under the transformation.
+        val (fragments, rawValues) = StringConcatenationProcessor.process(receiver.arguments)
+        val folded = TrimFolding.foldOrNull(fragments, rawValues.size, operation) ?: return null
+        // Same reasoning as in visitStringConcatenation: values are bound as parameters, so
+        // transform them outside the enclosing add/unaryPlus context.
+        val values = withoutCurrent { rawValues.map { it.transform(this, null) } }
+        return irInterpolateCall(irBuilder(expression), enclosing, folded, values)
     }
 
     private fun IrCall.trimOperationOrNull(): TrimOperation? = when (symbol.owner.fqNameWhenAvailable) {

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/CallableIds.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/CallableIds.kt
@@ -6,4 +6,6 @@ import org.jetbrains.kotlin.name.Name
 
 internal object CallableIds {
     val LIST_OF = CallableId(FqName("kotlin.collections"), Name.identifier("listOf"))
+    val TRIM_INDENT = CallableId(FqName("kotlin.text"), Name.identifier("trimIndent"))
+    val TRIM_MARGIN = CallableId(FqName("kotlin.text"), Name.identifier("trimMargin"))
 }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/StringConcatenationProcessor.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/StringConcatenationProcessor.kt
@@ -1,15 +1,13 @@
 package dev.hsbrysk.kuery.compiler.ir.misc
 
-import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
-import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstKind
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 
-internal class StringConcatenationProcessor(private val builder: IrBuilderWithScope) {
+internal object StringConcatenationProcessor {
     // first: fragments, second: values
-    fun process(expressions: List<IrExpression>): Pair<List<IrExpression>, List<IrExpression>> {
-        val fragments = mutableListOf<IrExpression>()
+    fun process(expressions: List<IrExpression>): Pair<List<String>, List<IrExpression>> {
+        val fragments = mutableListOf<String>()
         val values = mutableListOf<IrExpression>()
 
         // K2 constant-folds `const val` references into standalone IrConst nodes without merging
@@ -22,13 +20,13 @@ internal class StringConcatenationProcessor(private val builder: IrBuilderWithSc
                 pending.append(text)
             } else {
                 // The reason for adding an empty string fragment can be found in `DefaultSqlBuilder.interpolate`.
-                fragments.add(builder.irString(pending.toString()))
+                fragments.add(pending.toString())
                 pending.clear()
                 values.add(expression)
             }
         }
         if (pending.isNotEmpty()) {
-            fragments.add(builder.irString(pending.toString()))
+            fragments.add(pending.toString())
         }
 
         return fragments to values

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/TrimFolding.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/TrimFolding.kt
@@ -35,17 +35,8 @@ internal object TrimFolding {
         valueCount: Int,
         operation: TrimOperation,
     ): List<String>? {
-        if (fragments.any { SENTINEL in it }) {
+        if (!isFoldable(fragments, operation)) {
             return null
-        }
-        if (operation is TrimOperation.TrimMargin) {
-            // A blank prefix throws IllegalArgumentException at runtime, which must be preserved.
-            // A prefix containing ':' can match into the runtime `:pN` placeholder text, in which
-            // case the sentinel stand-in would diverge from the runtime result.
-            val prefix = operation.marginPrefix
-            if (prefix.isBlank() || ':' in prefix || SENTINEL in prefix) {
-                return null
-            }
         }
 
         // Join in the same shape as DefaultSqlBuilder.interpolate: fragment, value, fragment, ...
@@ -57,14 +48,28 @@ internal object TrimFolding {
             fragments.drop(valueCount).forEach { append(it) }
         }
 
-        val trimmed = runCatching { operation.apply(joined) }.getOrElse { return null }
-
         // The trim functions only remove whitespace, the margin prefix, and blank first/last
-        // lines, none of which can contain the sentinel — but re-check defensively.
-        val folded = trimmed.split(SENTINEL)
-        if (folded.size != valueCount + 1) {
-            return null
+        // lines, none of which can contain the sentinel — but re-check the count defensively.
+        return runCatching { operation.apply(joined) }
+            .getOrNull()
+            ?.split(SENTINEL)
+            ?.takeIf { it.size == valueCount + 1 }
+    }
+
+    private fun isFoldable(
+        fragments: List<String>,
+        operation: TrimOperation,
+    ): Boolean {
+        if (fragments.any { SENTINEL in it }) {
+            return false
         }
-        return folded
+        // A blank prefix throws IllegalArgumentException at runtime, which must be preserved.
+        // A prefix containing ':' can match into the runtime `:pN` placeholder text, in which
+        // case the sentinel stand-in would diverge from the runtime result.
+        if (operation is TrimOperation.TrimMargin) {
+            val prefix = operation.marginPrefix
+            return prefix.isNotBlank() && ':' !in prefix && SENTINEL !in prefix
+        }
+        return true
     }
 }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/TrimFolding.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/TrimFolding.kt
@@ -1,0 +1,70 @@
+package dev.hsbrysk.kuery.compiler.ir.misc
+
+internal sealed interface TrimOperation {
+    fun apply(input: String): String
+
+    data object TrimIndent : TrimOperation {
+        override fun apply(input: String): String = input.trimIndent()
+    }
+
+    data class TrimMargin(val marginPrefix: String) : TrimOperation {
+        override fun apply(input: String): String = input.trimMargin(marginPrefix)
+    }
+}
+
+/**
+ * Compile-time folding of `trimIndent()` / `trimMargin(...)` applied to an interpolated SQL
+ * template. At runtime the interpolated values are replaced by `:pN` placeholders, which contain
+ * neither newlines nor whitespace, so per-line leading whitespace and blank-line detection — all
+ * that the trim functions look at — are fully determined by the constant fragments. The trim
+ * result can therefore be computed at compile time by standing in a single non-whitespace
+ * sentinel character for each value, applying the stdlib trim to the joined string, and splitting
+ * it back into fragments.
+ */
+internal object TrimFolding {
+    // NUL never appears in realistic SQL text and is not whitespace, so lines containing a value
+    // stay non-blank exactly like their runtime `:pN` counterparts.
+    private const val SENTINEL = '\u0000'
+
+    /**
+     * Returns the folded fragments (`valueCount + 1` elements), or null when equivalence with the
+     * runtime behavior cannot be guaranteed and the caller must fall back to runtime trimming.
+     */
+    fun foldOrNull(
+        fragments: List<String>,
+        valueCount: Int,
+        operation: TrimOperation,
+    ): List<String>? {
+        if (fragments.any { SENTINEL in it }) {
+            return null
+        }
+        if (operation is TrimOperation.TrimMargin) {
+            // A blank prefix throws IllegalArgumentException at runtime, which must be preserved.
+            // A prefix containing ':' can match into the runtime `:pN` placeholder text, in which
+            // case the sentinel stand-in would diverge from the runtime result.
+            val prefix = operation.marginPrefix
+            if (prefix.isBlank() || ':' in prefix || SENTINEL in prefix) {
+                return null
+            }
+        }
+
+        // Join in the same shape as DefaultSqlBuilder.interpolate: fragment, value, fragment, ...
+        val joined = buildString {
+            repeat(valueCount) { index ->
+                append(fragments.getOrElse(index) { "" })
+                append(SENTINEL)
+            }
+            fragments.drop(valueCount).forEach { append(it) }
+        }
+
+        val trimmed = runCatching { operation.apply(joined) }.getOrElse { return null }
+
+        // The trim functions only remove whitespace, the margin prefix, and blank first/last
+        // lines, none of which can contain the sentinel — but re-check defensively.
+        val folded = trimmed.split(SENTINEL)
+        if (folded.size != valueCount + 1) {
+            return null
+        }
+        return folded
+    }
+}

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/TrimFoldingBytecodeTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/TrimFoldingBytecodeTest.kt
@@ -1,0 +1,155 @@
+package dev.hsbrysk.kuery.compiler
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+
+/**
+ * Proof that the compile-time trim folding actually fires: when a trimIndent/trimMargin call is
+ * folded, the generated classes no longer reference the stdlib trim function, so its name
+ * disappears from the constant pool. The fallback tests double as negative controls showing that
+ * this detection method is valid. Behavioral equivalence is covered by the functional-test
+ * module's TrimFoldingTest.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+class TrimFoldingBytecodeTest {
+    @Test
+    fun `trimIndent on an interpolated template is folded away`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(id: Int) = Sql {
+                add(
+                    ${TRIPLE_QUOTE}
+                    SELECT * FROM users
+                    WHERE id = ${'$'}id
+                    ${TRIPLE_QUOTE}.trimIndent(),
+                )
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.classesReference("trimIndent")).isFalse()
+    }
+
+    @Test
+    fun `trimIndent via unaryPlus is folded away`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(id: Int) = Sql {
+                +${TRIPLE_QUOTE}
+                SELECT * FROM users
+                WHERE id = ${'$'}id
+                ${TRIPLE_QUOTE}.trimIndent()
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.classesReference("trimIndent")).isFalse()
+    }
+
+    @Test
+    fun `trimIndent on a constant string is folded away`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query() = Sql {
+                add(
+                    ${TRIPLE_QUOTE}
+                    SELECT * FROM users
+                    ${TRIPLE_QUOTE}.trimIndent(),
+                )
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.classesReference("trimIndent")).isFalse()
+    }
+
+    @Test
+    fun `trimMargin with a literal prefix is folded away`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(id: Int) = Sql {
+                add(
+                    ${TRIPLE_QUOTE}
+                    |SELECT * FROM users
+                    |WHERE id = ${'$'}id
+                    ${TRIPLE_QUOTE}.trimMargin(),
+                )
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.classesReference("trimMargin")).isFalse()
+    }
+
+    @Test
+    fun `trimMargin with a colon prefix falls back and stays in bytecode`() {
+        // Negative control: the fallback must keep the runtime call, which also proves that
+        // the constant-pool scan used by these tests can detect the reference at all.
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(id: Int) = Sql {
+                add(
+                    ${TRIPLE_QUOTE}
+                    :x = ${'$'}id
+                    ${TRIPLE_QUOTE}.trimMargin(":"),
+                )
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.classesReference("trimMargin")).isTrue()
+    }
+
+    @Test
+    fun `trimIndent on a variable falls back and stays in bytecode`() {
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            @Suppress("KUERY_UNSAFE_SQL_STRING")
+            fun query(s: String) = Sql {
+                add(s.trimIndent())
+            }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.classesReference("trimIndent")).isTrue()
+    }
+
+    private fun compile(source: String): JvmCompilationResult = KotlinCompilation().apply {
+        sources = listOf(SourceFile.kotlin("Sample.kt", source))
+        commandLineProcessors = listOf(KueryClientCompilerCommandLineProcessor())
+        compilerPluginRegistrars = listOf(KueryClientCompilerPluginRegistrar())
+        inheritClassPath = true
+        verbose = false
+    }.compile()
+
+    // The constant pool stores referenced method names as plain modified-UTF-8 entries, so a
+    // simple byte scan is enough to tell whether any generated class still calls the function.
+    private fun JvmCompilationResult.classesReference(name: String): Boolean = outputDirectory
+        .walkTopDown()
+        .filter { it.isFile && it.extension == "class" }
+        .also { check(it.any()) { "no classes were generated" } }
+        .any { String(it.readBytes(), Charsets.ISO_8859_1).contains(name) }
+
+    companion object {
+        private const val TRIPLE_QUOTE = "\"\"\""
+    }
+}

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/TrimFoldingTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/TrimFoldingTest.kt
@@ -1,0 +1,157 @@
+package dev.hsbrysk.kuery.compiler.ir.misc
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import org.junit.jupiter.api.Test
+
+class TrimFoldingTest {
+    @Test
+    fun `trimIndent with values mid-line`() {
+        assertFoldsLikeRuntime(
+            fragments = listOf("\n                UPDATE user\n                SET name = ", "\n                "),
+            valueCount = 1,
+            operation = TrimOperation.TrimIndent,
+        )
+    }
+
+    @Test
+    fun `trimIndent with a value at line start`() {
+        assertFoldsLikeRuntime(
+            fragments = listOf("\n    ", " AND foo\n    bar\n"),
+            valueCount = 1,
+            operation = TrimOperation.TrimIndent,
+        )
+    }
+
+    @Test
+    fun `trimIndent with a trailing value`() {
+        // fragments.size == valueCount (no trailing fragment)
+        assertFoldsLikeRuntime(
+            fragments = listOf("\n  SELECT *\n  WHERE id = "),
+            valueCount = 1,
+            operation = TrimOperation.TrimIndent,
+        )
+    }
+
+    @Test
+    fun `trimIndent with consecutive values and blank lines`() {
+        assertFoldsLikeRuntime(
+            fragments = listOf("\n   a ", "", "\n\n   b\n   "),
+            valueCount = 3,
+            operation = TrimOperation.TrimIndent,
+        )
+    }
+
+    @Test
+    fun `trimIndent with blank first and last lines`() {
+        assertFoldsLikeRuntime(
+            fragments = listOf("   \n  x = ", "\n   \t"),
+            valueCount = 1,
+            operation = TrimOperation.TrimIndent,
+        )
+    }
+
+    @Test
+    fun `trimIndent with no values`() {
+        assertFoldsLikeRuntime(
+            fragments = listOf("\n  SELECT *\n  FROM user\n"),
+            valueCount = 0,
+            operation = TrimOperation.TrimIndent,
+        )
+    }
+
+    @Test
+    fun `trimIndent single line`() {
+        assertFoldsLikeRuntime(
+            fragments = listOf("  SELECT ", ""),
+            valueCount = 1,
+            operation = TrimOperation.TrimIndent,
+        )
+    }
+
+    @Test
+    fun `trimMargin with default prefix`() {
+        assertFoldsLikeRuntime(
+            fragments = listOf("\n      |SELECT *\n      |WHERE id = ", "\n      "),
+            valueCount = 1,
+            operation = TrimOperation.TrimMargin("|"),
+        )
+    }
+
+    @Test
+    fun `trimMargin with custom prefix`() {
+        assertFoldsLikeRuntime(
+            fragments = listOf("\n      > SELECT *\n      > WHERE id = ", "\n      "),
+            valueCount = 1,
+            operation = TrimOperation.TrimMargin("> "),
+        )
+    }
+
+    @Test
+    fun `trimMargin with lines lacking the prefix`() {
+        assertFoldsLikeRuntime(
+            fragments = listOf("\n  |a = ", "\n  no margin here\n  |b\n"),
+            valueCount = 1,
+            operation = TrimOperation.TrimMargin("|"),
+        )
+    }
+
+    @Test
+    fun `trimMargin with a blank prefix falls back`() {
+        assertThat(
+            TrimFolding.foldOrNull(listOf("a"), 0, TrimOperation.TrimMargin(" ")),
+        ).isNull()
+    }
+
+    @Test
+    fun `trimMargin with a colon prefix falls back`() {
+        assertThat(
+            TrimFolding.foldOrNull(listOf("\n:a = ", "\n"), 1, TrimOperation.TrimMargin(":")),
+        ).isNull()
+    }
+
+    @Test
+    fun `trimMargin with a sentinel prefix falls back`() {
+        assertThat(
+            TrimFolding.foldOrNull(listOf("a"), 0, TrimOperation.TrimMargin("\u0000")),
+        ).isNull()
+    }
+
+    @Test
+    fun `fragment containing the sentinel falls back`() {
+        assertThat(
+            TrimFolding.foldOrNull(listOf("a\u0000b"), 0, TrimOperation.TrimIndent),
+        ).isNull()
+    }
+
+    /**
+     * The correctness contract: rendering `:pN` placeholders into the *folded* fragments must
+     * produce exactly the same string as applying the trim function at runtime to the string
+     * rendered from the *original* fragments.
+     */
+    private fun assertFoldsLikeRuntime(
+        fragments: List<String>,
+        valueCount: Int,
+        operation: TrimOperation,
+    ) {
+        val runtimeResult = operation.apply(render(fragments, valueCount))
+        val folded = checkNotNull(TrimFolding.foldOrNull(fragments, valueCount, operation)) {
+            "expected folding to succeed for $fragments"
+        }
+        assertThat(folded.size).isEqualTo(valueCount + 1)
+        assertThat(render(folded, valueCount)).isEqualTo(runtimeResult)
+    }
+
+    // Same shape as DefaultSqlBuilder.interpolate with placeholder text substituted for values.
+    private fun render(
+        fragments: List<String>,
+        valueCount: Int,
+    ): String = buildString {
+        repeat(valueCount) { index ->
+            append(fragments.getOrElse(index) { "" })
+            append(":p").append(index)
+        }
+        fragments.drop(valueCount).forEach { append(it) }
+    }
+}


### PR DESCRIPTION
## Summary

`+"""..."""​.trimIndent()` previously left the `trimIndent()` call in the compiled code, so it ran on every execution against the placeholder-interpolated string. Since the fragments are compile-time constants and `:pN` placeholders contain neither newlines nor whitespace, the trim result is fully determined at compile time. The compiler plugin now folds it.

- **`TrimFolding`**: stands in a non-whitespace sentinel (NUL) for each interpolated value, applies the stdlib `trimIndent()`/`trimMargin(prefix)` to the joined string, and splits it back into fragments. This is strictly equivalent to the runtime behavior.
- **`StringInterpolationTransformer`**: when the argument of `add`/`unaryPlus` is a string template (or constant) wrapped in `trimIndent()`/`trimMargin(...)`, the trim call is dropped and the folded fragments are passed to `interpolate` directly.
- **Fallback**: every case whose equivalence cannot be guaranteed keeps the existing runtime behavior untouched — variable receivers, non-literal `trimMargin` arguments, blank prefixes (preserves the runtime `IllegalArgumentException`), prefixes containing `:` (could match into the runtime `:pN` text), and fragments containing the sentinel.

No changes to `DefaultSqlBuilder.interpolate` (effectively public ABI), the FIR checker, or the core module.

## Tests

- `TrimFoldingTest` (compiler, unit): folded fragments rendered with `:pN` match the stdlib trim applied to the runtime string, plus all fallback guards.
- `TrimFoldingTest` (functional-test, real plugin under `-Xverify-ir=error`): behavioral equivalence for folded and fallback cases, including nested `add` inside interpolation values and `when` branches.
- `TrimFoldingBytecodeTest`: proves the folding actually fires — generated classes contain no constant-pool reference to `trimIndent`/`trimMargin`; fallback cases double as negative controls validating the scan itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)