### PR TITLE
Add observation tests for explicit sqlId and JDBC error paths

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ObservationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ObservationTest.kt
@@ -1,7 +1,9 @@
 package dev.hsbrysk.kuery.spring.jdbc
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import com.example.spring.jdbc.UserRepository
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationHandler
@@ -10,6 +12,8 @@ import io.micrometer.observation.tck.TestObservationRegistryAssert
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.dao.DataAccessException
+import org.springframework.dao.EmptyResultDataAccessException
 
 class ObservationTest {
     private val registry = TestObservationRegistry.create()
@@ -115,6 +119,41 @@ class ObservationTest {
             sqlId = "com.example.spring.jdbc.UserRepository.generatedValues",
             sql = "INSERT INTO users (username, email) VALUES (:p0, :p1)",
         )
+    }
+
+    @Test
+    fun `explicit sqlId overload propagates to the observation`() {
+        kueryClient.sql("my.explicit.sql.id") { +"SELECT * FROM users" }.listMap()
+        assertObservation(
+            sqlId = "my.explicit.sql.id",
+            sql = "SELECT * FROM users",
+        )
+    }
+
+    @Test
+    fun `records error when single result is missing`() {
+        assertFailure { userRepository.singleMap(999) }.isInstanceOf(EmptyResultDataAccessException::class)
+        TestObservationRegistryAssert.assertThat(registry)
+            .doesNotHaveAnyRemainingCurrentObservation()
+            .hasObservationWithNameEqualTo("kuery.client.fetches")
+            .that()
+            .hasBeenStarted()
+            .hasBeenStopped()
+            .hasError()
+    }
+
+    @Test
+    fun `records error when the sql execution fails`() {
+        assertFailure {
+            kueryClient.sql { +"SELECT * FROM missing_table" }.listMap()
+        }.isInstanceOf(DataAccessException::class)
+        TestObservationRegistryAssert.assertThat(registry)
+            .doesNotHaveAnyRemainingCurrentObservation()
+            .hasObservationWithNameEqualTo("kuery.client.fetches")
+            .that()
+            .hasBeenStarted()
+            .hasBeenStopped()
+            .hasError()
     }
 
     @Test

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationTest.kt
@@ -125,6 +125,15 @@ class ObservationTest {
     }
 
     @Test
+    fun `explicit sqlId overload propagates to the observation`() = runTest {
+        kueryClient.sql("my.explicit.sql.id") { +"SELECT * FROM users" }.listMap()
+        assertObservation(
+            sqlId = "my.explicit.sql.id",
+            sql = "SELECT * FROM users",
+        )
+    }
+
+    @Test
     fun `records error when single result is missing`() = runTest {
         assertFailure { userRepository.singleMap(999) }.isInstanceOf(EmptyResultDataAccessException::class)
         TestObservationRegistryAssert.assertThat(registry)


### PR DESCRIPTION
## Summary

Two observation-related coverage gaps:

- **`sql(sqlId, block)` explicit overload**: this public API had no test anywhere in the repo (the only caller was a JMH benchmark). New tests in both modules verify the explicitly passed sqlId propagates to the observation's `sql.id` low-cardinality tag.
- **JDBC error paths**: the R2DBC `ObservationTest` covers error recording (missing single result, failing SQL execution), but the JDBC side only covered success paths. This ports the same two error tests to the JDBC module, asserting `observation.error` is recorded and the observation is started/stopped cleanly. This matters for consumers whose `ObservationHandler.onStop` reads `context.error` to log the SQL body and parameters on failure.

## Test plan

- `./gradlew :kuery-client-spring-data-jdbc:test --tests "dev.hsbrysk.kuery.spring.jdbc.ObservationTest" :kuery-client-spring-data-r2dbc:test --tests "dev.hsbrysk.kuery.spring.r2dbc.ObservationTest"` (12 + 12 tests, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)