### PR TITLE
Add tests for collection variations, scalar fetch edges, and keyset pagination

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CollectionConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CollectionConversionTest.kt
@@ -131,6 +131,67 @@ class CollectionConversionTest {
         assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
     }
 
+    @Test
+    fun testSet() {
+        insertThreeRows()
+
+        val result = kueryClient.sql {
+            val inSet = setOf(StringWrapper("text1"), StringWrapper("text2"))
+            +"SELECT * FROM converter WHERE text IN ($inSet)"
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
+    }
+
+    @Test
+    fun testMapKeysView() {
+        insertThreeRows()
+
+        val map = mapOf(StringWrapper("text1") to 1, StringWrapper("text3") to 3)
+        val result = kueryClient.sql {
+            +"SELECT * FROM converter WHERE text IN (${map.keys})"
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 3L, "text" to "text3")))
+    }
+
+    @Test
+    fun testCustomCollectionSubtype() {
+        // Non-standard Collection implementations (e.g. NonEmptyList of functional libraries)
+        // must expand like any other Collection.
+        class NonEmptyList<T>(private val delegate: List<T>) : Collection<T> by delegate
+
+        insertThreeRows()
+
+        val result = kueryClient.sql {
+            val inList = NonEmptyList(listOf(StringWrapper("text1"), StringWrapper("text2")))
+            +"SELECT * FROM converter WHERE text IN ($inList)"
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
+    }
+
+    @Test
+    fun testNullElement() {
+        // A null element binds as SQL NULL, which never matches in an IN list; the non-null
+        // elements still do.
+        insertThreeRows()
+
+        val result = kueryClient.sql {
+            val inList = listOf(StringWrapper("text1"), null)
+            +"SELECT * FROM converter WHERE text IN ($inList)"
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1")))
+    }
+
+    private fun insertThreeRows() {
+        kueryClient.sql {
+            +"""
+            INSERT INTO converter (text) VALUES
+            ('text1'),
+            ('text2'),
+            ('text3');
+            """.trimIndent()
+        }.rowsUpdated()
+    }
+
     companion object {
         private val h2 = H2TestDatabase()
     }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ValueClassFetchTest.kt
@@ -9,11 +9,21 @@ import dev.hsbrysk.kuery.core.list
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.BeanInstantiationException
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.ReadingConverter
 
 /**
- * Kotlin value classes are NOT supported as fetch types: DataClassRowMapper cannot resolve the
- * parameter names of their (private, boxed) constructor. Use the underlying type and wrap it
- * yourself, or a regular data class. This pins the current limitation.
+ * Kotlin value classes are NOT supported on the fetch side, in either position:
+ *
+ * - As the fetch type itself, DataClassRowMapper cannot resolve the parameter names of the
+ *   value class's (private, boxed) constructor.
+ * - As a data class property, instantiation fails because the enclosing class's JVM
+ *   constructor takes the unboxed underlying type; even a registered reading converter does
+ *   not help.
+ *
+ * Use the underlying type and wrap it yourself, or a regular data class. This pins the
+ * current limitation.
  */
 class ValueClassFetchTest {
     @JvmInline
@@ -40,6 +50,26 @@ class ValueClassFetchTest {
             }.list<UserName>()
         }.isInstanceOf(IllegalStateException::class)
             .message().isNotNull().startsWith("Cannot resolve parameter names")
+    }
+
+    @Test
+    fun `value class as a data class property is not supported either`() {
+        val kueryClient = h2.kueryClient(listOf(StringToUserNameConverter()))
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT id, text FROM converter ORDER BY id"
+            }.list<Record>()
+        }.isInstanceOf(BeanInstantiationException::class)
+    }
+
+    data class Record(
+        val id: Long,
+        val text: UserName,
+    )
+
+    @ReadingConverter
+    class StringToUserNameConverter : Converter<String, UserName> {
+        override fun convert(source: String): UserName = UserName(source)
     }
 
     companion object {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ValueClassFetchTest.kt
@@ -1,0 +1,48 @@
+package dev.hsbrysk.kuery.spring.jdbc
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.message
+import assertk.assertions.startsWith
+import dev.hsbrysk.kuery.core.list
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Kotlin value classes are NOT supported as fetch types: DataClassRowMapper cannot resolve the
+ * parameter names of their (private, boxed) constructor. Use the underlying type and wrap it
+ * yourself, or a regular data class. This pins the current limitation.
+ */
+class ValueClassFetchTest {
+    @JvmInline
+    value class UserName(val value: String)
+
+    private val kueryClient = h2.kueryClient()
+
+    @BeforeEach
+    fun beforeEach() {
+        h2.setUpForConverterTest()
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1'), ('user2')").update()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun `value class is not supported as a fetch type`() {
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT text AS value FROM converter ORDER BY id"
+            }.list<UserName>()
+        }.isInstanceOf(IllegalStateException::class)
+            .message().isNotNull().startsWith("Cannot resolve parameter names")
+    }
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlByteArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlByteArrayBindingTest.kt
@@ -2,7 +2,9 @@ package dev.hsbrysk.kuery.spring.jdbc.mysql
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import dev.hsbrysk.kuery.core.single
+import dev.hsbrysk.kuery.core.singleOrNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -59,6 +61,15 @@ class MySqlByteArrayBindingTest {
             .sql { +"SELECT COUNT(*) FROM binaries WHERE id = $id AND data = $data AND data = $data" }
             .single<Long>()
         assertThat(count).isEqualTo(1L)
+    }
+
+    @Test
+    fun `singleOrNull ByteArray returns null when no row matches`() {
+        val id = ByteArray(16) { it.toByte() }
+        val stored = kueryClient
+            .sql { +"SELECT data FROM binaries WHERE id = $id" }
+            .singleOrNull<ByteArray>()
+        assertThat(stored).isNull()
     }
 
     companion object {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlKeysetPaginationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlKeysetPaginationTest.kt
@@ -1,0 +1,75 @@
+package dev.hsbrysk.kuery.spring.jdbc.mysql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+/**
+ * Keyset (cursor) pagination via a row-value comparison with two interpolated values:
+ * `(created_at, id) > ($cursorCreatedAt, $cursorId)`.
+ */
+class MySqlKeysetPaginationTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        mysql.jdbcClient.sql(
+            """
+            CREATE TABLE events (
+                id INT PRIMARY KEY,
+                created_at DATETIME NOT NULL
+            )
+            """.trimIndent(),
+        ).update()
+        mysql.jdbcClient.sql(
+            """
+            INSERT INTO events (id, created_at) VALUES
+            (1, '2026-01-01 10:00:00'),
+            (2, '2026-01-01 10:00:00'),
+            (3, '2026-01-01 10:05:00'),
+            (4, '2026-01-01 10:05:00'),
+            (5, '2026-01-01 10:10:00')
+            """.trimIndent(),
+        ).update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mysql.jdbcClient.sql("DROP TABLE events").update()
+    }
+
+    @Test
+    fun `keyset pagination ascending`() {
+        val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0)
+        val cursorId = 1
+
+        val page = kueryClient.sql {
+            +"SELECT id FROM events"
+            +"WHERE (created_at, id) > ($cursorCreatedAt, $cursorId)"
+            +"ORDER BY created_at, id"
+            +"LIMIT 2"
+        }.listMap()
+        assertThat(page.map { it["id"] }).isEqualTo(listOf(2, 3))
+    }
+
+    @Test
+    fun `keyset pagination descending`() {
+        val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 5, 0)
+        val cursorId = 4
+
+        val page = kueryClient.sql {
+            +"SELECT id FROM events"
+            +"WHERE (created_at, id) < ($cursorCreatedAt, $cursorId)"
+            +"ORDER BY created_at DESC, id DESC"
+            +"LIMIT 2"
+        }.listMap()
+        assertThat(page.map { it["id"] }).isEqualTo(listOf(3, 2))
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlScalarFetchTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlScalarFetchTest.kt
@@ -1,0 +1,57 @@
+package dev.hsbrysk.kuery.spring.jdbc.mysql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.core.single
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Common scalar-fetch idioms against MySQL: `SELECT EXISTS(...)` (which MySQL returns as
+ * BIGINT 0/1) into Boolean, and `COUNT(*)` (BIGINT) into Int/Long.
+ */
+class MySqlScalarFetchTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        mysql.jdbcClient.sql("CREATE TABLE scalar_users (user_id INT PRIMARY KEY)").update()
+        mysql.jdbcClient.sql("INSERT INTO scalar_users (user_id) VALUES (1), (2)").update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mysql.jdbcClient.sql("DROP TABLE scalar_users").update()
+    }
+
+    @Test
+    fun `EXISTS maps to Boolean`() {
+        val exists: Boolean = kueryClient
+            .sql { +"SELECT EXISTS(SELECT 1 FROM scalar_users WHERE user_id = 1)" }
+            .single()
+        assertThat(exists).isEqualTo(true)
+
+        val notExists: Boolean = kueryClient
+            .sql { +"SELECT EXISTS(SELECT 1 FROM scalar_users WHERE user_id = 999)" }
+            .single()
+        assertThat(notExists).isEqualTo(false)
+    }
+
+    @Test
+    fun `COUNT maps to Long and narrows to Int`() {
+        val asLong: Long = kueryClient
+            .sql { +"SELECT COUNT(*) FROM scalar_users" }
+            .single()
+        assertThat(asLong).isEqualTo(2L)
+
+        val asInt: Int = kueryClient
+            .sql { +"SELECT COUNT(*) FROM scalar_users" }
+            .single()
+        assertThat(asInt).isEqualTo(2)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresKeysetPaginationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresKeysetPaginationTest.kt
@@ -1,0 +1,75 @@
+package dev.hsbrysk.kuery.spring.jdbc.postgres
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+/**
+ * Keyset (cursor) pagination via a row-value comparison with two interpolated values:
+ * `(created_at, id) > ($cursorCreatedAt, $cursorId)`.
+ */
+class PostgresKeysetPaginationTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        postgres.jdbcClient.sql(
+            """
+            CREATE TABLE events (
+                id INT PRIMARY KEY,
+                created_at TIMESTAMP NOT NULL
+            )
+            """.trimIndent(),
+        ).update()
+        postgres.jdbcClient.sql(
+            """
+            INSERT INTO events (id, created_at) VALUES
+            (1, '2026-01-01 10:00:00'),
+            (2, '2026-01-01 10:00:00'),
+            (3, '2026-01-01 10:05:00'),
+            (4, '2026-01-01 10:05:00'),
+            (5, '2026-01-01 10:10:00')
+            """.trimIndent(),
+        ).update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        postgres.jdbcClient.sql("DROP TABLE events").update()
+    }
+
+    @Test
+    fun `keyset pagination ascending`() {
+        val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0)
+        val cursorId = 1
+
+        val page = kueryClient.sql {
+            +"SELECT id FROM events"
+            +"WHERE (created_at, id) > ($cursorCreatedAt, $cursorId)"
+            +"ORDER BY created_at, id"
+            +"LIMIT 2"
+        }.listMap()
+        assertThat(page.map { it["id"] }).isEqualTo(listOf(2, 3))
+    }
+
+    @Test
+    fun `keyset pagination descending`() {
+        val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 5, 0)
+        val cursorId = 4
+
+        val page = kueryClient.sql {
+            +"SELECT id FROM events"
+            +"WHERE (created_at, id) < ($cursorCreatedAt, $cursorId)"
+            +"ORDER BY created_at DESC, id DESC"
+            +"LIMIT 2"
+        }.listMap()
+        assertThat(page.map { it["id"] }).isEqualTo(listOf(3, 2))
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CollectionConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CollectionConversionTest.kt
@@ -1,7 +1,9 @@
 package dev.hsbrysk.kuery.spring.r2dbc
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import dev.hsbrysk.kuery.core.DelicateKueryClientApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -130,6 +132,69 @@ class CollectionConversionTest {
             addUnsafe("SELECT * FROM converter WHERE text IN (${bind(texts)})")
         }.listMap()
         assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
