### PR TITLE
Add integration tests for values() type inference and upsert clauses

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlUpsertTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlUpsertTest.kt
@@ -1,0 +1,82 @@
+package dev.hsbrysk.kuery.spring.jdbc.mysql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.values
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * The values() DSL followed by MySQL upsert clauses. Note the affected-row count contract:
+ * MySQL reports 1 for an inserted row and 2 for an updated row of ON DUPLICATE KEY UPDATE.
+ */
+class MySqlUpsertTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        mysql.jdbcClient.sql(
+            """
+            CREATE TABLE upsert_users (
+                user_id INT PRIMARY KEY,
+                email VARCHAR(100) NOT NULL
+            )
+            """.trimIndent(),
+        ).update()
+        mysql.jdbcClient.sql("INSERT INTO upsert_users (user_id, email) VALUES (1, 'old@example.com')").update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mysql.jdbcClient.sql("DROP TABLE upsert_users").update()
+    }
+
+    @Test
+    fun `values followed by ON DUPLICATE KEY UPDATE with row alias`() {
+        val input = listOf(
+            listOf(1, "new1@example.com"),
+            listOf(2, "new2@example.com"),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO upsert_users (user_id, email)"
+            values(input)
+            +"AS new ON DUPLICATE KEY UPDATE email = new.email"
+        }.rowsUpdated()
+        // 2 for the updated row (user_id=1) + 1 for the inserted row (user_id=2)
+        assertThat(rowsUpdated).isEqualTo(3L)
+
+        assertUpserted()
+    }
+
+    @Test
+    fun `values followed by ON DUPLICATE KEY UPDATE with VALUES function`() {
+        // MySQL's VALUES(col) function (deprecated in 8.0.20 but widely used) shares its name
+        // with the values() DSL; they must not interfere.
+        val input = listOf(
+            listOf(1, "new1@example.com"),
+            listOf(2, "new2@example.com"),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO upsert_users (user_id, email)"
+            values(input)
+            +"ON DUPLICATE KEY UPDATE email = VALUES(email)"
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(3L)
+
+        assertUpserted()
+    }
+
+    private fun assertUpserted() {
+        val result = kueryClient
+            .sql { +"SELECT user_id, email FROM upsert_users ORDER BY user_id" }
+            .listMap()
+        assertThat(result.map { it["email"] }).isEqualTo(listOf("new1@example.com", "new2@example.com"))
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlValuesHelperTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlValuesHelperTest.kt
@@ -1,0 +1,54 @@
+package dev.hsbrysk.kuery.spring.jdbc.mysql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.values
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+/**
+ * Contrast to PostgresValuesHelperTest: MySQL does not infer VALUES parameter types per row, so
+ * mixing null and non-null rows on a typed column just works.
+ */
+class MySqlValuesHelperTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        mysql.jdbcClient.sql(
+            """
+            CREATE TABLE documents (
+                id INT PRIMARY KEY,
+                parent_id BINARY(16),
+                created_at DATETIME
+            )
+            """.trimIndent(),
+        ).update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mysql.jdbcClient.sql("DROP TABLE documents").update()
+    }
+
+    @Test
+    fun `values mixing null and non-null rows on typed columns`() {
+        val createdAt = LocalDateTime.of(2026, 1, 1, 0, 0, 0)
+        val input = listOf(
+            listOf(1, ByteArray(16) { it.toByte() }, createdAt),
+            listOf(2, null, null),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO documents (id, parent_id, created_at)"
+            values(input)
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(2L)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresUpsertTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresUpsertTest.kt
@@ -1,0 +1,58 @@
+package dev.hsbrysk.kuery.spring.jdbc.postgres
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.values
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * The values() DSL followed by PostgreSQL's ON CONFLICT DO UPDATE. Unlike MySQL, PostgreSQL
+ * reports 1 affected row per row regardless of insert vs update.
+ */
+class PostgresUpsertTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        postgres.jdbcClient.sql(
+            """
+            CREATE TABLE upsert_users (
+                user_id INT PRIMARY KEY,
+                email VARCHAR(100) NOT NULL
+            )
+            """.trimIndent(),
+        ).update()
+        postgres.jdbcClient.sql("INSERT INTO upsert_users (user_id, email) VALUES (1, 'old@example.com')").update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        postgres.jdbcClient.sql("DROP TABLE upsert_users").update()
+    }
+
+    @Test
+    fun `values followed by ON CONFLICT DO UPDATE`() {
+        val input = listOf(
+            listOf(1, "new1@example.com"),
+            listOf(2, "new2@example.com"),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO upsert_users (user_id, email)"
+            values(input)
+            +"ON CONFLICT (user_id) DO UPDATE SET email = EXCLUDED.email"
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(2L)
+
+        val result = kueryClient
+            .sql { +"SELECT user_id, email FROM upsert_users ORDER BY user_id" }
+            .listMap()
+        assertThat(result.map { it["email"] }).isEqualTo(listOf("new1@example.com", "new2@example.com"))
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresValuesHelperTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresValuesHelperTest.kt
@@ -2,8 +2,11 @@ package dev.hsbrysk.kuery.spring.jdbc.postgres
 
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.cause
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.messageContains
 import dev.hsbrysk.kuery.core.values
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -72,6 +75,30 @@ class PostgresValuesHelperTest {
             values(input)
         }.rowsUpdated()
         assertThat(rowsUpdated).isEqualTo(2L)
+    }
+
+    @Test
+    fun `values mixing conflicting parameter types in one column is rejected`() {
+        // PostgreSQL unifies the parameter types of a VALUES column across rows. A null is sent
+        // without type information and simply adopts the column type (see the test above), but
+        // a single String-typed row poisons the whole multi-row VALUES even when every other
+        // row is properly typed: the column's common type resolves to varchar and then fails
+        // against the uuid target column. (Historically this surfaced as "VALUES types
+        // character varying and uuid cannot be matched" on older driver/server combinations.)
+        val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        val input = listOf(
+            listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
+            listOf(UUID.randomUUID(), "0f14d0ab-9605-4a62-a9e4-5ed26688389b", createdAt),
+        )
+
+        assertFailure {
+            kueryClient.sql {
+                +"INSERT INTO documents (id, parent_id, created_at)"
+                values(input)
+            }.rowsUpdated()
+        }.isInstanceOf(BadSqlGrammarException::class)
+            .cause().isNotNull()
+            .messageContains("is of type uuid but expression is of type character varying")
     }
 
     @Test

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresValuesHelperTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresValuesHelperTest.kt
@@ -1,0 +1,94 @@
+package dev.hsbrysk.kuery.spring.jdbc.postgres
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import dev.hsbrysk.kuery.core.values
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.BadSqlGrammarException
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * How PostgreSQL's parameter type inference interacts with the values() helper:
+ *
+ * - Binding properly typed Java objects (java.util.UUID, OffsetDateTime, ...) works, including
+ *   rows that mix null and non-null values in the same column.
+ * - Binding Strings for typed columns (UUID, TIMESTAMPTZ, ...) is rejected, because the JDBC
+ *   driver declares string parameters as varchar and PostgreSQL does not implicitly cast them.
+ *   The workaround is an explicit cast right after the placeholder (see PostgresCastBindingTest),
+ *   which the values() helper cannot emit today.
+ */
+class PostgresValuesHelperTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        postgres.jdbcClient.sql(
+            """
+            CREATE TABLE documents (
+                id UUID PRIMARY KEY,
+                parent_id UUID,
+                created_at TIMESTAMPTZ NOT NULL
+            )
+            """.trimIndent(),
+        ).update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        postgres.jdbcClient.sql("DROP TABLE documents").update()
+    }
+
+    @Test
+    fun `values with non-null typed rows`() {
+        val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        val input = listOf(
+            listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
+            listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO documents (id, parent_id, created_at)"
+            values(input)
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(2L)
+    }
+
+    @Test
+    fun `values mixing null and non-null rows on a typed column`() {
+        val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        val input = listOf(
+            listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
+            listOf(UUID.randomUUID(), null, createdAt),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO documents (id, parent_id, created_at)"
+            values(input)
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(2L)
+    }
+
+    @Test
+    fun `values binding strings for typed columns is rejected`() {
+        val input = listOf(
+            listOf("0f14d0ab-9605-4a62-a9e4-5ed26688389b", null, "2026-01-01 00:00:00+00"),
+        )
+
+        assertFailure {
+            kueryClient.sql {
+                +"INSERT INTO documents (id, parent_id, created_at)"
+                values(input)
+            }.rowsUpdated()
+        }.isInstanceOf(BadSqlGrammarException::class)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlUpsertTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlUpsertTest.kt
@@ -1,0 +1,85 @@
+package dev.hsbrysk.kuery.spring.r2dbc.mysql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.values
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * The values() DSL followed by MySQL upsert clauses. Note the affected-row count contract:
+ * MySQL reports 1 for an inserted row and 2 for an updated row of ON DUPLICATE KEY UPDATE.
+ */
+class MySqlUpsertTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        mysql.databaseClient.sql(
+            """
+            CREATE TABLE upsert_users (
+                user_id INT PRIMARY KEY,
+                email VARCHAR(100) NOT NULL
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+        mysql.databaseClient.sql("INSERT INTO upsert_users (user_id, email) VALUES (1, 'old@example.com')")
+            .fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        mysql.databaseClient.sql("DROP TABLE upsert_users").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `values followed by ON DUPLICATE KEY UPDATE with row alias`() = runTest {
+        val input = listOf(
+            listOf(1, "new1@example.com"),
+            listOf(2, "new2@example.com"),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO upsert_users (user_id, email)"
+            values(input)
+            +"AS new ON DUPLICATE KEY UPDATE email = new.email"
+        }.rowsUpdated()
+        // 2 for the updated row (user_id=1) + 1 for the inserted row (user_id=2)
+        assertThat(rowsUpdated).isEqualTo(3L)
+
+        assertUpserted()
+    }
+
+    @Test
+    fun `values followed by ON DUPLICATE KEY UPDATE with VALUES function`() = runTest {
+        // MySQL's VALUES(col) function (deprecated in 8.0.20 but widely used) shares its name
+        // with the values() DSL; they must not interfere.
+        val input = listOf(
+            listOf(1, "new1@example.com"),
+            listOf(2, "new2@example.com"),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO upsert_users (user_id, email)"
+            values(input)
+            +"ON DUPLICATE KEY UPDATE email = VALUES(email)"
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(3L)
+
+        assertUpserted()
+    }
+
+    private suspend fun assertUpserted() {
+        val result = kueryClient
+            .sql { +"SELECT user_id, email FROM upsert_users ORDER BY user_id" }
+            .listMap()
+        assertThat(result.map { it["email"] }).isEqualTo(listOf("new1@example.com", "new2@example.com"))
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlValuesHelperTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlValuesHelperTest.kt
@@ -1,0 +1,56 @@
+package dev.hsbrysk.kuery.spring.r2dbc.mysql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.values
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+import java.time.LocalDateTime
+
+/**
+ * Contrast to PostgresValuesHelperTest: MySQL does not infer VALUES parameter types per row, so
+ * mixing null and non-null rows on a typed column just works.
+ */
+class MySqlValuesHelperTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        mysql.databaseClient.sql(
+            """
+            CREATE TABLE documents (
+                id INT PRIMARY KEY,
+                parent_id BINARY(16),
+                created_at DATETIME
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        mysql.databaseClient.sql("DROP TABLE documents").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `values mixing null and non-null rows on typed columns`() = runTest {
+        val createdAt = LocalDateTime.of(2026, 1, 1, 0, 0, 0)
+        val input = listOf(
+            listOf(1, ByteArray(16) { it.toByte() }, createdAt),
+            listOf(2, null, null),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO documents (id, parent_id, created_at)"
+            values(input)
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(2L)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresUpsertTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresUpsertTest.kt
@@ -1,0 +1,61 @@
+package dev.hsbrysk.kuery.spring.r2dbc.postgres
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.values
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * The values() DSL followed by PostgreSQL's ON CONFLICT DO UPDATE. Unlike MySQL, PostgreSQL
+ * reports 1 affected row per row regardless of insert vs update.
+ */
+class PostgresUpsertTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        postgres.databaseClient.sql(
+            """
+            CREATE TABLE upsert_users (
+                user_id INT PRIMARY KEY,
+                email VARCHAR(100) NOT NULL
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+        postgres.databaseClient.sql("INSERT INTO upsert_users (user_id, email) VALUES (1, 'old@example.com')")
+            .fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        postgres.databaseClient.sql("DROP TABLE upsert_users").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `values followed by ON CONFLICT DO UPDATE`() = runTest {
+        val input = listOf(
+            listOf(1, "new1@example.com"),
+            listOf(2, "new2@example.com"),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO upsert_users (user_id, email)"
+            values(input)
+            +"ON CONFLICT (user_id) DO UPDATE SET email = EXCLUDED.email"
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(2L)
+
+        val result = kueryClient
+            .sql { +"SELECT user_id, email FROM upsert_users ORDER BY user_id" }
+            .listMap()
+        assertThat(result.map { it["email"] }).isEqualTo(listOf("new1@example.com", "new2@example.com"))
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresValuesHelperTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresValuesHelperTest.kt
@@ -2,8 +2,11 @@ package dev.hsbrysk.kuery.spring.r2dbc.postgres
 
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.cause
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.messageContains
 import dev.hsbrysk.kuery.core.values
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -74,6 +77,30 @@ class PostgresValuesHelperTest {
             values(input)
         }.rowsUpdated()
         assertThat(rowsUpdated).isEqualTo(2L)
+    }
+
+    @Test
+    fun `values mixing conflicting parameter types in one column is rejected`() = runTest {
+        // PostgreSQL unifies the parameter types of a VALUES column across rows. A null is sent
+        // without type information and simply adopts the column type (see the test above), but
+        // a single String-typed row poisons the whole multi-row VALUES even when every other
+        // row is properly typed: the column's common type resolves to varchar and then fails
+        // against the uuid target column. (Historically this surfaced as "VALUES types
+        // character varying and uuid cannot be matched" on older driver/server combinations.)
+        val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        val input = listOf(
+            listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
+            listOf(UUID.randomUUID(), "0f14d0ab-9605-4a62-a9e4-5ed26688389b", createdAt),
+        )
+
+        assertFailure {
+            kueryClient.sql {
+                +"INSERT INTO documents (id, parent_id, created_at)"
+                values(input)
+            }.rowsUpdated()
+        }.isInstanceOf(BadSqlGrammarException::class)
+            .cause().isNotNull()
+            .messageContains("is of type uuid but expression is of type character varying")
     }
 
     @Test

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresValuesHelperTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresValuesHelperTest.kt
@@ -1,0 +1,96 @@
+package dev.hsbrysk.kuery.spring.r2dbc.postgres
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import dev.hsbrysk.kuery.core.values
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.BadSqlGrammarException
+import org.springframework.r2dbc.core.awaitRowsUpdated
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * How PostgreSQL's parameter type inference interacts with the values() helper:
+ *
+ * - Binding properly typed Java objects (java.util.UUID, OffsetDateTime, ...) works, including
+ *   rows that mix null and non-null values in the same column.
+ * - Binding Strings for typed columns (UUID, TIMESTAMPTZ, ...) is rejected, because the driver
+ *   declares string parameters as varchar and PostgreSQL does not implicitly cast them.
+ *   The workaround is an explicit cast right after the placeholder (see PostgresCastBindingTest),
+ *   which the values() helper cannot emit today.
+ */
+class PostgresValuesHelperTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        postgres.databaseClient.sql(
+            """
+            CREATE TABLE documents (
+                id UUID PRIMARY KEY,
+                parent_id UUID,
+                created_at TIMESTAMPTZ NOT NULL
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        postgres.databaseClient.sql("DROP TABLE documents").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `values with non-null typed rows`() = runTest {
+        val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        val input = listOf(
+            listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
+            listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO documents (id, parent_id, created_at)"
+            values(input)
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(2L)
+    }
+
+    @Test
+    fun `values mixing null and non-null rows on a typed column`() = runTest {
+        val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        val input = listOf(
+            listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
+            listOf(UUID.randomUUID(), null, createdAt),
+        )
+
+        val rowsUpdated = kueryClient.sql {
+            +"INSERT INTO documents (id, parent_id, created_at)"
+            values(input)
+        }.rowsUpdated()
+        assertThat(rowsUpdated).isEqualTo(2L)
+    }
+
+    @Test
+    fun `values binding strings for typed columns is rejected`() = runTest {
+        val input = listOf(
+            listOf("0f14d0ab-9605-4a62-a9e4-5ed26688389b", null, "2026-01-01 00:00:00+00"),
+        )
+
+        assertFailure {
+            kueryClient.sql {
+                +"INSERT INTO documents (id, parent_id, created_at)"
+                values(input)
+            }.rowsUpdated()
+        }.isInstanceOf(BadSqlGrammarException::class)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}


### PR DESCRIPTION
## Summary

Pins how the `values()` DSL interacts with PostgreSQL's parameter type inference, and with upsert clauses on both databases:

- **PostgreSQL + typed Java objects** (`java.util.UUID`, `OffsetDateTime`): works, **including rows mixing null and non-null values in the same column** — a null is sent without type information and adopts the column type, so the commonly feared inference failure does not occur on this path.
- **PostgreSQL + String values for typed columns** (UUID/TIMESTAMPTZ): rejected with `BadSqlGrammarException`, because string parameters are declared as varchar and PostgreSQL does not implicitly cast them. The workaround is an explicit `::uuid`-style cast right after the placeholder (see `PostgresCastBindingTest`), which `values()` cannot emit today — this is the concrete input for a future cast-aware `values()` API.
- **PostgreSQL + mixed parameter types across rows**: a single String-typed row poisons the whole multi-row VALUES even when every other row is properly typed — the column's common type resolves to varchar and then fails coercion against the uuid target column (`column ... is of type uuid but expression is of type character varying`). On older server/driver combinations this same conflict surfaced as `VALUES types character varying and uuid cannot be matched`; that exact message does not reproduce on PostgreSQL 16 + current pgjdbc/r2dbc drivers.
- **MySQL contrast**: mixing null and non-null rows on typed columns (BINARY, DATETIME) just works.
- **Upsert after `values()`**: MySQL `ON DUPLICATE KEY UPDATE` (both the 8.0 `AS new` row-alias form and the classic `VALUES(col)` function form, which shares its name with the DSL but does not interfere) and PostgreSQL `ON CONFLICT DO UPDATE`. Pins the `rowsUpdated()` contracts: MySQL reports 2 per updated row + 1 per inserted row; PostgreSQL reports 1 per row either way.

## Test plan

- `./gradlew :kuery-client-spring-data-jdbc:test :kuery-client-spring-data-r2dbc:test` with Docker (Testcontainers MySQL/PostgreSQL) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)