### PR TITLE
Add tests for timeout firing, sequence eagerness, and delegated sqlId

### DIFF
--- a/kuery-client-core/src/test/kotlin/com/example/core/DelegationFixtures.kt
+++ b/kuery-client-core/src/test/kotlin/com/example/core/DelegationFixtures.kt
@@ -1,0 +1,17 @@
+package com.example.core
+
+import dev.hsbrysk.kuery.core.SqlBuilder
+import dev.hsbrysk.kuery.core.internal.FakeClientEntryPoint
+
+/**
+ * Simulates the common decorator pattern `class Guard(client: KueryBlockingClient) :
+ * KueryBlockingClient by client` (transaction guards etc.) sitting between the repository and
+ * the client.
+ */
+internal class DelegatingClient {
+    fun sql(block: SqlBuilder.() -> Unit): String = FakeClientEntryPoint.sql(block)
+}
+
+internal class RepositoryBehindDelegation(private val client: DelegatingClient = DelegatingClient()) {
+    fun find(): String = client.sql { }
+}

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/FakeClientEntryPoint.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/FakeClientEntryPoint.kt
@@ -1,0 +1,14 @@
+package dev.hsbrysk.kuery.core.internal
+
+import dev.hsbrysk.kuery.core.KueryClientInternalApi
+import dev.hsbrysk.kuery.core.SqlBuilder
+import dev.hsbrysk.kuery.core.internal.SqlIds.id
+
+/**
+ * Stand-in for a real client entry point: it lives in the dev.hsbrysk.kuery package, so its
+ * frame is skipped by SqlIds' stack walk exactly like DefaultSpring*KueryClient.sql().
+ */
+@OptIn(KueryClientInternalApi::class)
+internal object FakeClientEntryPoint {
+    fun sql(block: SqlBuilder.() -> Unit): String = block.id()
+}

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
@@ -27,6 +27,16 @@ class SqlIdsTest {
     }
 
     @Test
+    fun `id resolved through a delegating wrapper points at the wrapper`() {
+        // A decorator forwarding to the client (KueryBlockingClient by delegate, guard wrappers,
+        // ...) contributes the first non-kuery frame, so the auto-resolved sqlId identifies the
+        // wrapper method, NOT the repository call site. Wrapped clients should pass an explicit
+        // sqlId via sql(sqlId, block) if per-call-site ids are needed.
+        assertThat(com.example.core.RepositoryBehindDelegation().find())
+            .isEqualTo("com.example.core.DelegatingClient.sql")
+    }
+
+    @Test
     fun removeSuffixes() {
         assertThat("a.b.c".removeSuffixes(listOf(".b", ".c"))).isEqualTo("a.b")
         assertThat("a.b.c".removeSuffixes(listOf(".a", ".d"))).isEqualTo("a.b.c")

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SequenceExecutionTimingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SequenceExecutionTimingTest.kt
@@ -1,0 +1,58 @@
+package dev.hsbrysk.kuery.spring.jdbc
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.util.concurrent.atomic.AtomicInteger
+import javax.sql.DataSource
+
+/**
+ * sequence()/sequenceMap() are NOT lazy: the statement executes eagerly when the sequence is
+ * created (see the note in DefaultSpringJdbcKueryClient), before any element is consumed. This
+ * pins that contract — wrappers that want to defer or guard execution cannot rely on laziness.
+ */
+class SequenceExecutionTimingTest {
+    private val connectionCount = AtomicInteger()
+    private val countingDataSource = object : DataSource by h2.dataSource {
+        override fun getConnection(): Connection {
+            connectionCount.incrementAndGet()
+            return h2.dataSource.connection
+        }
+    }
+    private val kueryClient = SpringJdbcKueryClient.builder()
+        .dataSource(countingDataSource)
+        .build()
+
+    @BeforeEach
+    fun beforeEach() {
+        h2.setUpForConverterTest()
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('text1'), ('text2')").update()
+        connectionCount.set(0)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun `sequenceMap executes the query eagerly at call time`() {
+        val sequence = kueryClient.sql { +"SELECT * FROM converter" }.sequenceMap()
+        sequence.use {
+            // The connection was already acquired (and the statement executed) by sequenceMap()
+            // itself, before the first element was consumed.
+            assertThat(connectionCount.get()).isEqualTo(1)
+
+            assertThat(it.toList()).hasSize(2)
+            assertThat(connectionCount.get()).isEqualTo(1)
+        }
+    }
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlQueryTimeoutTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlQueryTimeoutTest.kt
@@ -1,0 +1,28 @@
+package dev.hsbrysk.kuery.spring.jdbc.mysql
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.dao.QueryTimeoutException
+
+/**
+ * queryTimeoutSeconds must actually abort a query that exceeds the timeout (the H2
+ * StatementOptionsTest only verifies the option does not break fast queries).
+ */
+class MySqlQueryTimeoutTest {
+    private val kueryClient = mysql.kueryClient()
+
+    @Test
+    fun `queryTimeoutSeconds aborts a query that runs too long`() {
+        assertFailure {
+            kueryClient
+                .sql { +"SELECT SLEEP(10)" }
+                .queryTimeoutSeconds(1)
+                .singleMap()
+        }.isInstanceOf(QueryTimeoutException::class)
+    }
+
+    companion object {
+        private val mysql = MySqlTestContainer
+    }
+}


### PR DESCRIPTION
## Summary

Three execution-semantics contracts, each previously untested:

- **`queryTimeoutSeconds` actually fires** (`MySqlQueryTimeoutTest`): a `SELECT SLEEP(10)` with a 1-second timeout aborts with Spring's `QueryTimeoutException`. The existing H2 `StatementOptionsTest` only verified the option doesn't break fast queries.
- **`sequence()`/`sequenceMap()` are eager, not lazy** (`SequenceExecutionTimingTest`): a connection-counting DataSource shows the statement executes when the sequence is created, before any element is consumed — matching the note in `DefaultSpringJdbcKueryClient`. This is worth pinning explicitly because guard/decorator wrappers might otherwise assume execution is deferred until iteration.
- **sqlId auto-resolution through a delegating wrapper** (`SqlIdsTest`): with a decorator between the repository and the client (the common `KueryBlockingClient by delegate` guard pattern), the resolved sqlId identifies the wrapper method — the first non-kuery stack frame — not the repository call site. Wrapped clients should pass an explicit sqlId via `sql(sqlId, block)` when per-call-site ids are needed. A future frame-skip mechanism could improve this; the test documents today's behavior.

## Test plan

- `./gradlew :kuery-client-core:test :kuery-client-spring-data-jdbc:test` with Docker — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)