+    }
+
+    @Test
+    fun testSet() = runTest {
+        insertThreeRows()
+
+        val result = kueryClient.sql {
+            val inSet = setOf(StringWrapper("text1"), StringWrapper("text2"))
+            +"SELECT * FROM converter WHERE text IN ($inSet)"
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
+    }
+
+    @Test
+    fun testMapKeysView() = runTest {
+        insertThreeRows()
+
+        val map = mapOf(StringWrapper("text1") to 1, StringWrapper("text3") to 3)
+        val result = kueryClient.sql {
+            +"SELECT * FROM converter WHERE text IN (${map.keys})"
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 3L, "text" to "text3")))
+    }
+
+    @Test
+    fun testCustomCollectionSubtype() = runTest {
+        // Non-standard Collection implementations (e.g. NonEmptyList of functional libraries)
+        // must expand like any other Collection.
+        class NonEmptyList<T>(private val delegate: List<T>) : Collection<T> by delegate
+
+        insertThreeRows()
+
+        val result = kueryClient.sql {
+            val inList = NonEmptyList(listOf(StringWrapper("text1"), StringWrapper("text2")))
+            +"SELECT * FROM converter WHERE text IN ($inList)"
+        }.listMap()
+        assertThat(result).isEqualTo(listOf(mapOf("id" to 1L, "text" to "text1"), mapOf("id" to 2L, "text" to "text2")))
+    }
+
+    @Test
+    fun testNullElement() = runTest {
+        // Unlike JDBC (where a null element binds as SQL NULL and simply never matches),
+        // R2DBC's Statement.bind rejects null values, so a collection containing null cannot
+        // be expanded. This pins the asymmetry.
+        insertThreeRows()
+
+        assertFailure {
+            kueryClient.sql {
+                val inList = listOf(StringWrapper("text1"), null)
+                +"SELECT * FROM converter WHERE text IN ($inList)"
+            }.listMap()
+        }.isInstanceOf(IllegalArgumentException::class)
+    }
+
+    private suspend fun insertThreeRows() {
+        kueryClient.sql {
+            +"""
+            INSERT INTO converter (text) VALUES
+            ('text1'),
+            ('text2'),
+            ('text3');
+            """.trimIndent()
+        }.rowsUpdated()
     }
 
     companion object {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ValueClassFetchTest.kt
@@ -10,12 +10,22 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.BeanInstantiationException
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.ReadingConverter
 import org.springframework.r2dbc.core.awaitRowsUpdated
 
 /**
- * Kotlin value classes are NOT supported as fetch types: DataClassRowMapper cannot resolve the
- * parameter names of their (private, boxed) constructor. Use the underlying type and wrap it
- * yourself, or a regular data class. This pins the current limitation.
+ * Kotlin value classes are NOT supported on the fetch side, in either position:
+ *
+ * - As the fetch type itself, DataClassRowMapper cannot resolve the parameter names of the
+ *   value class's (private, boxed) constructor.
+ * - As a data class property, instantiation fails because the enclosing class's JVM
+ *   constructor takes the unboxed underlying type; even a registered reading converter does
+ *   not help.
+ *
+ * Use the underlying type and wrap it yourself, or a regular data class. This pins the
+ * current limitation.
  */
 class ValueClassFetchTest {
     @JvmInline
@@ -42,6 +52,26 @@ class ValueClassFetchTest {
             }.list<UserName>()
         }.isInstanceOf(IllegalStateException::class)
             .message().isNotNull().startsWith("Cannot resolve parameter names")
+    }
+
+    @Test
+    fun `value class as a data class property is not supported either`() = runTest {
+        val kueryClient = h2.kueryClient(listOf(StringToUserNameConverter()))
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT id, text FROM converter ORDER BY id"
+            }.list<Record>()
+        }.isInstanceOf(BeanInstantiationException::class)
+    }
+
+    data class Record(
+        val id: Long,
+        val text: UserName,
+    )
+
+    @ReadingConverter
+    class StringToUserNameConverter : Converter<String, UserName> {
+        override fun convert(source: String): UserName = UserName(source)
     }
 
     companion object {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ValueClassFetchTest.kt
@@ -1,0 +1,50 @@
+package dev.hsbrysk.kuery.spring.r2dbc
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.message
+import assertk.assertions.startsWith
+import dev.hsbrysk.kuery.core.list
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * Kotlin value classes are NOT supported as fetch types: DataClassRowMapper cannot resolve the
+ * parameter names of their (private, boxed) constructor. Use the underlying type and wrap it
+ * yourself, or a regular data class. This pins the current limitation.
+ */
+class ValueClassFetchTest {
+    @JvmInline
+    value class UserName(val value: String)
+
+    private val kueryClient = h2.kueryClient()
+
+    @BeforeEach
+    fun beforeEach() = runTest {
+        h2.setUpForConverterTest()
+        h2.databaseClient.sql("INSERT INTO converter (text) VALUES ('user1'), ('user2')").fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun afterEach() = runTest {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun `value class is not supported as a fetch type`() = runTest {
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT text AS value FROM converter ORDER BY id"
+            }.list<UserName>()
+        }.isInstanceOf(IllegalStateException::class)
+            .message().isNotNull().startsWith("Cannot resolve parameter names")
+    }
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlByteArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlByteArrayBindingTest.kt
@@ -2,7 +2,9 @@ package dev.hsbrysk.kuery.spring.r2dbc.mysql
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import dev.hsbrysk.kuery.core.single
+import dev.hsbrysk.kuery.core.singleOrNull
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -62,6 +64,15 @@ class MySqlByteArrayBindingTest {
             .sql { +"SELECT COUNT(*) FROM binaries WHERE id = $id AND data = $data AND data = $data" }
             .single<Long>()
         assertThat(count).isEqualTo(1L)
+    }
+
+    @Test
+    fun `singleOrNull ByteArray returns null when no row matches`() = runTest {
+        val id = ByteArray(16) { it.toByte() }
+        val stored = kueryClient
+            .sql { +"SELECT data FROM binaries WHERE id = $id" }
+            .singleOrNull<ByteArray>()
+        assertThat(stored).isNull()
     }
 
     companion object {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlKeysetPaginationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlKeysetPaginationTest.kt
@@ -1,0 +1,77 @@
+package dev.hsbrysk.kuery.spring.r2dbc.mysql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+import java.time.LocalDateTime
+
+/**
+ * Keyset (cursor) pagination via a row-value comparison with two interpolated values:
+ * `(created_at, id) > ($cursorCreatedAt, $cursorId)`.
+ */
+class MySqlKeysetPaginationTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        mysql.databaseClient.sql(
+            """
+            CREATE TABLE events (
+                id INT PRIMARY KEY,
+                created_at DATETIME NOT NULL
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+        mysql.databaseClient.sql(
+            """
+            INSERT INTO events (id, created_at) VALUES
+            (1, '2026-01-01 10:00:00'),
+            (2, '2026-01-01 10:00:00'),
+            (3, '2026-01-01 10:05:00'),
+            (4, '2026-01-01 10:05:00'),
+            (5, '2026-01-01 10:10:00')
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        mysql.databaseClient.sql("DROP TABLE events").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `keyset pagination ascending`() = runTest {
+        val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0)
+        val cursorId = 1
+
+        val page = kueryClient.sql {
+            +"SELECT id FROM events"
+            +"WHERE (created_at, id) > ($cursorCreatedAt, $cursorId)"
+            +"ORDER BY created_at, id"
+            +"LIMIT 2"
+        }.listMap()
+        assertThat(page.map { it["id"] }).isEqualTo(listOf(2, 3))
+    }
+
+    @Test
+    fun `keyset pagination descending`() = runTest {
+        val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 5, 0)
+        val cursorId = 4
+
+        val page = kueryClient.sql {
+            +"SELECT id FROM events"
+            +"WHERE (created_at, id) < ($cursorCreatedAt, $cursorId)"
+            +"ORDER BY created_at DESC, id DESC"
+            +"LIMIT 2"
+        }.listMap()
+        assertThat(page.map { it["id"] }).isEqualTo(listOf(3, 2))
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlScalarFetchTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlScalarFetchTest.kt
@@ -1,0 +1,64 @@
+package dev.hsbrysk.kuery.spring.r2dbc.mysql
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import dev.hsbrysk.kuery.core.single
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * Common scalar-fetch idioms against MySQL: `SELECT EXISTS(...)` (which MySQL returns as
+ * BIGINT 0/1) into Boolean, and `COUNT(*)` (BIGINT) into Int/Long.
+ */
+class MySqlScalarFetchTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        mysql.databaseClient.sql("CREATE TABLE scalar_users (user_id INT PRIMARY KEY)").fetch().awaitRowsUpdated()
+        mysql.databaseClient.sql("INSERT INTO scalar_users (user_id) VALUES (1), (2)").fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        mysql.databaseClient.sql("DROP TABLE scalar_users").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `EXISTS does not map to Boolean`() = runTest {
+        // Unlike JDBC, the R2DBC path cannot narrow MySQL's BIGINT 0/1 to Boolean (see also the
+        // commented-out Boolean cases in MySqlSingleBasicTypeTest). Fetch it as Long instead.
+        assertFailure {
+            kueryClient
+                .sql { +"SELECT EXISTS(SELECT 1 FROM scalar_users WHERE user_id = 1)" }
+                .single<Boolean>()
+        }.isInstanceOf(IllegalArgumentException::class)
+
+        val exists: Long = kueryClient
+            .sql { +"SELECT EXISTS(SELECT 1 FROM scalar_users WHERE user_id = 1)" }
+            .single()
+        assertThat(exists).isEqualTo(1L)
+    }
+
+    @Test
+    fun `COUNT maps to Long and narrows to Int`() = runTest {
+        val asLong: Long = kueryClient
+            .sql { +"SELECT COUNT(*) FROM scalar_users" }
+            .single()
+        assertThat(asLong).isEqualTo(2L)
+
+        val asInt: Int = kueryClient
+            .sql { +"SELECT COUNT(*) FROM scalar_users" }
+            .single()
+        assertThat(asInt).isEqualTo(2)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresKeysetPaginationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresKeysetPaginationTest.kt
@@ -1,0 +1,77 @@
+package dev.hsbrysk.kuery.spring.r2dbc.postgres
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.awaitRowsUpdated
+import java.time.LocalDateTime
+
+/**
+ * Keyset (cursor) pagination via a row-value comparison with two interpolated values:
+ * `(created_at, id) > ($cursorCreatedAt, $cursorId)`.
+ */
+class PostgresKeysetPaginationTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        postgres.databaseClient.sql(
+            """
+            CREATE TABLE events (
+                id INT PRIMARY KEY,
+                created_at TIMESTAMP NOT NULL
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+        postgres.databaseClient.sql(
+            """
+            INSERT INTO events (id, created_at) VALUES
+            (1, '2026-01-01 10:00:00'),
+            (2, '2026-01-01 10:00:00'),
+            (3, '2026-01-01 10:05:00'),
+            (4, '2026-01-01 10:05:00'),
+            (5, '2026-01-01 10:10:00')
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        postgres.databaseClient.sql("DROP TABLE events").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `keyset pagination ascending`() = runTest {
+        val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0)
+        val cursorId = 1
+
+        val page = kueryClient.sql {
+            +"SELECT id FROM events"
+            +"WHERE (created_at, id) > ($cursorCreatedAt, $cursorId)"
+            +"ORDER BY created_at, id"
+            +"LIMIT 2"
+        }.listMap()
+        assertThat(page.map { it["id"] }).isEqualTo(listOf(2, 3))
+    }
+
+    @Test
+    fun `keyset pagination descending`() = runTest {
+        val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 5, 0)
+        val cursorId = 4
+
+        val page = kueryClient.sql {
+            +"SELECT id FROM events"
+            +"WHERE (created_at, id) < ($cursorCreatedAt, $cursorId)"
+            +"ORDER BY created_at DESC, id DESC"
+            +"LIMIT 2"
+        }.listMap()
+        assertThat(page.map { it["id"] }).isEqualTo(listOf(3, 2))
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}


### PR DESCRIPTION
## Summary

Three groups of behavior pins, all driven by real consumer usage patterns:

**Collection interpolation variations** (H2, `CollectionConversionTest`):
- `Set`, a custom `Collection` subtype (NonEmptyList-style class delegation), and `Map.keys` views expand like any other collection, with per-element converters applied.
- A collection containing a **null element** pins an asymmetry: JDBC binds it as SQL NULL (which simply never matches in an `IN` list), while **R2DBC rejects it** with `IllegalArgumentException` because R2DBC's `Statement.bind` does not accept null values.

**Scalar fetch edges** (MySQL):
- `SELECT EXISTS(...)` → `single<Boolean>()` works on JDBC; on **R2DBC it fails** (BIGINT 0/1 cannot be narrowed to Boolean — same root cause as the commented-out Boolean cases in `MySqlSingleBasicTypeTest`); fetch it as `Long` instead.
- `COUNT(*)` (BIGINT) narrows to `Int` on both modules; `Long` works as expected.
- `singleOrNull<ByteArray>()` returns null when no row matches (added to `MySqlByteArrayBindingTest`).
- **Kotlin value classes are unsupported on the fetch side, in either position** — as the fetch type itself (`DataClassRowMapper` cannot resolve the constructor parameter names) and as a data class property (`BeanInstantiationException`; the enclosing JVM constructor takes the unboxed underlying type, and even a registered reading converter does not help). Pinned in new `ValueClassFetchTest`s.

**Keyset pagination** (MySQL + PostgreSQL): row-value comparisons with two interpolated values (`(created_at, id) > ($cursorCreatedAt, $cursorId)`), ascending and descending, with ties on the timestamp column.

## Test plan

- `./gradlew :kuery-client-spring-data-jdbc:test :kuery-client-spring-data-r2dbc:test` with Docker — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
