### PR TITLE
Add tests for transaction participation and DuplicateKeyException

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/TransactionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/TransactionTest.kt
@@ -1,0 +1,68 @@
+package dev.hsbrysk.kuery.spring.jdbc
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import dev.hsbrysk.kuery.core.single
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+
+/**
+ * The client participates in Spring-managed transactions (the same mechanism behind
+ * `@Transactional`) as long as it is built on the transaction manager's DataSource.
+ */
+class TransactionTest {
+    private val kueryClient = h2.kueryClient()
+    private val transactionTemplate = TransactionTemplate(DataSourceTransactionManager(h2.dataSource))
+
+    @BeforeEach
+    fun beforeEach() {
+        h2.setUpForConverterTest()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun `commit persists the changes`() {
+        transactionTemplate.execute {
+            kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
+        }
+
+        assertThat(count()).isEqualTo(1L)
+    }
+
+    @Test
+    fun `setRollbackOnly discards the changes`() {
+        transactionTemplate.execute { status ->
+            kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
+            status.setRollbackOnly()
+        }
+
+        assertThat(count()).isEqualTo(0L)
+    }
+
+    @Test
+    fun `an exception rolls back the changes`() {
+        assertFailure {
+            transactionTemplate.execute<Nothing> {
+                kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
+                error("boom")
+            }
+        }.isInstanceOf(IllegalStateException::class)
+
+        assertThat(count()).isEqualTo(0L)
+    }
+
+    private fun count(): Long = kueryClient.sql { +"SELECT COUNT(*) FROM converter" }.single()
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlDuplicateKeyTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlDuplicateKeyTest.kt
@@ -1,0 +1,49 @@
+package dev.hsbrysk.kuery.spring.jdbc.mysql
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DuplicateKeyException
+
+/**
+ * A unique constraint violation must surface as Spring's DuplicateKeyException so that callers
+ * can catch it in their use-case layer.
+ */
+class MySqlDuplicateKeyTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        mysql.jdbcClient.sql(
+            """
+            CREATE TABLE dup_users (
+                user_id INT PRIMARY KEY,
+                email VARCHAR(100) NOT NULL,
+                UNIQUE KEY uq_email (email)
+            )
+            """.trimIndent(),
+        ).update()
+        mysql.jdbcClient.sql("INSERT INTO dup_users (user_id, email) VALUES (1, 'user1@example.com')").update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mysql.jdbcClient.sql("DROP TABLE dup_users").update()
+    }
+
+    @Test
+    fun `unique constraint violation throws DuplicateKeyException`() {
+        val email = "user1@example.com"
+        assertFailure {
+            kueryClient.sql {
+                +"INSERT INTO dup_users (user_id, email) VALUES (2, $email)"
+            }.rowsUpdated()
+        }.isInstanceOf(DuplicateKeyException::class)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresDuplicateKeyTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresDuplicateKeyTest.kt
@@ -1,0 +1,48 @@
+package dev.hsbrysk.kuery.spring.jdbc.postgres
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DuplicateKeyException
+
+/**
+ * A unique constraint violation must surface as Spring's DuplicateKeyException so that callers
+ * can catch it in their use-case layer.
+ */
+class PostgresDuplicateKeyTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() {
+        postgres.jdbcClient.sql(
+            """
+            CREATE TABLE dup_users (
+                user_id INT PRIMARY KEY,
+                email VARCHAR(100) NOT NULL UNIQUE
+            )
+            """.trimIndent(),
+        ).update()
+        postgres.jdbcClient.sql("INSERT INTO dup_users (user_id, email) VALUES (1, 'user1@example.com')").update()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        postgres.jdbcClient.sql("DROP TABLE dup_users").update()
+    }
+
+    @Test
+    fun `unique constraint violation throws DuplicateKeyException`() {
+        val email = "user1@example.com"
+        assertFailure {
+            kueryClient.sql {
+                +"INSERT INTO dup_users (user_id, email) VALUES (2, $email)"
+            }.rowsUpdated()
+        }.isInstanceOf(DuplicateKeyException::class)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/TransactionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/TransactionTest.kt
@@ -1,0 +1,70 @@
+package dev.hsbrysk.kuery.spring.r2dbc
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import dev.hsbrysk.kuery.core.single
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.connection.R2dbcTransactionManager
+import org.springframework.transaction.reactive.TransactionalOperator
+import org.springframework.transaction.reactive.executeAndAwait
+
+/**
+ * The client participates in Spring-managed reactive transactions (the same mechanism behind
+ * `@Transactional`) as long as it is built on the transaction manager's ConnectionFactory.
+ */
+class TransactionTest {
+    private val kueryClient = h2.kueryClient()
+    private val transactionalOperator = TransactionalOperator.create(R2dbcTransactionManager(h2.connectionFactory))
+
+    @BeforeEach
+    fun beforeEach() = runTest {
+        h2.setUpForConverterTest()
+    }
+
+    @AfterEach
+    fun afterEach() = runTest {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun `commit persists the changes`() = runTest {
+        transactionalOperator.executeAndAwait {
+            kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
+        }
+
+        assertThat(count()).isEqualTo(1L)
+    }
+
+    @Test
+    fun `setRollbackOnly discards the changes`() = runTest {
+        transactionalOperator.executeAndAwait { status ->
+            kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
+            status.setRollbackOnly()
+        }
+
+        assertThat(count()).isEqualTo(0L)
+    }
+
+    @Test
+    fun `an exception rolls back the changes`() = runTest {
+        assertFailure {
+            transactionalOperator.executeAndAwait<Nothing> {
+                kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
+                error("boom")
+            }
+        }.isInstanceOf(IllegalStateException::class)
+
+        assertThat(count()).isEqualTo(0L)
+    }
+
+    private suspend fun count(): Long = kueryClient.sql { +"SELECT COUNT(*) FROM converter" }.single()
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlDuplicateKeyTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlDuplicateKeyTest.kt
@@ -1,0 +1,52 @@
+package dev.hsbrysk.kuery.spring.r2dbc.mysql
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * A unique constraint violation must surface as Spring's DuplicateKeyException so that callers
+ * can catch it in their use-case layer.
+ */
+class MySqlDuplicateKeyTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        mysql.databaseClient.sql(
+            """
+            CREATE TABLE dup_users (
+                user_id INT PRIMARY KEY,
+                email VARCHAR(100) NOT NULL,
+                UNIQUE KEY uq_email (email)
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+        mysql.databaseClient.sql("INSERT INTO dup_users (user_id, email) VALUES (1, 'user1@example.com')")
+            .fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        mysql.databaseClient.sql("DROP TABLE dup_users").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `unique constraint violation throws DuplicateKeyException`() = runTest {
+        val email = "user1@example.com"
+        assertFailure {
+            kueryClient.sql {
+                +"INSERT INTO dup_users (user_id, email) VALUES (2, $email)"
+            }.rowsUpdated()
+        }.isInstanceOf(DuplicateKeyException::class)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresDuplicateKeyTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresDuplicateKeyTest.kt
@@ -1,0 +1,51 @@
+package dev.hsbrysk.kuery.spring.r2dbc.postgres
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.r2dbc.core.awaitRowsUpdated
+
+/**
+ * A unique constraint violation must surface as Spring's DuplicateKeyException so that callers
+ * can catch it in their use-case layer.
+ */
+class PostgresDuplicateKeyTest {
+    private val kueryClient = postgres.kueryClient()
+
+    @BeforeEach
+    fun setUp() = runTest {
+        postgres.databaseClient.sql(
+            """
+            CREATE TABLE dup_users (
+                user_id INT PRIMARY KEY,
+                email VARCHAR(100) NOT NULL UNIQUE
+            )
+            """.trimIndent(),
+        ).fetch().awaitRowsUpdated()
+        postgres.databaseClient.sql("INSERT INTO dup_users (user_id, email) VALUES (1, 'user1@example.com')")
+            .fetch().awaitRowsUpdated()
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+        postgres.databaseClient.sql("DROP TABLE dup_users").fetch().awaitRowsUpdated()
+    }
+
+    @Test
+    fun `unique constraint violation throws DuplicateKeyException`() = runTest {
+        val email = "user1@example.com"
+        assertFailure {
+            kueryClient.sql {
+                +"INSERT INTO dup_users (user_id, email) VALUES (2, $email)"
+            }.rowsUpdated()
+        }.isInstanceOf(DuplicateKeyException::class)
+    }
+
+    companion object {
+        private val postgres = PostgresTestContainer
+    }
+}


### PR DESCRIPTION
## Summary

- **Transactions** (H2, both modules): the README advertises that Spring's `@Transactional` works out of the box, but there was no transaction test in the repo. New `TransactionTest`s verify the clients participate in Spring-managed transactions via the underlying mechanism (`TransactionTemplate` + `DataSourceTransactionManager` on JDBC, `TransactionalOperator` + `R2dbcTransactionManager` on R2DBC) when built on the same DataSource/ConnectionFactory: commit persists, `setRollbackOnly` discards, and an exception rolls back.
- **DuplicateKeyException** (MySQL + PostgreSQL, both modules): a unique constraint violation surfaces as Spring's `DuplicateKeyException`, which consumers catch in their use-case layers.

## Test plan

- `./gradlew :kuery-client-spring-data-jdbc:test :kuery-client-spring-data-r2dbc:test` with Docker — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)