### PR TITLE
Pin core interpolation and bind() contracts in tests

### DIFF
--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
@@ -127,6 +127,64 @@ class SqlTest {
     }
 
     @Test
+    fun `select in empty collection`() {
+        // An empty collection is NOT expanded at the core level. It is bound as a single
+        // parameter whose value is the empty collection; what happens next is up to the
+        // executing layer (e.g. Spring's named parameter expansion).
+        val emptyIds = emptyList<Int>()
+        val sql = Sql {
+            +"SELECT *"
+            +"FROM user"
+            +"WHERE id IN ($emptyIds)"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                """
+                SELECT *
+                FROM user
+                WHERE id IN (:p0)
+                """.trimIndent(),
+                listOf(
+                    NamedSqlParameter("p0", emptyIds),
+                ),
+            ),
+        )
+
+        val emptyIdSet = emptySet<Int>()
+        val sql2 = Sql {
+            +"SELECT * FROM user WHERE id IN ($emptyIdSet)"
+        }
+        assertThat(sql2).isEqualTo(
+            Sql(
+                "SELECT * FROM user WHERE id IN (:p0)",
+                listOf(
+                    NamedSqlParameter("p0", emptyIdSet),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `placeholder immediately followed by a cast suffix`() {
+        // PostgreSQL style casts like `$value::jsonb` must keep the cast suffix verbatim
+        // right after the generated placeholder.
+        val json = """{"theme":"dark"}"""
+        val id = "id"
+        val sql = Sql {
+            +"UPDATE user SET settings = $json::jsonb WHERE id = $id::uuid"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                "UPDATE user SET settings = :p0::jsonb WHERE id = :p1::uuid",
+                listOf(
+                    NamedSqlParameter("p0", json),
+                    NamedSqlParameter("p1", id),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `insert multi`() {
         data class User(
             val name: String,
@@ -191,6 +249,36 @@ class SqlTest {
                 listOf(
                     NamedSqlParameter("p0", filter.id),
                     NamedSqlParameter("p1", filter.age),
+                ),
+            ),
+        )
+    }
+
+    @Suppress("KUERY_UNSAFE_SQL_STRING")
+    @Test
+    fun `mixing interpolation and manual bind`() {
+        // Interpolation and manual bind() share a single parameter counter, so numbering
+        // never collides. Binding the same value twice yields two distinct parameters.
+        val userId = "user1"
+        val mask = 0b0100
+        val age = 18
+        val sql = Sql {
+            +"SELECT * FROM user WHERE id = $userId"
+            addUnsafe("AND permission & ${bind(mask)} = ${bind(mask)}")
+            +"AND age = $age"
+        }
+        assertThat(sql).isEqualTo(
+            Sql(
+                """
+                SELECT * FROM user WHERE id = :p0
+                AND permission & :p1 = :p2
+                AND age = :p3
+                """.trimIndent(),
+                listOf(
+                    NamedSqlParameter("p0", userId),
+                    NamedSqlParameter("p1", mask),
+                    NamedSqlParameter("p2", mask),
+                    NamedSqlParameter("p3", age),
                 ),
             ),
         )

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderTest.kt
@@ -95,6 +95,33 @@ class DefaultSqlBuilderTest {
     }
 
     @Test
+    fun bindSameValueTwice() {
+        DefaultSqlBuilder()
+            .apply {
+                assertThat(bind(1)).isEqualTo(":p0")
+                assertThat(bind(1)).isEqualTo(":p1")
+            }
+            .build()
+            .let {
+                assertThat(it).isEqualTo(Sql("", listOf(NamedSqlParameter("p0", 1), NamedSqlParameter("p1", 1))))
+            }
+    }
+
+    @Test
+    fun bindCollection() {
+        // A collection is bound as a single parameter holding the collection itself.
+        val ids = listOf(1, 2, 3)
+        DefaultSqlBuilder()
+            .apply {
+                assertThat(bind(ids)).isEqualTo(":p0")
+            }
+            .build()
+            .let {
+                assertThat(it).isEqualTo(Sql("", listOf(NamedSqlParameter("p0", ids))))
+            }
+    }
+
+    @Test
     fun buildIsNotAffectedByLaterBind() {
         val builder = DefaultSqlBuilder().apply {
             addUnsafe("SELECT * FROM some_table WHERE id = ${bind(1)}")


### PR DESCRIPTION
## Summary

Adds tests for core-level contracts that downstream users depend on when hand-building SQL fragments with `bind()` / `addUnsafe()`, but that had no test coverage:

- **Empty collection interpolation** (`IN ($emptyList)`): bound as a single parameter holding the empty collection, with no expansion at the core level. Expansion (and whether the resulting SQL is valid) is the executing layer's concern.
- **Cast suffix right after a placeholder** (`$x::jsonb`): the `::jsonb` fragment is kept verbatim right after the generated placeholder, producing `:p0::jsonb`.
- **Mixing interpolation and manual `bind()`** in one block: both share a single parameter counter, so numbering never collides; binding the same value twice yields two distinct parameters (`:p1`, `:p2`).
- **`bind(collection)`**: a whole collection passed to one `bind()` call becomes a single parameter.

These patterns are used in production by consumers of this library (hand-built tuple `IN` clauses, PostgreSQL casts on JSON columns, bitmask predicates binding the same value twice), so this pins them as explicit contracts.

## Test plan

- `./gradlew :kuery-client-core:test :kuery-client-compiler:functional-test:test` (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)