### PR TITLE
Add integration tests for parameter binding edge cases

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CollectionConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CollectionConversionTest.kt
@@ -2,6 +2,7 @@ package dev.hsbrysk.kuery.spring.jdbc
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.DelicateKueryClientApi
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -72,6 +73,62 @@ class CollectionConversionTest {
             +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"
         }.listMap()
         assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1")))
+    }
+
+    @Test
+    fun testEmptyCollection() {
+        // An empty collection is bound as-is; Spring's named parameter expansion then renders
+        // it as `IN ()`. Whether that is valid SQL depends on the database: H2 accepts it and
+        // returns no rows, while MySQL/PostgreSQL reject it (see the mysql/postgres packages).
+        // Callers targeting those databases must guard against empty collections themselves.
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES ('text1')"
+        }.rowsUpdated()
+
+        val result = kueryClient.sql {
+            val emptyIds = emptyList<Long>()
+            +"SELECT * FROM converter WHERE id IN ($emptyIds)"
+        }.listMap()
+        assertThat(result).isEqualTo(emptyList())
+    }
+
+    @OptIn(DelicateKueryClientApi::class)
+    @Test
+    fun testHandBuiltTupleIn() {
+        kueryClient.sql {
+            +"""
+            INSERT INTO converter (text) VALUES
+            ('text1'),
+            ('text2'),
+            ('text3');
+            """.trimIndent()
+        }.rowsUpdated()
+
+        val pairs = listOf(1L to "text1", 3L to "text3")
+        val result = kueryClient.sql {
+            +"SELECT * FROM converter"
+            addUnsafe("WHERE (id, text) IN (${pairs.joinToString(", ") { "(${bind(it.first)}, ${bind(it.second)})" }})")
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 3L, "text" to "text3")))
+    }
+
+    @OptIn(DelicateKueryClientApi::class)
+    @Test
+    fun testBindCollectionViaAddUnsafe() {
+        kueryClient.sql {
+            +"""
+            INSERT INTO converter (text) VALUES
+            ('text1'),
+            ('text2'),
+            ('text3');
+            """.trimIndent()
+        }.rowsUpdated()
+
+        val result = kueryClient.sql {
+            val texts = listOf("text1", "text2")
+            addUnsafe("SELECT * FROM converter WHERE text IN (${bind(texts)})")
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
     }
 
     companion object {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlByteArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlByteArrayBindingTest.kt
@@ -1,0 +1,67 @@
+package dev.hsbrysk.kuery.spring.jdbc.mysql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.single
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * A ByteArray must be bound as a single binary value (e.g. `BINARY(16)` keys), never expanded
+ * like a collection.
+ */
+class MySqlByteArrayBindingTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        mysql.jdbcClient.sql(
+            """
+            CREATE TABLE binaries (
+                id BINARY(16) PRIMARY KEY,
+                data VARBINARY(255) NOT NULL
+            )
+            """.trimIndent(),
+        ).update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mysql.jdbcClient.sql("DROP TABLE binaries").update()
+    }
+
+    @Test
+    fun `bind ByteArray as a single binary value`() {
+        val id = ByteArray(16) { it.toByte() }
+        val data = byteArrayOf(1, 2, 3)
+
+        val inserted = kueryClient
+            .sql { +"INSERT INTO binaries (id, data) VALUES ($id, $data)" }
+            .rowsUpdated()
+        assertThat(inserted).isEqualTo(1L)
+
+        val stored = kueryClient
+            .sql { +"SELECT data FROM binaries WHERE id = $id" }
+            .single<ByteArray>()
+        assertThat(stored.toList()).isEqualTo(data.toList())
+    }
+
+    @Test
+    fun `bind the same ByteArray twice in one statement`() {
+        val id = ByteArray(16) { it.toByte() }
+        val data = byteArrayOf(1, 2, 3)
+        kueryClient
+            .sql { +"INSERT INTO binaries (id, data) VALUES ($id, $data)" }
+            .rowsUpdated()
+
+        val count = kueryClient
+            .sql { +"SELECT COUNT(*) FROM binaries WHERE id = $id AND data = $data AND data = $data" }
+            .single<Long>()
+        assertThat(count).isEqualTo(1L)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlEmptyCollectionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlEmptyCollectionTest.kt
@@ -1,0 +1,29 @@
+package dev.hsbrysk.kuery.spring.jdbc.mysql
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.BadSqlGrammarException
+
+/**
+ * An empty collection is expanded to `IN ()` by Spring's named parameter handling, which MySQL
+ * rejects as a syntax error (unlike H2, which accepts it and returns no rows). This pins the
+ * behavior; callers must guard against empty collections themselves.
+ */
+class MySqlEmptyCollectionTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @Test
+    fun `empty collection in IN clause is rejected`() {
+        assertFailure {
+            kueryClient.sql {
+                val emptyIds = emptyList<Long>()
+                +"SELECT 1 FROM DUAL WHERE 1 IN ($emptyIds)"
+            }.listMap()
+        }.isInstanceOf(BadSqlGrammarException::class)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresCastBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresCastBindingTest.kt
@@ -1,0 +1,62 @@
+package dev.hsbrysk.kuery.spring.jdbc.postgres
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * PostgreSQL cast syntax (`::jsonb`, `::uuid`, ...) placed right after an interpolated value
+ * relies on Spring's named parameter parsing keeping the `::` suffix intact after the generated
+ * placeholder (`:p0::jsonb`). This pins that contract against a real PostgreSQL.
+ */
+class PostgresCastBindingTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        postgres.jdbcClient.sql(
+            """
+            CREATE TABLE cast_targets (
+                id UUID PRIMARY KEY,
+                settings JSONB,
+                created_at TIMESTAMPTZ
+            )
+            """.trimIndent(),
+        ).update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        postgres.jdbcClient.sql("DROP TABLE cast_targets").update()
+    }
+
+    @Test
+    fun `casts right after placeholders are kept intact`() {
+        val id = "0f14d0ab-9605-4a62-a9e4-5ed26688389b"
+        val settings = """{"theme": "dark"}"""
+        val createdAt = "2026-01-01 00:00:00+00"
+
+        val inserted = kueryClient
+            .sql {
+                +"INSERT INTO cast_targets (id, settings, created_at)"
+                +"VALUES ($id::uuid, $settings::jsonb, $createdAt::timestamptz)"
+            }
+            .rowsUpdated()
+        assertThat(inserted).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql {
+                +"SELECT id::text AS id, settings::text AS settings FROM cast_targets"
+                +"WHERE id = $id::uuid AND created_at = $createdAt::timestamptz"
+            }
+            .singleMap()
+        assertThat(record["id"]).isEqualTo(id)
+        assertThat(record["settings"]).isEqualTo(settings)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresEmptyCollectionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresEmptyCollectionTest.kt
@@ -1,0 +1,29 @@
+package dev.hsbrysk.kuery.spring.jdbc.postgres
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.BadSqlGrammarException
+
+/**
+ * An empty collection is expanded to `IN ()` by Spring's named parameter handling, which
+ * PostgreSQL rejects as a syntax error (unlike H2, which accepts it and returns no rows). This
+ * pins the behavior; callers must guard against empty collections themselves.
+ */
+class PostgresEmptyCollectionTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @Test
+    fun `empty collection in IN clause is rejected`() {
+        assertFailure {
+            kueryClient.sql {
+                val emptyIds = emptyList<Long>()
+                +"SELECT 1 WHERE 1 IN ($emptyIds)"
+            }.listMap()
+        }.isInstanceOf(BadSqlGrammarException::class)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CollectionConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CollectionConversionTest.kt
@@ -2,6 +2,7 @@ package dev.hsbrysk.kuery.spring.r2dbc
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.DelicateKueryClientApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -73,6 +74,62 @@ class CollectionConversionTest {
             +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"
         }.listMap()
         assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1")))
+    }
+
+    @Test
+    fun testEmptyCollection() = runTest {
+        // An empty collection is bound as-is; Spring's named parameter expansion then renders
+        // it as `IN ()`. Whether that is valid SQL depends on the database: H2 accepts it and
+        // returns no rows, while MySQL/PostgreSQL reject it (see the mysql/postgres packages).
+        // Callers targeting those databases must guard against empty collections themselves.
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES ('text1')"
+        }.rowsUpdated()
+
+        val result = kueryClient.sql {
+            val emptyIds = emptyList<Long>()
+            +"SELECT * FROM converter WHERE id IN ($emptyIds)"
+        }.listMap()
+        assertThat(result).isEqualTo(emptyList())
+    }
+
+    @OptIn(DelicateKueryClientApi::class)
+    @Test
+    fun testHandBuiltTupleIn() = runTest {
+        kueryClient.sql {
+            +"""
+            INSERT INTO converter (text) VALUES
+            ('text1'),
+            ('text2'),
+            ('text3');
+            """.trimIndent()
+        }.rowsUpdated()
+
+        val pairs = listOf(1L to "text1", 3L to "text3")
+        val result = kueryClient.sql {
+            +"SELECT * FROM converter"
+            addUnsafe("WHERE (id, text) IN (${pairs.joinToString(", ") { "(${bind(it.first)}, ${bind(it.second)})" }})")
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 3L, "text" to "text3")))
+    }
+
+    @OptIn(DelicateKueryClientApi::class)
+    @Test
+    fun testBindCollectionViaAddUnsafe() = runTest {
+        kueryClient.sql {
+            +"""
+            INSERT INTO converter (text) VALUES
+            ('text1'),
+            ('text2'),
+            ('text3');
+            """.trimIndent()
+        }.rowsUpdated()
+
+        val result = kueryClient.sql {
+            val texts = listOf("text1", "text2")
+            addUnsafe("SELECT * FROM converter WHERE text IN (${bind(texts)})")
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
     }
 
     companion object {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlByteArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlByteArrayBindingTest.kt
@@ -1,0 +1,70 @@
+package dev.hsbrysk.kuery.spring.r2dbc.mysql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.single
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * A ByteArray must be bound as a single binary value (e.g. `BINARY(16)` keys), never expanded
+ * like a collection. This is why ByteArray is excluded from the primitive-array boxing in
+ * DefaultSpringR2dbcKueryClient.
+ */
+class MySqlByteArrayBindingTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        mysql.databaseClient.sql(
+            """
+            CREATE TABLE binaries (
+                id BINARY(16) PRIMARY KEY,
+                data VARBINARY(255) NOT NULL
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        mysql.databaseClient.sql("DROP TABLE binaries").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `bind ByteArray as a single binary value`() = runTest {
+        val id = ByteArray(16) { it.toByte() }
+        val data = byteArrayOf(1, 2, 3)
+
+        val inserted = kueryClient
+            .sql { +"INSERT INTO binaries (id, data) VALUES ($id, $data)" }
+            .rowsUpdated()
+        assertThat(inserted).isEqualTo(1L)
+
+        val stored = kueryClient
+            .sql { +"SELECT data FROM binaries WHERE id = $id" }
+            .single<ByteArray>()
+        assertThat(stored.toList()).isEqualTo(data.toList())
+    }
+
+    @Test
+    fun `bind the same ByteArray twice in one statement`() = runTest {
+        val id = ByteArray(16) { it.toByte() }
+        val data = byteArrayOf(1, 2, 3)
+        kueryClient
+            .sql { +"INSERT INTO binaries (id, data) VALUES ($id, $data)" }
+            .rowsUpdated()
+
+        val count = kueryClient
+            .sql { +"SELECT COUNT(*) FROM binaries WHERE id = $id AND data = $data AND data = $data" }
+            .single<Long>()
+        assertThat(count).isEqualTo(1L)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlEmptyCollectionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlEmptyCollectionTest.kt
@@ -1,0 +1,30 @@
+package dev.hsbrysk.kuery.spring.r2dbc.mysql
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.BadSqlGrammarException
+
+/**
+ * An empty collection is expanded to `IN ()` by Spring's named parameter handling, which MySQL
+ * rejects as a syntax error (unlike H2, which accepts it and returns no rows). This pins the
+ * behavior; callers must guard against empty collections themselves.
+ */
+class MySqlEmptyCollectionTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @Test
+    fun `empty collection in IN clause is rejected`() = runTest {
+        assertFailure {
+            kueryClient.sql {
+                val emptyIds = emptyList<Long>()
+                +"SELECT 1 FROM DUAL WHERE 1 IN ($emptyIds)"
+            }.listMap()
+        }.isInstanceOf(BadSqlGrammarException::class)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
@@ -127,6 +127,60 @@ class PostgresArrayBindingTest {
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
+    @Test
+    fun `bind primitive long array to ANY predicate`() = runTest {
+        val userIds = longArrayOf(1, 2)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind primitive short array to ANY predicate`() = runTest {
+        val userIds = shortArrayOf(1, 2)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind primitive double array to ANY predicate`() = runTest {
+        val userIds = doubleArrayOf(1.0, 2.0)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind primitive float array to ANY predicate`() = runTest {
+        val userIds = floatArrayOf(1.0f, 2.0f)
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
+            .listMap()
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind primitive boolean array round-trips through select`() = runTest {
+        val flags = booleanArrayOf(true, false)
+        val record = kueryClient
+            .sql { +"SELECT $flags AS flags" }
+            .singleMap()
+        assertThat((record["flags"] as Array<*>).toList()).isEqualTo(listOf(true, false))
+    }
+
+    @Test
+    fun `bind primitive char array round-trips through select`() = runTest {
+        val chars = charArrayOf('a', 'b')
+        val record = kueryClient
+            .sql { +"SELECT $chars AS chars" }
+            .singleMap()
+        assertThat((record["chars"] as Array<*>).toList()).isEqualTo(listOf("a", "b"))
+    }
+
     companion object {
         private val postgres = PostgresTestContainer
     }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresCastBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresCastBindingTest.kt
@@ -1,0 +1,64 @@
+package dev.hsbrysk.kuery.spring.r2dbc.postgres
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * PostgreSQL cast syntax (`::jsonb`, `::uuid`, ...) placed right after an interpolated value
+ * relies on Spring's named parameter parsing keeping the `::` suffix intact after the generated
+ * placeholder (`:p0::jsonb`). This pins that contract against a real PostgreSQL.
+ */
+class PostgresCastBindingTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        postgres.databaseClient.sql(
+            """
+            CREATE TABLE cast_targets (
+                id UUID PRIMARY KEY,
+                settings JSONB,
+                created_at TIMESTAMPTZ
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        postgres.databaseClient.sql("DROP TABLE cast_targets").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `casts right after placeholders are kept intact`() = runTest {
+        val id = "0f14d0ab-9605-4a62-a9e4-5ed26688389b"
+        val settings = """{"theme": "dark"}"""
+        val createdAt = "2026-01-01 00:00:00+00"
+
+        val inserted = kueryClient
+            .sql {
+                +"INSERT INTO cast_targets (id, settings, created_at)"
+                +"VALUES ($id::uuid, $settings::jsonb, $createdAt::timestamptz)"
+            }
+            .rowsUpdated()
+        assertThat(inserted).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql {
+                +"SELECT id::text AS id, settings::text AS settings FROM cast_targets"
+                +"WHERE id = $id::uuid AND created_at = $createdAt::timestamptz"
+            }
+            .singleMap()
+        assertThat(record["id"]).isEqualTo(id)
+        assertThat(record["settings"]).isEqualTo(settings)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresEmptyCollectionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresEmptyCollectionTest.kt
@@ -1,0 +1,30 @@
+package dev.hsbrysk.kuery.spring.r2dbc.postgres
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.BadSqlGrammarException
+
+/**
+ * An empty collection is expanded to `IN ()` by Spring's named parameter handling, which
+ * PostgreSQL rejects as a syntax error (unlike H2, which accepts it and returns no rows). This
+ * pins the behavior; callers must guard against empty collections themselves.
+ */
+class PostgresEmptyCollectionTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @Test
+    fun `empty collection in IN clause is rejected`() = runTest {
+        assertFailure {
+            kueryClient.sql {
+                val emptyIds = emptyList<Long>()
+                +"SELECT 1 WHERE 1 IN ($emptyIds)"
+            }.listMap()
+        }.isInstanceOf(BadSqlGrammarException::class)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}


### PR DESCRIPTION
## Summary

- **Empty collection in an `IN` clause**: Spring's named parameter expansion renders it as `IN ()`. It turns out the outcome is database-dependent — H2 accepts it and returns no rows, while MySQL and PostgreSQL reject it with `BadSqlGrammarException`. New tests pin all three behaviors (H2 in `CollectionConversionTest`, real databases in the `mysql`/`postgres` packages). Callers targeting MySQL/PostgreSQL must guard against empty collections themselves; this may be worth documenting in the docs later.
- **Hand-built tuple `IN` clauses** (`(a, b) IN ((:p0, :p1), ...)`) composed from `bind()` return values via `addUnsafe()`, and a whole collection passed to a single `bind()` being expanded by Spring — the `@DelicateKueryClientApi` escape-hatch patterns used for dynamic SQL helpers.
- **PostgreSQL cast right after a placeholder** (`$x::uuid`, `$x::jsonb`, `$x::timestamptz`): verifies Spring's named parameter parsing keeps the `::` suffix intact against a real PostgreSQL (INSERT + SELECT round-trip).
- **ByteArray as a single binary value**: `BINARY(16)` key round-trip on MySQL, including binding the same ByteArray twice in one statement. This pins the reason ByteArray is excluded from the R2DBC primitive-array boxing.
- **Remaining R2DBC primitive-array boxing branches**: `DefaultSpringR2dbcKueryClient` boxes `LongArray`/`ShortArray`/`DoubleArray`/`FloatArray`/`BooleanArray`/`CharArray`, but only `IntArray` had a test. All branches are now exercised against PostgreSQL.

## Test plan

- `./gradlew :kuery-client-spring-data-jdbc:test :kuery-client-spring-data-r2dbc:test` with Docker running (Testcontainers MySQL/PostgreSQL) — all green (133 + 131 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)