### PR TITLE
Add tests for converter registration edge cases

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ConverterRegistrationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ConverterRegistrationTest.kt
@@ -1,0 +1,121 @@
+package dev.hsbrysk.kuery.spring.jdbc
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.single
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.core.convert.TypeDescriptor
+import org.springframework.core.convert.converter.Converter
+import org.springframework.core.convert.converter.GenericConverter
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+
+/**
+ * Pins which converter registration styles are supported beyond plain annotated Converter pairs
+ * (see StringWrapperConversionTest) and ConverterFactory (see CodeEnumConversionTest).
+ *
+ * Note that reading converters for non-simple wrapper types apply on the DataClassRowMapper
+ * property path; reading a wrapper as a single scalar column is unsupported regardless of
+ * converter registration (see BasicUsageTest's unSupportNotSimpleProperty).
+ */
+class ConverterRegistrationTest {
+    data class StringWrapper(val value: String)
+
+    data class IntWrapper(val value: Int)
+
+    data class Record(val text: StringWrapper)
+
+    data class IntRecord(val num: IntWrapper)
+
+    @ReadingConverter
+    class StringToStringWrapperGenericConverter : GenericConverter {
+        override fun getConvertibleTypes(): Set<GenericConverter.ConvertiblePair> =
+            setOf(GenericConverter.ConvertiblePair(String::class.java, StringWrapper::class.java))
+
+        override fun convert(
+            source: Any?,
+            sourceType: TypeDescriptor,
+            targetType: TypeDescriptor,
+        ): Any = StringWrapper(source as String)
+    }
+
+    @ReadingConverter
+    class IntToIntWrapperGenericConverter : GenericConverter {
+        // Int::class.java (primitive int) would never match: JDBC values arrive boxed, so the
+        // pair must be registered with the boxed java.lang.Integer type (javaObjectType).
+        override fun getConvertibleTypes(): Set<GenericConverter.ConvertiblePair> =
+            setOf(GenericConverter.ConvertiblePair(Int::class.javaObjectType, IntWrapper::class.java))
+
+        override fun convert(
+            source: Any?,
+            sourceType: TypeDescriptor,
+            targetType: TypeDescriptor,
+        ): Any = IntWrapper(source as Int)
+    }
+
+    @WritingConverter
+    class StringWrapperToStringConverter : Converter<StringWrapper, String> {
+        override fun convert(source: StringWrapper): String = source.value
+    }
+
+    class UnannotatedStringWrapperToStringConverter : Converter<StringWrapper, String> {
+        override fun convert(source: StringWrapper): String = source.value
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        h2.setUpForConverterTest()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun `GenericConverter is supported for reading`() {
+        val kueryClient = h2.kueryClient(
+            listOf(StringToStringWrapperGenericConverter(), StringWrapperToStringConverter()),
+        )
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES ('hoge')"
+        }.rowsUpdated()
+
+        val record: Record = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.single()
+        assertThat(record.text).isEqualTo(StringWrapper("hoge"))
+    }
+
+    @Test
+    fun `GenericConverter for a Kotlin Int works via javaObjectType`() {
+        val kueryClient = h2.kueryClient(listOf(IntToIntWrapperGenericConverter()))
+
+        val record: IntRecord = kueryClient.sql {
+            +"SELECT CAST(42 AS INT) AS num"
+        }.single()
+        assertThat(record).isEqualTo(IntRecord(IntWrapper(42)))
+    }
+
+    @Test
+    fun `converter without annotation infers direction from the store-typed side`() {
+        // Converter<StringWrapper, String> targets a store type, so Spring infers it as a
+        // writing converter even without @WritingConverter.
+        val kueryClient = h2.kueryClient(listOf(UnannotatedStringWrapperToStringConverter()))
+
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${StringWrapper("hoge")})"
+        }.rowsUpdated()
+
+        val result = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single<String>()
+        assertThat(result).isEqualTo("hoge")
+    }
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ConverterRegistrationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ConverterRegistrationTest.kt
@@ -1,0 +1,122 @@
+package dev.hsbrysk.kuery.spring.r2dbc
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.single
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.core.convert.TypeDescriptor
+import org.springframework.core.convert.converter.Converter
+import org.springframework.core.convert.converter.GenericConverter
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+
+/**
+ * Pins which converter registration styles are supported beyond plain annotated Converter pairs
+ * (see StringWrapperConversionTest) and ConverterFactory (see CodeEnumConversionTest).
+ *
+ * Note that reading converters for non-simple wrapper types apply on the row-mapping property
+ * path; reading a wrapper as a single scalar column is unsupported regardless of converter
+ * registration (see BasicUsageTest's unSupportNotSimpleProperty).
+ */
+class ConverterRegistrationTest {
+    data class StringWrapper(val value: String)
+
+    data class IntWrapper(val value: Int)
+
+    data class Record(val text: StringWrapper)
+
+    data class IntRecord(val num: IntWrapper)
+
+    @ReadingConverter
+    class StringToStringWrapperGenericConverter : GenericConverter {
+        override fun getConvertibleTypes(): Set<GenericConverter.ConvertiblePair> =
+            setOf(GenericConverter.ConvertiblePair(String::class.java, StringWrapper::class.java))
+
+        override fun convert(
+            source: Any?,
+            sourceType: TypeDescriptor,
+            targetType: TypeDescriptor,
+        ): Any = StringWrapper(source as String)
+    }
+
+    @ReadingConverter
+    class IntToIntWrapperGenericConverter : GenericConverter {
+        // Int::class.java (primitive int) would never match: driver values arrive boxed, so the
+        // pair must be registered with the boxed java.lang.Integer type (javaObjectType).
+        override fun getConvertibleTypes(): Set<GenericConverter.ConvertiblePair> =
+            setOf(GenericConverter.ConvertiblePair(Int::class.javaObjectType, IntWrapper::class.java))
+
+        override fun convert(
+            source: Any?,
+            sourceType: TypeDescriptor,
+            targetType: TypeDescriptor,
+        ): Any = IntWrapper(source as Int)
+    }
+
+    @WritingConverter
+    class StringWrapperToStringConverter : Converter<StringWrapper, String> {
+        override fun convert(source: StringWrapper): String = source.value
+    }
+
+    class UnannotatedStringWrapperToStringConverter : Converter<StringWrapper, String> {
+        override fun convert(source: StringWrapper): String = source.value
+    }
+
+    @BeforeEach
+    fun beforeEach() = runTest {
+        h2.setUpForConverterTest()
+    }
+
+    @AfterEach
+    fun afterEach() = runTest {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun `GenericConverter is supported for reading`() = runTest {
+        val kueryClient = h2.kueryClient(
+            listOf(StringToStringWrapperGenericConverter(), StringWrapperToStringConverter()),
+        )
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES ('hoge')"
+        }.rowsUpdated()
+
+        val record: Record = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.single()
+        assertThat(record.text).isEqualTo(StringWrapper("hoge"))
+    }
+
+    @Test
+    fun `GenericConverter for a Kotlin Int works via javaObjectType`() = runTest {
+        val kueryClient = h2.kueryClient(listOf(IntToIntWrapperGenericConverter()))
+
+        val record: IntRecord = kueryClient.sql {
+            +"SELECT CAST(42 AS INT) AS num"
+        }.single()
+        assertThat(record).isEqualTo(IntRecord(IntWrapper(42)))
+    }
+
+    @Test
+    fun `converter without annotation infers direction from the store-typed side`() = runTest {
+        // Converter<StringWrapper, String> targets a store type, so Spring infers it as a
+        // writing converter even without @WritingConverter.
+        val kueryClient = h2.kueryClient(listOf(UnannotatedStringWrapperToStringConverter()))
+
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${StringWrapper("hoge")})"
+        }.rowsUpdated()
+
+        val result = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single<String>()
+        assertThat(result).isEqualTo("hoge")
+    }
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}


### PR DESCRIPTION
## Summary

Pins converter registration styles beyond plain annotated `Converter` pairs (`StringWrapperConversionTest`) and `ConverterFactory` (`CodeEnumConversionTest`), covering traps consumers have hit in production:

- **`GenericConverter` is supported for reading** — it applies on the `DataClassRowMapper` property path. (Reading a non-simple wrapper as a single scalar column remains unsupported regardless of converter registration, as already pinned by `unSupportNotSimpleProperty`.)
- **`Int::class.javaObjectType` trap**: a `GenericConverter.ConvertiblePair` for a Kotlin `Int` must use the boxed `java.lang.Integer` type; registering the primitive `int` class silently never matches because driver values arrive boxed.
- **Unannotated converter**: a `Converter<Wrapper, String>` without `@WritingConverter` still works — Spring infers the direction from the store-typed side.

Both JDBC and R2DBC modules, H2-backed (this is Spring-layer behavior, not driver-dependent).

## Test plan

- `./gradlew :kuery-client-spring-data-jdbc:test :kuery-client-spring-data-r2dbc:test` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)