### PR TITLE
Unify test method naming and structure test bodies with given-when-then

### DIFF
--- a/kuery-client-compiler/functional-test-auto-trim/src/test/kotlin/dev/hsbrysk/kuery/core/AutoTrimIndentTest.kt
+++ b/kuery-client-compiler/functional-test-auto-trim/src/test/kotlin/dev/hsbrysk/kuery/core/AutoTrimIndentTest.kt
@@ -14,8 +14,11 @@ import org.junit.jupiter.api.Test
 class AutoTrimIndentTest {
     @Test
     fun `multi-line template no longer needs an explicit trimIndent`() {
+        // given
         val name = "n"
         val age = 18
+
+        // when
         val sql = Sql {
             add(
                 """
@@ -25,6 +28,8 @@ class AutoTrimIndentTest {
                 """,
             )
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "UPDATE user\nSET name = :p0, age = :p1\nWHERE id = :p2",
@@ -38,15 +43,20 @@ class AutoTrimIndentTest {
     }
 
     @Test
-    fun `unaryPlus template with values at line start and line end`() {
+    fun `values at line start and line end survive the automatic trim`() {
+        // given
         val a = "A"
         val b = "B"
+
+        // when
         val sql = Sql {
             +"""
             $a AND x
             y = $b
             """
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 ":p0 AND x\ny = :p1",
@@ -57,7 +67,10 @@ class AutoTrimIndentTest {
 
     @Test
     fun `blank line in the middle is preserved`() {
+        // given
         val a = "A"
+
+        // when
         val sql = Sql {
             +"""
             a = $a
@@ -65,6 +78,8 @@ class AutoTrimIndentTest {
             b
             """
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "a = :p0\n\nb",
@@ -97,15 +112,21 @@ class AutoTrimIndentTest {
     @Suppress("KUERY_UNSAFE_SQL_STRING")
     @Test
     fun `variable argument is trimmed at runtime`() {
+        // given
         val s = "\n    SELECT 1\n"
+
+        // when
         val sql = Sql {
             add(s)
         }
+
+        // then
         assertThat(sql).isEqualTo(Sql("SELECT 1"))
     }
 
     @Test
     fun `if expression argument is trimmed once as a whole`() {
+        // given
         val x = "X"
 
         fun build(flag: Boolean) = Sql {
@@ -120,6 +141,8 @@ class AutoTrimIndentTest {
                 }
                 )
         }
+
+        // when & then
         assertThat(build(true)).isEqualTo(
             Sql("id = :p0\nAND y", listOf(NamedSqlParameter("p0", x))),
         )
@@ -129,13 +152,18 @@ class AutoTrimIndentTest {
     @Suppress("KUERY_REDUNDANT_TRIM_INDENT")
     @Test
     fun `explicit trimIndent still works`() {
+        // given
         val a = "A"
+
+        // when
         val sql = Sql {
             +"""
             SELECT *
             WHERE id = $a
             """.trimIndent()
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "SELECT *\nWHERE id = :p0",
@@ -146,13 +174,18 @@ class AutoTrimIndentTest {
 
     @Test
     fun `explicit trimMargin still works`() {
+        // given
         val a = "A"
+
+        // when
         val sql = Sql {
             +"""
             |SELECT *
             |WHERE id = $a
             """.trimMargin()
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "SELECT *\nWHERE id = :p0",
@@ -166,12 +199,16 @@ class AutoTrimIndentTest {
         // The automatic trim applies to whatever string reaches add — including the result of
         // an explicit trimMargin. Indentation deliberately kept after the margin prefix is
         // therefore stripped as well (documented in docs/basics.md; use addUnsafe to keep it).
+
+        // when
         val sql = Sql {
             +"""
             |  SELECT *
             |  FROM user
             """.trimMargin()
         }
+
+        // then
         assertThat(sql).isEqualTo(Sql("SELECT *\nFROM user"))
     }
 
@@ -180,6 +217,8 @@ class AutoTrimIndentTest {
     fun `blank edge line kept by an explicit trimIndent is also dropped`() {
         // Without the option the body would keep the blank line the explicit trimIndent
         // retained ("A\n\nSELECT 1"); the automatic trim drops it.
+
+        // when
         val sql = Sql {
             +"A"
             +"""
@@ -187,12 +226,17 @@ class AutoTrimIndentTest {
             SELECT 1
             """.trimIndent()
         }
+
+        // then
         assertThat(sql).isEqualTo(Sql("A\nSELECT 1"))
     }
 
     @Test
-    fun `nested add inside an interpolation value`() {
+    fun `a nested add inside an interpolation value trims its own string`() {
+        // given
         val x = "X"
+
+        // when
         val sql = Sql {
             +"""
             A ${run {
@@ -201,6 +245,8 @@ class AutoTrimIndentTest {
             }}
             """
         }
+
+        // then
         // The inner add runs first while the outer template's values are being evaluated, and
         // each add trims its own string.
         assertThat(sql).isEqualTo(
@@ -227,11 +273,13 @@ class AutoTrimIndentTest {
     @Suppress("KUERY_UNSAFE_SQL_STRING")
     @Test
     fun `addUnsafe is not trimmed`() {
+        // given
         val rawSql = """
             SELECT *
             FROM user
         """
 
+        // when & then
         // The same raw string, side by side: add gets the automatic trimIndent ...
         val trimmed = Sql { add(rawSql) }
         assertThat(trimmed).isEqualTo(Sql("SELECT *\nFROM user"))

--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/ExtensionHelperTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/ExtensionHelperTest.kt
@@ -31,11 +31,14 @@ private fun SqlBuilder.paging(
 class ExtensionHelperTest {
     @Test
     fun `extension function helpers are interpolated as usual`() {
+        // when
         val sql = Sql {
             +"SELECT * FROM users"
             whereUser(UserFilter(tenantId = 1, name = null, minAge = 20))
             paging(limit = 10, offset = 0)
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """

--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/GenericReceiverExtensionTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/GenericReceiverExtensionTest.kt
@@ -24,11 +24,14 @@ private fun <T : SqlBuilder> T.paging(
 
 class GenericReceiverExtensionTest {
     @Test
-    fun `generic receiver helper using unaryPlus`() {
+    fun `a helper with a generic SqlBuilder receiver using unaryPlus binds its value`() {
+        // when
         val sql = Sql {
             +"SELECT * FROM users"
             whereUserId(1)
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -41,11 +44,14 @@ class GenericReceiverExtensionTest {
     }
 
     @Test
-    fun `generic receiver helper using add`() {
+    fun `a helper with a generic SqlBuilder receiver using add binds its values`() {
+        // when
         val sql = Sql {
             +"SELECT * FROM users"
             paging(limit = 10, offset = 0)
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -61,11 +67,14 @@ class GenericReceiverExtensionTest {
     }
 
     @Test
-    fun `chained generic receiver helpers`() {
+    fun `chained generic receiver helpers share one consecutive parameter numbering`() {
+        // when
         val sql = Sql {
             +"SELECT * FROM users"
             whereUserId(1).paging(limit = 10, offset = 0)
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """

--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 @OptIn(DelicateKueryClientApi::class)
 class SqlTest {
     @Test
-    fun `simple create`() {
+    fun `a plain fragment becomes the SQL body with no parameters`() {
         val sql = Sql {
             +"SELECT * FROM user"
         }
@@ -15,7 +15,8 @@ class SqlTest {
     }
 
     @Test
-    fun `simple insert`() {
+    fun `interpolated values are bound as ordered named parameters`() {
+        // given
         data class User(
             val name: String,
             val age: Int,
@@ -23,10 +24,14 @@ class SqlTest {
         )
 
         val user = User(name = "name", age = 18, address = "address")
+
+        // when
         val sql = Sql {
             +"INSERT INTO user (name, age, address)"
             +"VALUES (${user.name}, ${user.age}, ${user.address})"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -43,7 +48,8 @@ class SqlTest {
     }
 
     @Test
-    fun `simple update`() {
+    fun `a multi-line template keeps its shape while values become placeholders`() {
+        // given
         data class User(
             val id: String,
             val name: String,
@@ -52,6 +58,8 @@ class SqlTest {
         )
 
         val user = User(id = "id", name = "name", age = 18, address = "address")
+
+        // when
         val sql = Sql {
             add(
                 """
@@ -65,6 +73,8 @@ class SqlTest {
                 """.trimIndent(),
             )
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -87,11 +97,16 @@ class SqlTest {
     }
 
     @Test
-    fun `simple delete`() {
+    fun `an interpolated value in a single-line fragment is bound as a parameter`() {
+        // given
         val id = "id"
+
+        // when
         val sql = Sql {
             +"DELETE FROM user WHERE id = $id"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -105,13 +120,18 @@ class SqlTest {
     }
 
     @Test
-    fun `select in`() {
+    fun `a collection value in an IN clause is bound as a single parameter`() {
+        // given
         val ids = listOf(1, 2, 3, 4, 5)
+
+        // when
         val sql = Sql {
             +"SELECT *"
             +"FROM user"
             +"WHERE id IN ($ids)"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -127,16 +147,22 @@ class SqlTest {
     }
 
     @Test
-    fun `select in empty collection`() {
+    fun `an empty collection is bound as a single parameter without expansion`() {
         // An empty collection is NOT expanded at the core level. It is bound as a single
         // parameter whose value is the empty collection; what happens next is up to the
         // executing layer (e.g. Spring's named parameter expansion).
+
+        // given
         val emptyIds = emptyList<Int>()
+
+        // when
         val sql = Sql {
             +"SELECT *"
             +"FROM user"
             +"WHERE id IN ($emptyIds)"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -150,10 +176,15 @@ class SqlTest {
             ),
         )
 
+        // given
         val emptyIdSet = emptySet<Int>()
+
+        // when
         val sql2 = Sql {
             +"SELECT * FROM user WHERE id IN ($emptyIdSet)"
         }
+
+        // then
         assertThat(sql2).isEqualTo(
             Sql(
                 "SELECT * FROM user WHERE id IN (:p0)",
@@ -165,14 +196,20 @@ class SqlTest {
     }
 
     @Test
-    fun `placeholder immediately followed by a cast suffix`() {
+    fun `a cast suffix immediately after a placeholder is kept verbatim`() {
         // PostgreSQL style casts like `$value::jsonb` must keep the cast suffix verbatim
         // right after the generated placeholder.
+
+        // given
         val json = """{"theme":"dark"}"""
         val id = "id"
+
+        // when
         val sql = Sql {
             +"UPDATE user SET settings = $json::jsonb WHERE id = $id::uuid"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "UPDATE user SET settings = :p0::jsonb WHERE id = :p1::uuid",
@@ -185,7 +222,8 @@ class SqlTest {
     }
 
     @Test
-    fun `insert multi`() {
+    fun `values expands rows into consecutively numbered parameters`() {
+        // given
         data class User(
             val name: String,
             val age: Int,
@@ -197,10 +235,14 @@ class SqlTest {
             User(name = "name2", age = 2, address = "address2"),
             User(name = "name3", age = 3, address = "address3"),
         )
+
+        // when
         val sql = Sql {
             +"INSERT INTO user (name, age, address)"
             values(users) { listOf(it.name, it.age, it.address) }
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -219,7 +261,8 @@ class SqlTest {
     }
 
     @Test
-    fun `select complex condition`() {
+    fun `conditional lines appear only for non-null values with consecutive numbering`() {
+        // given
         data class UserFilter(
             val id: String,
             val name: String?,
@@ -228,6 +271,8 @@ class SqlTest {
         )
 
         val filter = UserFilter(id = "id", name = null, age = 18, address = null)
+
+        // when
         val sql = Sql {
             +"SELECT *"
             +"FROM user"
@@ -237,6 +282,8 @@ class SqlTest {
             filter.age?.let { +"AND age = $it" }
             filter.address?.let { +"AND address = $it" }
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -256,17 +303,23 @@ class SqlTest {
 
     @Suppress("KUERY_UNSAFE_SQL_STRING")
     @Test
-    fun `mixing interpolation and manual bind`() {
+    fun `interpolation and manual bind share a single parameter counter`() {
         // Interpolation and manual bind() share a single parameter counter, so numbering
         // never collides. Binding the same value twice yields two distinct parameters.
+
+        // given
         val userId = "user1"
         val mask = 0b0100
         val age = 18
+
+        // when
         val sql = Sql {
             +"SELECT * FROM user WHERE id = $userId"
             addUnsafe("AND permission & ${bind(mask)} = ${bind(mask)}")
             +"AND age = $age"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """
@@ -286,7 +339,8 @@ class SqlTest {
 
     @Suppress("KUERY_UNSAFE_SQL_STRING")
     @Test
-    fun mixedOrder() {
+    fun `parameter numbering follows bind evaluation order, not line order`() {
+        // when
         val sql = Sql {
             val line2 = "L2=${bind(2)}"
             val line1 = "L1=${bind(1)}"
@@ -296,6 +350,8 @@ class SqlTest {
             +line1
             +line2
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 """

--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
@@ -10,14 +10,14 @@ private const val ORDER_COLUMN = "created_at"
 
 class StringInterpolationTest {
     @Test
-    fun none() {
+    fun `an empty block builds an empty Sql`() {
         val sql = Sql {
         }
         assertThat(sql).isEqualTo(Sql(""))
     }
 
     @Test
-    fun `empty string`() {
+    fun `empty fragments collapse to an empty Sql`() {
         val sql1 = Sql {
             +""
         }
@@ -34,7 +34,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `only string interpolation`() {
+    fun `a template consisting only of values produces only placeholders`() {
         val sql1 = Sql {
             +"${1}"
         }
@@ -57,7 +57,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `only fragments`() {
+    fun `fragments without values are joined with newlines`() {
         val sql1 = Sql {
             +"hoge"
         }
@@ -77,7 +77,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun mixed() {
+    fun `values become placeholders at their exact positions in the text`() {
         val sql1 = Sql {
             +"a${1}b"
         }
@@ -119,7 +119,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `int string interpolation`() {
+    fun `int constants and int expressions are bound as parameters`() {
         val sql1 = Sql {
             +"a ${1}"
         }
@@ -142,7 +142,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `string string interpolation`() {
+    fun `a string literal value is inlined while a computed string is bound`() {
         // In such cases, string interpolation will not be executed.
         val sql1 = Sql {
             +"a ${"hoge"}"
@@ -166,7 +166,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `boolean string interpolation`() {
+    fun `boolean constants and boolean expressions are bound as parameters`() {
         // In such cases, string interpolation will not be executed.
         val sql1 = Sql {
             +"a ${true}"
@@ -192,9 +192,12 @@ class StringInterpolationTest {
 
     @Suppress("KUERY_UNSAFE_SQL_STRING")
     @Test
-    fun `nested add`() {
+    fun `an add nested in a run block emits its line before the outer add`() {
+        // given
         val x = "X"
         val y = "1; DROP TABLE users"
+
+        // when
         val sql = Sql {
             add(
                 run {
@@ -203,6 +206,8 @@ class StringInterpolationTest {
                 },
             )
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "B :p0\nS :p1",
@@ -213,15 +218,20 @@ class StringInterpolationTest {
 
     @Suppress("KUERY_UNSAFE_SQL_STRING")
     @Test
-    fun `nested unaryPlus`() {
+    fun `a unaryPlus nested in a run block emits its line before the outer one`() {
+        // given
         val x = "X"
         val y = "1; DROP TABLE users"
+
+        // when
         val sql = Sql {
             +run {
                 +"B $x"
                 "S $y"
             }
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "B :p0\nS :p1",
@@ -232,10 +242,13 @@ class StringInterpolationTest {
 
     @Suppress("KUERY_UNSAFE_SQL_STRING")
     @Test
-    fun `doubly nested add`() {
+    fun `doubly nested adds emit lines in innermost-first order`() {
+        // given
         val x = "X"
         val y = "Y"
         val z = "Z"
+
+        // when
         val sql = Sql {
             add(
                 run {
@@ -249,6 +262,8 @@ class StringInterpolationTest {
                 },
             )
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "A :p0\nB :p1\nC :p2",
@@ -262,15 +277,20 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `nested add inside an interpolation value`() {
+    fun `an add inside an interpolation value emits first and the block result is bound`() {
+        // given
         val x = "X"
         val y = "Y"
+
+        // when
         val sql = Sql {
             +"A ${run {
                 add("B $x")
                 "v"
             }} C $y"
         }
+
+        // then
         // The inner add runs first while the outer template's values are being evaluated,
         // then the outer template binds the run block's result ("v") as a single value.
         assertThat(sql).isEqualTo(
@@ -286,14 +306,19 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `nested unaryPlus inside an interpolation value`() {
+    fun `a unaryPlus inside an interpolation value emits first and the block result is bound`() {
+        // given
         val x = "X"
+
+        // when
         val sql = Sql {
             +"A ${run {
                 +"B $x"
                 "v"
             }}"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "B :p0\nA :p1",
@@ -321,16 +346,20 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `if expression as the whole argument`() {
+    fun `templates inside if branches are converted into bind parameters`() {
         // The IR transformation keeps its context across the whole argument expression,
         // so templates inside if branches are converted into bind parameters.
         // This is the premise for KUERY_UNSAFE_SQL_STRING accepting if/when expressions
         // with safe branches (allWarningsAsErrors guards that no warning is reported).
+
+        // given
         val x = "X"
 
         fun build(flag: Boolean) = Sql {
             +(if (flag) "id = $x" else "TRUE")
         }
+
+        // when & then
         assertThat(build(true)).isEqualTo(
             Sql("id = :p0", listOf(NamedSqlParameter("p0", "X"))),
         )
@@ -338,7 +367,8 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `when expression as the whole argument`() {
+    fun `templates inside when branches are converted and const branches stay raw text`() {
+        // given
         val x = "X"
 
         fun build(sort: String?) = Sql {
@@ -350,6 +380,8 @@ class StringInterpolationTest {
                 },
             )
         }
+
+        // when & then
         assertThat(build("name")).isEqualTo(Sql("ORDER BY name"))
         assertThat(build("id")).isEqualTo(
             Sql("ORDER BY id, :p0", listOf(NamedSqlParameter("p0", "X"))),
@@ -359,11 +391,16 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `const val string interpolation`() {
+    fun `a const val in a template is expanded as raw SQL text`() {
+        // given
         val id = 1
+
+        // when
         val sql = Sql {
             +"SELECT * FROM $TABLE WHERE id = $id"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "SELECT * FROM users WHERE id = :p0",
@@ -373,7 +410,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `const val only`() {
+    fun `a template consisting of a single const val expands to its raw text`() {
         val sql = Sql {
             +"$TABLE"
         }
@@ -381,7 +418,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `const val as whole argument`() {
+    fun `a const val passed directly to add executes as raw SQL text`() {
         // A const val reference is a compile-time constant, so it is accepted without
         // a KUERY_UNSAFE_SQL_STRING warning and executed as raw SQL text.
         val sql = Sql {
@@ -391,11 +428,16 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `trailing const val`() {
+    fun `a trailing const val expands as raw text while runtime values are bound`() {
+        // given
         val id = 1
+
+        // when
         val sql = Sql {
             +"WHERE id = $id ORDER BY $ORDER_COLUMN"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "WHERE id = :p0 ORDER BY created_at",
@@ -405,11 +447,16 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `char constant string interpolation`() {
+    fun `an interpolated char constant is inlined as raw text`() {
+        // given
         val x = 1
+
+        // when
         val sql = Sql {
             +"SELECT data->>'${'$'}name' FROM t WHERE id = $x"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "SELECT data->>'\$name' FROM t WHERE id = :p0",
@@ -419,11 +466,16 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `char percent constant string interpolation`() {
+    fun `interpolated percent chars are inlined as raw text around a bound value`() {
+        // given
         val keyword = "foo"
+
+        // when
         val sql = Sql {
             +"WHERE name LIKE ${'%'}$keyword${'%'}"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "WHERE name LIKE %:p0%",
@@ -434,10 +486,15 @@ class StringInterpolationTest {
 
     @Test
     fun `consecutive constants are merged`() {
+        // given
         val x = 1
+
+        // when
         val sql = Sql {
             +"a$TABLE${'c'} $x"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "ausersc :p0",
@@ -447,11 +504,16 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `literal string interpolation mixed with runtime value`() {
+    fun `an inlined literal and a bound runtime value coexist in one template`() {
+        // given
         val x = 1
+
+        // when
         val sql = Sql {
             +"a ${"hoge"} b $x"
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql(
                 "a hoge b :p0",
@@ -462,7 +524,10 @@ class StringInterpolationTest {
 
     @Test
     fun `receiver expression is evaluated only once`() {
+        // given
         var count = 0
+
+        // when
         val sql = Sql {
             fun receiver(): SqlBuilder {
                 count++
@@ -470,6 +535,8 @@ class StringInterpolationTest {
             }
             receiver().add("WHERE id = ${1}")
         }
+
+        // then
         assertThat(sql).isEqualTo(
             Sql("WHERE id = :p0", listOf(NamedSqlParameter("p0", 1))),
         )
@@ -478,9 +545,12 @@ class StringInterpolationTest {
 
     @Test
     fun `body and parameter go to the same builder even if the receiver expression is impure`() {
+        // given
         var callCount = 0
         lateinit var outerBuilder: SqlBuilder
         val innerSqls = mutableListOf<Sql>()
+
+        // when
         val outerSql = Sql {
             outerBuilder = this
             val innerSql = Sql {
@@ -494,6 +564,8 @@ class StringInterpolationTest {
             }
             innerSqls.add(innerSql)
         }
+
+        // then
         // The receiver expression must be evaluated once, so both the SQL body and
         // the parameter must go to its first result (= outerBuilder).
         assertThat(outerSql).isEqualTo(
@@ -503,7 +575,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `null string interpolation`() {
+    fun `a null constant is bound as null and a computed null string as text`() {
         // In such cases, string interpolation will not be executed.
         val sql1 = Sql {
             +"a ${null}"

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/AutoTrimIndentBytecodeTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/AutoTrimIndentBytecodeTest.kt
@@ -20,13 +20,17 @@ import org.junit.jupiter.api.Test
 class AutoTrimIndentBytecodeTest {
     @Test
     fun `template argument is trimmed at compile time`() {
+        // when
         val result = compile(autoTrimIndent = true, source = TEMPLATE_ARGUMENT_SOURCE)
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.classesReference("trimIndent")).isFalse()
     }
 
     @Test
     fun `constant argument is trimmed at compile time`() {
+        // when
         val result = compile(
             autoTrimIndent = true,
             source = """
@@ -39,27 +43,38 @@ class AutoTrimIndentBytecodeTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.classesReference("trimIndent")).isFalse()
     }
 
     @Test
     fun `variable argument is trimmed at runtime`() {
+        // when
         val result = compile(autoTrimIndent = true, source = VARIABLE_ARGUMENT_SOURCE)
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.classesReference("trimIndent")).isTrue()
     }
 
     @Test
     fun `nothing is injected for a template argument when the option is off`() {
+        // when
         val result = compile(autoTrimIndent = false, source = TEMPLATE_ARGUMENT_SOURCE)
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.classesReference("trimIndent")).isFalse()
     }
 
     @Test
     fun `nothing is injected for a variable argument when the option is off`() {
+        // when
         val result = compile(autoTrimIndent = false, source = VARIABLE_ARGUMENT_SOURCE)
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.classesReference("trimIndent")).isFalse()
     }

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/BindCallInSqlTemplateCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/BindCallInSqlTemplateCheckerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 class BindCallInSqlTemplateCheckerTest {
     @Test
     fun `warn when bind is called inside a template passed to unaryPlus`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.DelicateKueryClientApi
@@ -23,12 +24,15 @@ class BindCallInSqlTemplateCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn when bind is called inside a template passed to add`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.DelicateKueryClientApi
@@ -40,12 +44,15 @@ class BindCallInSqlTemplateCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn when bind is called indirectly inside an interpolated value`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.DelicateKueryClientApi
@@ -57,12 +64,15 @@ class BindCallInSqlTemplateCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn when bind is called inside a template in an if branch passed to add`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.DelicateKueryClientApi
@@ -74,12 +84,15 @@ class BindCallInSqlTemplateCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `no warning when bind is used with addUnsafe`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.DelicateKueryClientApi
@@ -92,12 +105,15 @@ class BindCallInSqlTemplateCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `no warning for plain interpolation`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -109,12 +125,15 @@ class BindCallInSqlTemplateCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `warning can be suppressed by diagnostic name`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.DelicateKueryClientApi
@@ -128,12 +147,15 @@ class BindCallInSqlTemplateCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `warning becomes an error with -Werror`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.DelicateKueryClientApi
@@ -146,6 +168,8 @@ class BindCallInSqlTemplateCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerCommandLineProcessorTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerCommandLineProcessorTest.kt
@@ -16,13 +16,19 @@ class KueryClientCompilerCommandLineProcessorTest {
     @ParameterizedTest
     @ValueSource(strings = ["true", "false"])
     fun `canonical boolean values are accepted`(value: String) {
+        // when
         val result = compileWithOptionValue(value)
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `an invalid option value fails with an error naming the option`() {
+        // when
         val result = compileWithOptionValue("True")
+
+        // then
         assertThat(result.exitCode).isNotEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains("autoTrimIndent must be 'true' or 'false', but was 'True'")
     }

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/RedundantTrimIndentCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/RedundantTrimIndentCheckerTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 class RedundantTrimIndentCheckerTest {
     @Test
     fun `warn on an explicit trimIndent on a template passed to add`() {
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -22,12 +23,15 @@ class RedundantTrimIndentCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn on an explicit trimIndent on a literal passed to unaryPlus`() {
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -37,12 +41,15 @@ class RedundantTrimIndentCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn on an explicit trimIndent on a const val`() {
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -54,12 +61,15 @@ class RedundantTrimIndentCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn on a trimIndent chained after trimMargin`() {
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -69,12 +79,15 @@ class RedundantTrimIndentCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn on a doubled trimIndent`() {
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -84,12 +97,15 @@ class RedundantTrimIndentCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn on a trimIndent inside an if branch`() {
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -99,6 +115,8 @@ class RedundantTrimIndentCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
@@ -108,6 +126,7 @@ class RedundantTrimIndentCheckerTest {
         // The unsafe branch draws KUERY_UNSAFE_SQL_STRING on the whole argument, but the
         // redundant trim in the safe branch is still real: the runtime auto-trim wraps the
         // selected branch value regardless.
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -124,6 +143,8 @@ class RedundantTrimIndentCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
         assertThat(result.messages).contains("KUERY_UNSAFE_SQL_STRING")
@@ -132,6 +153,7 @@ class RedundantTrimIndentCheckerTest {
     @Test
     fun `no warning for trimMargin`() {
         // autoTrimIndent does not remove margins, so an explicit trimMargin is not redundant.
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -142,12 +164,15 @@ class RedundantTrimIndentCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `no warning without an explicit trimIndent`() {
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -158,12 +183,15 @@ class RedundantTrimIndentCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `no warning when the option is off`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -174,6 +202,8 @@ class RedundantTrimIndentCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
@@ -182,6 +212,7 @@ class RedundantTrimIndentCheckerTest {
     fun `a variable receiver gets both the unsafe and the redundant warning`() {
         // The two warnings state independent facts: the string cannot be verified at compile
         // time, and the explicit trim is redundant because the automatic one runs anyway.
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -191,6 +222,8 @@ class RedundantTrimIndentCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains("KUERY_UNSAFE_SQL_STRING")
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
@@ -198,6 +231,7 @@ class RedundantTrimIndentCheckerTest {
 
     @Test
     fun `warning can be suppressed by diagnostic name`() {
+        // when
         val result = compileWithAutoTrim(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -209,6 +243,8 @@ class RedundantTrimIndentCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 class UnsafeSqlStringCheckerTest {
     @Test
     fun `warn when a variable is passed to add`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -22,12 +23,15 @@ class UnsafeSqlStringCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn when a variable is passed to unaryPlus`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -38,12 +42,15 @@ class UnsafeSqlStringCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn when a run block is passed to add`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -53,12 +60,15 @@ class UnsafeSqlStringCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `no warning when an if expression with safe branches is passed to add`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -71,12 +81,15 @@ class UnsafeSqlStringCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `no warning when a when expression with safe branches is passed to add`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -97,12 +110,15 @@ class UnsafeSqlStringCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `no warning when a when expression has an error branch`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -121,12 +137,15 @@ class UnsafeSqlStringCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `no warning when an if expression has a throw branch`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -145,12 +164,15 @@ class UnsafeSqlStringCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `warn when an if expression has an unsafe branch`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -160,12 +182,15 @@ class UnsafeSqlStringCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn when a non-whitelisted method chain is passed to add`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -175,12 +200,15 @@ class UnsafeSqlStringCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warn when string concatenation via plus is passed to add`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -190,6 +218,8 @@ class UnsafeSqlStringCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
@@ -197,6 +227,7 @@ class UnsafeSqlStringCheckerTest {
     @Test
     fun `no warning for safe argument forms`() {
         // allWarningsAsErrors = true, so any unexpected warning fails the compilation as well
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.DelicateKueryClientApi
@@ -221,6 +252,8 @@ class UnsafeSqlStringCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
@@ -229,6 +262,7 @@ class UnsafeSqlStringCheckerTest {
     fun `no warning for extension function helpers writing common query parts`() {
         // Mirrors the documented helper style: common WHERE clauses etc. written as
         // SqlBuilder extension functions using add/unaryPlus with string templates.
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -254,12 +288,15 @@ class UnsafeSqlStringCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `warn when an extension helper passes its parameter to unaryPlus`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.SqlBuilder
@@ -269,12 +306,15 @@ class UnsafeSqlStringCheckerTest {
             }
             """.trimIndent(),
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     @Test
     fun `warning can be suppressed by diagnostic name`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -287,12 +327,15 @@ class UnsafeSqlStringCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `warning becomes an error with -Werror`() {
+        // when
         val result = compile(
             """
             import dev.hsbrysk.kuery.core.Sql
@@ -304,6 +347,8 @@ class UnsafeSqlStringCheckerTest {
             """.trimIndent(),
             allWarningsAsErrors = true,
         )
+
+        // then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
         assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/TrimFoldingTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/ir/misc/TrimFoldingTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 
 class TrimFoldingTest {
     @Test
-    fun `values mid-line`() {
+    fun `a template with values mid-line folds like runtime trimIndent`() {
         assertFoldsLikeRuntime(
             fragments = listOf("\n                UPDATE user\n                SET name = ", "\n                "),
             valueCount = 1,
@@ -15,7 +15,7 @@ class TrimFoldingTest {
     }
 
     @Test
-    fun `value at line start`() {
+    fun `a template with a value at line start folds like runtime trimIndent`() {
         assertFoldsLikeRuntime(
             fragments = listOf("\n    ", " AND foo\n    bar\n"),
             valueCount = 1,
@@ -23,7 +23,7 @@ class TrimFoldingTest {
     }
 
     @Test
-    fun `trailing value`() {
+    fun `a template ending with a value folds like runtime trimIndent`() {
         // fragments.size == valueCount (no trailing fragment)
         assertFoldsLikeRuntime(
             fragments = listOf("\n  SELECT *\n  WHERE id = "),
@@ -32,7 +32,7 @@ class TrimFoldingTest {
     }
 
     @Test
-    fun `consecutive values and blank lines`() {
+    fun `a template with consecutive values and blank lines folds like runtime trimIndent`() {
         assertFoldsLikeRuntime(
             fragments = listOf("\n   a ", "", "\n\n   b\n   "),
             valueCount = 3,
@@ -40,7 +40,7 @@ class TrimFoldingTest {
     }
 
     @Test
-    fun `blank first and last lines`() {
+    fun `a template with blank first and last lines folds like runtime trimIndent`() {
         assertFoldsLikeRuntime(
             fragments = listOf("   \n  x = ", "\n   \t"),
             valueCount = 1,
@@ -48,7 +48,7 @@ class TrimFoldingTest {
     }
 
     @Test
-    fun `no values`() {
+    fun `a template with no values folds like runtime trimIndent`() {
         assertFoldsLikeRuntime(
             fragments = listOf("\n  SELECT *\n  FROM user\n"),
             valueCount = 0,
@@ -56,7 +56,7 @@ class TrimFoldingTest {
     }
 
     @Test
-    fun `single line`() {
+    fun `a single-line template folds like runtime trimIndent`() {
         assertFoldsLikeRuntime(
             fragments = listOf("  SELECT ", ""),
             valueCount = 1,
@@ -64,7 +64,7 @@ class TrimFoldingTest {
     }
 
     @Test
-    fun `empty template`() {
+    fun `an empty template folds like runtime trimIndent`() {
         assertFoldsLikeRuntime(
             fragments = listOf(""),
             valueCount = 0,
@@ -72,7 +72,7 @@ class TrimFoldingTest {
     }
 
     @Test
-    fun `value only`() {
+    fun `a value-only template folds like runtime trimIndent`() {
         assertFoldsLikeRuntime(
             fragments = listOf(""),
             valueCount = 1,
@@ -80,7 +80,7 @@ class TrimFoldingTest {
     }
 
     @Test
-    fun `fragment containing the sentinel falls back`() {
+    fun `foldOrNull returns null when a fragment contains the sentinel character`() {
         assertThat(TrimFolding.foldOrNull(listOf("a\u0000b"), 0)).isNull()
     }
 

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderTest.kt
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.Test
 
 class DefaultSqlBuilderTest {
     @Test
-    fun add() {
+    fun `add throws IllegalStateException when the compiler plugin is not applied`() {
+        // when & then
         assertFailure {
             DefaultSqlBuilder().add("")
         }.isInstanceOf(IllegalStateException::class)
@@ -23,7 +24,8 @@ class DefaultSqlBuilderTest {
     }
 
     @Test
-    fun unaryPlus() {
+    fun `unaryPlus throws IllegalStateException when the compiler plugin is not applied`() {
+        // when & then
         assertFailure {
             with(DefaultSqlBuilder()) {
                 +""
@@ -36,7 +38,7 @@ class DefaultSqlBuilderTest {
     }
 
     @Test
-    fun addUnsafe() {
+    fun `addUnsafe joins fragments with newlines, ignoring empty fragments`() {
         DefaultSqlBuilder()
             .apply {
                 addUnsafe("")
@@ -74,7 +76,7 @@ class DefaultSqlBuilderTest {
     }
 
     @Test
-    fun bind() {
+    fun `bind returns sequential placeholders and records the parameters in order`() {
         DefaultSqlBuilder()
             .apply {
                 assertThat(bind(1)).isEqualTo(":p0")
@@ -95,7 +97,7 @@ class DefaultSqlBuilderTest {
     }
 
     @Test
-    fun bindSameValueTwice() {
+    fun `binding the same value twice creates two parameters`() {
         DefaultSqlBuilder()
             .apply {
                 assertThat(bind(1)).isEqualTo(":p0")
@@ -108,7 +110,7 @@ class DefaultSqlBuilderTest {
     }
 
     @Test
-    fun bindCollection() {
+    fun `bind binds a collection as a single parameter holding the collection itself`() {
         // A collection is bound as a single parameter holding the collection itself.
         val ids = listOf(1, 2, 3)
         DefaultSqlBuilder()
@@ -122,19 +124,22 @@ class DefaultSqlBuilderTest {
     }
 
     @Test
-    fun buildIsNotAffectedByLaterBind() {
+    fun `build returns a snapshot that is not affected by later bind calls`() {
+        // given
         val builder = DefaultSqlBuilder().apply {
             addUnsafe("SELECT * FROM some_table WHERE id = ${bind(1)}")
         }
         val sql = builder.build()
 
+        // when
         builder.bind(2)
 
+        // then
         assertThat(sql.parameters).isEqualTo(listOf(NamedSqlParameter("p0", 1)))
     }
 
     @Test
-    fun interpolate() {
+    fun `interpolate weaves placeholders between fragments and throws IllegalStateException on count mismatch`() {
         assertThat(DefaultSqlBuilder().interpolate(emptyList(), emptyList())).isEqualTo("")
         assertThat(DefaultSqlBuilder().interpolate(listOf("a"), emptyList())).isEqualTo("a")
         assertThat(DefaultSqlBuilder().interpolate(listOf("a"), listOf(1))).isEqualTo("a:p0")

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/NamedSqlParameterTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/NamedSqlParameterTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 
 class NamedSqlParameterTest {
     @Test
-    fun of() {
+    fun `NamedSqlParameter creates a DefaultNamedSqlParameter with the given name and value`() {
         assertThat(NamedSqlParameter("hoge", "hoge-value"))
             .isEqualTo(DefaultNamedSqlParameter("hoge", "hoge-value"))
 

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/SqlBuilderHelpersTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/SqlBuilderHelpersTest.kt
@@ -9,15 +9,19 @@ import org.junit.jupiter.api.Test
 @OptIn(DelicateKueryClientApi::class)
 class SqlBuilderHelpersTest {
     @Test
-    fun `values single`() {
+    fun `values with a single row appends a single VALUES group`() {
+        // given
         val input = listOf(
             listOf("user0", "user0@example.com", 1),
         )
+
+        // when
         val result = Sql {
             addUnsafe("INSERT INTO users (userid, email, age)")
             values(input)
         }
 
+        // then
         assertThat(result.body)
             .isEqualTo("INSERT INTO users (userid, email, age)\nVALUES (:p0, :p1, :p2)")
         assertThat(result.parameters).isEqualTo(
@@ -30,17 +34,21 @@ class SqlBuilderHelpersTest {
     }
 
     @Test
-    fun `values multi`() {
+    fun `values with multiple rows appends comma-separated VALUES groups`() {
+        // given
         val input = listOf(
             listOf("user0", "user0@example.com", 1),
             listOf("user1", null, 2),
             listOf("user2", "user2@example.com", 3),
         )
+
+        // when
         val result = Sql {
             addUnsafe("INSERT INTO users (userid, email, age)")
             values(input)
         }
 
+        // then
         assertThat(result.body)
             .isEqualTo(
                 "INSERT INTO users (userid, email, age)\nVALUES (:p0, :p1, :p2), (:p3, :p4, :p5), (:p6, :p7, :p8)",
@@ -61,7 +69,8 @@ class SqlBuilderHelpersTest {
     }
 
     @Test
-    fun `values empty`() {
+    fun `values throws IllegalArgumentException for an empty list`() {
+        // when & then
         assertFailure {
             Sql {
                 addUnsafe("INSERT INTO users (userid, email, age)")
@@ -71,10 +80,13 @@ class SqlBuilderHelpersTest {
     }
 
     @Test
-    fun `values child list empty`() {
+    fun `values throws IllegalArgumentException when a row is empty`() {
+        // given
         val input = listOf(
             listOf<Any>(),
         )
+
+        // when & then
         assertFailure {
             Sql {
                 addUnsafe("INSERT INTO users (userid, email, age)")
@@ -84,12 +96,15 @@ class SqlBuilderHelpersTest {
     }
 
     @Test
-    fun `values child list size is different`() {
+    fun `values throws IllegalArgumentException when rows have different sizes`() {
+        // given
         val input = listOf(
             listOf("user0", "user0@example.com", 1),
             listOf("user1", null),
             listOf("user2", "user2@example.com", 3),
         )
+
+        // when & then
         assertFailure {
             Sql {
                 addUnsafe("INSERT INTO users (userid, email, age)")
@@ -99,7 +114,8 @@ class SqlBuilderHelpersTest {
     }
 
     @Test
-    fun `values multi with transformer`() {
+    fun `values with a transformer maps each element to a row of bind values`() {
+        // given
         data class UserParam(
             val userid: String,
             val email: String?,
@@ -111,11 +127,14 @@ class SqlBuilderHelpersTest {
             UserParam("user1", null, 2),
             UserParam("user2", "user2@example.com", 3),
         )
+
+        // when
         val result = Sql {
             addUnsafe("INSERT INTO users (userid, email, age)")
             values(input) { listOf(it.userid, it.email, it.age) }
         }
 
+        // then
         assertThat(result.body)
             .isEqualTo(
                 "INSERT INTO users (userid, email, age)\nVALUES (:p0, :p1, :p2), (:p3, :p4, :p5), (:p6, :p7, :p8)",

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/SqlTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 
 class SqlTest {
     @Test
-    fun of() {
+    fun `Sql creates a DefaultSql with the given body and parameters`() {
         assertThat(
             Sql(
                 "SELECT * FROM some_table",
@@ -23,12 +23,15 @@ class SqlTest {
     }
 
     @Test
-    fun notAffectedByCallerListMutation() {
+    fun `Sql is not affected by later mutation of the caller parameter list`() {
+        // given
         val parameters = mutableListOf(NamedSqlParameter("p0", 1))
         val sql = Sql("SELECT * FROM some_table WHERE id = :p0", parameters)
 
+        // when
         parameters.add(NamedSqlParameter("p1", 2))
 
+        // then
         assertThat(sql.parameters).isEqualTo(listOf(NamedSqlParameter("p0", 1)))
     }
 }

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
@@ -15,7 +15,7 @@ import java.lang.ref.WeakReference
 @OptIn(KueryClientInternalApi::class)
 class SqlIdsTest {
     @Test
-    fun id() {
+    fun `id resolves the fully qualified class and method name of the call site`() {
         assertThat(ClassA().sql1 {}).isEqualTo("com.example.core.ClassA.sql1")
         runBlocking { assertThat(ClassA().sql2 {}).isEqualTo("com.example.core.ClassA.sql2") }
         assertThat(ClassA.ClassB().sql3 {}).isEqualTo("com.example.core.ClassA.ClassB.sql3")
@@ -37,14 +37,17 @@ class SqlIdsTest {
     }
 
     @Test
-    fun removeSuffixes() {
+    fun `removeSuffixes strips a matching suffix and leaves the string unchanged otherwise`() {
         assertThat("a.b.c".removeSuffixes(listOf(".b", ".c"))).isEqualTo("a.b")
         assertThat("a.b.c".removeSuffixes(listOf(".a", ".d"))).isEqualTo("a.b.c")
     }
 
     @Test
-    fun `id should not pin the class loader of the block class`() {
+    fun `id does not pin the class loader of the block class`() {
+        // when
         val loaderRef = useBlockFromIsolatedClassLoader()
+
+        // then
         repeat(100) {
             if (loaderRef.get() == null) {
                 return

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConventionTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConventionTest.kt
@@ -12,12 +12,12 @@ class KueryClientFetchObservationConventionTest {
     private val target = KueryClientFetchObservationConvention.default()
 
     @Test
-    fun getName() {
+    fun `name returns the fixed observation name`() {
         assertThat(target.name).isEqualTo("kuery.client.fetches")
     }
 
     @Test
-    fun supportsContext() {
+    fun `supportsContext returns true only for KueryClientFetchContext`() {
         assertThat(target.supportsContext(KueryClientFetchContext("id", Sql("")))).isTrue()
         assertThat(target.supportsContext(Observation.Context())).isFalse()
     }

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentationTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentationTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class KueryClientObservationDocumentationTest {
     @Test
-    fun fetch() {
+    fun `FETCH declares the default convention and its low and high cardinality key names`() {
         assertThat(FETCH.defaultConvention).isEqualTo(DefaultKueryClientFetchObservationConvention::class.java)
         assertThat(FETCH.lowCardinalityKeyNames.map { it.asString() }).isEqualTo(listOf("sql.id"))
         assertThat(FETCH.highCardinalityKeyNames.map { it.asString() }).isEqualTo(listOf("sql"))

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/observation/internal/DefaultKueryClientFetchObservationConventionTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/observation/internal/DefaultKueryClientFetchObservationConventionTest.kt
@@ -10,18 +10,28 @@ class DefaultKueryClientFetchObservationConventionTest {
     private val target = DefaultKueryClientFetchObservationConvention()
 
     @Test
-    fun getLowCardinalityKeyValues() {
+    fun `getLowCardinalityKeyValues returns only the sql id key value`() {
+        // given
         val ctx = KueryClientFetchContext("id", Sql("body"))
+
+        // when
         val result = target.getLowCardinalityKeyValues(ctx)
+
+        // then
         assertThat(result.toList().size).isEqualTo(1)
         assertThat(result.first().key).isEqualTo("sql.id")
         assertThat(result.first().value).isEqualTo("id")
     }
 
     @Test
-    fun getHighCardinalityKeyValues() {
+    fun `getHighCardinalityKeyValues returns only the sql key holding the body`() {
+        // given
         val ctx = KueryClientFetchContext("id", Sql("body"))
+
+        // when
         val result = target.getHighCardinalityKeyValues(ctx)
+
+        // then
         assertThat(result.toList().size).isEqualTo(1)
         assertThat(result.first().key).isEqualTo("sql")
         assertThat(result.first().value).isEqualTo("body")

--- a/kuery-client-gradle-plugin/src/test/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePluginTest.kt
+++ b/kuery-client-gradle-plugin/src/test/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePluginTest.kt
@@ -20,32 +20,40 @@ class KueryClientGradlePluginTest {
 
     @ParameterizedTest
     @EnumSource(KotlinPlatformType::class, names = ["jvm", "androidJvm"])
-    fun `applicable to JVM compilations`(platformType: KotlinPlatformType) {
+    fun `the plugin is applicable to JVM compilations`(platformType: KotlinPlatformType) {
         assertThat(plugin.isApplicable(compilation(platformType))).isTrue()
     }
 
     @ParameterizedTest
     @EnumSource(KotlinPlatformType::class, names = ["jvm", "androidJvm"], mode = EnumSource.Mode.EXCLUDE)
-    fun `not applicable to non-JVM compilations`(platformType: KotlinPlatformType) {
+    fun `the plugin is not applicable to non-JVM compilations`(platformType: KotlinPlatformType) {
         assertThat(plugin.isApplicable(compilation(platformType))).isFalse()
     }
 
     @Test
     fun `no option is emitted at the default so older compiler plugins keep working`() {
+        // given
         val project = ProjectBuilder.builder().build()
         plugin.apply(project)
 
+        // when
         val options = plugin.applyToCompilation(compilation(project)).get()
+
+        // then
         assertThat(options).isEmpty()
     }
 
     @Test
     fun `autoTrimIndent is passed through when enabled`() {
+        // given
         val project = ProjectBuilder.builder().build()
         plugin.apply(project)
         project.extensions.getByType(KueryClientExtension::class.java).autoTrimIndent.set(true)
 
+        // when
         val options = plugin.applyToCompilation(compilation(project)).get()
+
+        // then
         assertThat(options.single().toEqualsString()).isEqualTo("autoTrimIndent=true")
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
@@ -108,7 +108,7 @@ class BasicUsageTest {
     )
 
     @Test
-    fun singleMap() {
+    fun `singleMap returns the only row as a map`() {
         val userId = 1
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleMap()
         assertThat(result).isEqualTo(
@@ -121,7 +121,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `singleMap no record`() {
+    fun `singleMap throws when no rows match`() {
         val userId = 5
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleMap()
@@ -129,14 +129,14 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `singleMap more than 1 record`() {
+    fun `singleMap throws when more than one row matches`() {
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users" }.singleMap()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 
     @Test
-    fun singleMapOrNull() {
+    fun `singleMapOrNull returns the only row as a map`() {
         val userId = 1
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleMapOrNull()
         assertThat(result).isEqualTo(
@@ -149,21 +149,21 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `singleMapOrNull no record`() {
+    fun `singleMapOrNull returns null when no rows match`() {
         val userId = 5
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleMapOrNull()
         assertThat(result).isNull()
     }
 
     @Test
-    fun `singleMapOrNull more than 1 record`() {
+    fun `singleMapOrNull throws when more than one row matches`() {
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users" }.singleMap()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 
     @Test
-    fun single() {
+    fun `single returns the only row mapped to a data class`() {
         val userId = 1
         val result: User = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.single()
         assertThat(result).isEqualTo(
@@ -176,7 +176,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `single invalid type`() {
+    fun `single throws when the target class does not match the selected columns`() {
         data class InvalidUser(
             val userId: Int,
             val invalid: String,
@@ -189,7 +189,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `single no record`() {
+    fun `single throws when no rows match`() {
         val userId = 5
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.single<User>()
@@ -197,14 +197,14 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `single more than 1 record`() {
+    fun `single throws when more than one row matches`() {
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users" }.single<User>()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 
     @Test
-    fun singleOrNull() {
+    fun `singleOrNull returns the only row mapped to a data class`() {
         val userId = 1
         val result: User? = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleOrNull()
         assertThat(result).isEqualTo(
@@ -217,21 +217,21 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `singleOrNull no record`() {
+    fun `singleOrNull returns null when no rows match`() {
         val userId = 5
         val result: User? = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleOrNull()
         assertThat(result).isNull()
     }
 
     @Test
-    fun `singleOrNull more than 1 record`() {
+    fun `singleOrNull throws when more than one row matches`() {
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users" }.singleOrNull<User>()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 
     @Test
-    fun listMap() {
+    fun `listMap returns all rows as maps`() {
         val result = kueryClient.sql { +"SELECT * FROM users" }.listMap()
         assertThat(result).isEqualTo(
             listOf(
@@ -250,14 +250,14 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `listMap empty`() {
+    fun `listMap returns an empty list when no rows match`() {
         val userId = 3
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }.listMap()
         assertThat(result).isEmpty()
     }
 
     @Test
-    fun list() {
+    fun `list returns all rows mapped to data classes`() {
         val result: List<User> = kueryClient.sql { +"SELECT * FROM users" }.list()
         assertThat(result).isEqualTo(
             listOf(
@@ -276,14 +276,14 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `list empty`() {
+    fun `list returns an empty list when no rows match`() {
         val userId = 3
         val result: List<User> = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }.list()
         assertThat(result).isEmpty()
     }
 
     @Test
-    fun sequenceMap() {
+    fun `sequenceMap returns all rows as maps`() {
         val result = kueryClient.sql { +"SELECT * FROM users" }.sequenceMap().toList()
         assertThat(result).isEqualTo(
             listOf(
@@ -302,14 +302,14 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `sequenceMap empty`() {
+    fun `sequenceMap returns an empty sequence when no rows match`() {
         val userId = 3
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }.sequenceMap().toList()
         assertThat(result).isEmpty()
     }
 
     @Test
-    fun sequence() {
+    fun `sequence returns all rows mapped to data classes`() {
         val result: List<User> = kueryClient.sql { +"SELECT * FROM users" }.sequence<User>().toList()
         assertThat(result).isEqualTo(
             listOf(
@@ -328,7 +328,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `sequence empty`() {
+    fun `sequence returns an empty sequence when no rows match`() {
         val userId = 3
         val result: List<User> = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }
             .sequence<User>()
@@ -337,7 +337,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun rowUpdated() {
+    fun `rowsUpdated returns the number of inserted rows`() {
         val username = "user3"
         val email = "user3"
         val result = kueryClient
@@ -349,7 +349,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `rowUpdated 0`() {
+    fun `rowsUpdated returns zero when no rows are affected`() {
         val userId = 5
         val result = kueryClient
             .sql {
@@ -360,7 +360,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `rowUpdated multi`() {
+    fun `rowsUpdated returns the count across all updated rows`() {
         val result = kueryClient
             .sql {
                 +"UPDATE users SET username = 'updated'"
@@ -370,7 +370,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun generatedValues() {
+    fun `generatedValues returns the auto-generated key of the inserted row`() {
         val username = "user3"
         val email = "user3"
         val result = kueryClient
@@ -382,7 +382,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `generatedValues multiple generated keys`() {
+    fun `generatedValues throws when multiple rows generate keys`() {
         assertFailure {
             kueryClient
                 .sql {
@@ -397,7 +397,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun userOrder() {
+    fun `two-table join maps combined columns to a data class`() {
         data class UserOrder(
             val username: String,
             val orderId: Int,
@@ -430,7 +430,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun orderProduct() {
+    fun `three-table join maps combined columns to data classes`() {
         data class OrderProduct(
             val orderId: Int,
             val productName: String,
@@ -458,7 +458,7 @@ class BasicUsageTest {
     }
 
     @Test
-    fun `using extension function`() {
+    fun `sql fragments can be composed via an extension function using addUnsafe and bind`() {
         @OptIn(DelicateKueryClientApi::class)
         fun SqlBuilder.userIdEqualsTo(userId: Int) {
             addUnsafe("users.user_id = ${bind(userId)}")

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CSVConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CSVConversionTest.kt
@@ -23,16 +23,19 @@ class CSVConversionTest {
     }
 
     @Test
-    fun test() {
+    fun `comma-separated text is read into a List property with trimmed elements`() {
+        // given
         val text = "a, b,c"
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES ($text)"
         }.rowsUpdated()
 
+        // when
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter"
         }.single()
 
+        // then
         assertThat(record.text).isEqualTo(listOf("a", "b", "c"))
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CodeEnumConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CodeEnumConversionTest.kt
@@ -93,27 +93,32 @@ class CodeEnumConversionTest {
     }
 
     @Test
-    fun test() {
+    fun `code enums are written as their codes and mapped back to enum properties`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO code_enum (int_enum, string_enum)"
             +"VALUES (${SampleIntCodeEnum.HOGE}, ${SampleStringCodeEnum.BAR})"
         }.rowsUpdated()
 
+        // when
         val record: Record = kueryClient.sql {
             +"SELECT * FROM code_enum"
         }.single()
 
+        // then
         assertThat(record.intEnum).isEqualTo(SampleIntCodeEnum.HOGE)
         assertThat(record.stringEnum).isEqualTo(SampleStringCodeEnum.BAR)
     }
 
     @Test
-    fun testScalar() {
+    fun `code enum is converted when fetched as a scalar`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO code_enum (int_enum, string_enum)"
             +"VALUES (${SampleIntCodeEnum.HOGE}, ${SampleStringCodeEnum.BAR})"
         }.rowsUpdated()
 
+        // when & then
         val intEnum: SampleIntCodeEnum = kueryClient.sql {
             +"SELECT int_enum FROM code_enum"
         }.single()

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CollectionConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/CollectionConversionTest.kt
@@ -41,7 +41,8 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun test() {
+    fun `list in an IN clause is expanded with each element converted`() {
+        // given
         kueryClient.sql {
             +"""
             INSERT INTO converter (text) VALUES
@@ -51,6 +52,7 @@ class CollectionConversionTest {
             """.trimIndent()
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             val inList = listOf(StringWrapper("text1"), StringWrapper("text2"))
             +"SELECT * FROM converter WHERE text IN ($inList)"
@@ -59,7 +61,8 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testCompositeIn() {
+    fun `list of arrays expands into composite IN tuples`() {
+        // given
         kueryClient.sql {
             +"""
             INSERT INTO converter (text) VALUES
@@ -68,6 +71,7 @@ class CollectionConversionTest {
             """.trimIndent()
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             val pairs = listOf(arrayOf<Any>(1L, StringWrapper("text1")))
             +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"
@@ -76,15 +80,18 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testEmptyCollection() {
+    fun `empty collection in an IN clause returns no rows on H2`() {
         // An empty collection is bound as-is; Spring's named parameter expansion then renders
         // it as `IN ()`. Whether that is valid SQL depends on the database: H2 accepts it and
         // returns no rows, while MySQL/PostgreSQL reject it (see the mysql/postgres packages).
         // Callers targeting those databases must guard against empty collections themselves.
+
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES ('text1')"
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             val emptyIds = emptyList<Long>()
             +"SELECT * FROM converter WHERE id IN ($emptyIds)"
@@ -94,7 +101,8 @@ class CollectionConversionTest {
 
     @OptIn(DelicateKueryClientApi::class)
     @Test
-    fun testHandBuiltTupleIn() {
+    fun `tuple IN clause hand-built with addUnsafe and bind matches the given pairs`() {
+        // given
         kueryClient.sql {
             +"""
             INSERT INTO converter (text) VALUES
@@ -104,6 +112,7 @@ class CollectionConversionTest {
             """.trimIndent()
         }.rowsUpdated()
 
+        // when & then
         val pairs = listOf(1L to "text1", 3L to "text3")
         val result = kueryClient.sql {
             +"SELECT * FROM converter"
@@ -114,7 +123,8 @@ class CollectionConversionTest {
 
     @OptIn(DelicateKueryClientApi::class)
     @Test
-    fun testBindCollectionViaAddUnsafe() {
+    fun `collection bound via bind inside addUnsafe is expanded in the IN clause`() {
+        // given
         kueryClient.sql {
             +"""
             INSERT INTO converter (text) VALUES
@@ -124,6 +134,7 @@ class CollectionConversionTest {
             """.trimIndent()
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             val texts = listOf("text1", "text2")
             addUnsafe("SELECT * FROM converter WHERE text IN (${bind(texts)})")
@@ -132,9 +143,11 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testSet() {
+    fun `set in an IN clause is expanded like a list`() {
+        // given
         insertThreeRows()
 
+        // when & then
         val result = kueryClient.sql {
             val inSet = setOf(StringWrapper("text1"), StringWrapper("text2"))
             +"SELECT * FROM converter WHERE text IN ($inSet)"
@@ -143,9 +156,11 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testMapKeysView() {
+    fun `map keys view in an IN clause is expanded like a collection`() {
+        // given
         insertThreeRows()
 
+        // when & then
         val map = mapOf(StringWrapper("text1") to 1, StringWrapper("text3") to 3)
         val result = kueryClient.sql {
             +"SELECT * FROM converter WHERE text IN (${map.keys})"
@@ -154,13 +169,15 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testCustomCollectionSubtype() {
+    fun `custom Collection subtype in an IN clause is expanded like a list`() {
         // Non-standard Collection implementations (e.g. NonEmptyList of functional libraries)
         // must expand like any other Collection.
         class NonEmptyList<T>(private val delegate: List<T>) : Collection<T> by delegate
 
+        // given
         insertThreeRows()
 
+        // when & then
         val result = kueryClient.sql {
             val inList = NonEmptyList(listOf(StringWrapper("text1"), StringWrapper("text2")))
             +"SELECT * FROM converter WHERE text IN ($inList)"
@@ -169,11 +186,14 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testNullElement() {
+    fun `null element in an IN list binds as SQL NULL and never matches`() {
         // A null element binds as SQL NULL, which never matches in an IN list; the non-null
         // elements still do.
+
+        // given
         insertThreeRows()
 
+        // when & then
         val result = kueryClient.sql {
             val inList = listOf(StringWrapper("text1"), null)
             +"SELECT * FROM converter WHERE text IN ($inList)"

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ConverterRegistrationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ConverterRegistrationTest.kt
@@ -76,6 +76,7 @@ class ConverterRegistrationTest {
 
     @Test
     fun `GenericConverter is supported for reading`() {
+        // given
         val kueryClient = h2.kueryClient(
             listOf(StringToStringWrapperGenericConverter(), StringWrapperToStringConverter()),
         )
@@ -83,6 +84,7 @@ class ConverterRegistrationTest {
             +"INSERT INTO converter (text) VALUES ('hoge')"
         }.rowsUpdated()
 
+        // when & then
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter"
         }.single()
@@ -91,8 +93,10 @@ class ConverterRegistrationTest {
 
     @Test
     fun `GenericConverter for a Kotlin Int works via javaObjectType`() {
+        // given
         val kueryClient = h2.kueryClient(listOf(IntToIntWrapperGenericConverter()))
 
+        // when & then
         val record: IntRecord = kueryClient.sql {
             +"SELECT CAST(42 AS INT) AS num"
         }.single()
@@ -103,12 +107,15 @@ class ConverterRegistrationTest {
     fun `converter without annotation infers direction from the store-typed side`() {
         // Converter<StringWrapper, String> targets a store type, so Spring infers it as a
         // writing converter even without @WritingConverter.
+
+        // given
         val kueryClient = h2.kueryClient(listOf(UnannotatedStringWrapperToStringConverter()))
 
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${StringWrapper("hoge")})"
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             +"SELECT text FROM converter"
         }.single<String>()

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/EnumConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/EnumConversionTest.kt
@@ -27,11 +27,13 @@ class EnumConversionTest {
     }
 
     @Test
-    fun test() {
+    fun `enum is stored as its name and mapped back to the enum`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
         }.rowsUpdated()
 
+        // when & then
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter"
         }.single()
@@ -44,11 +46,13 @@ class EnumConversionTest {
     }
 
     @Test
-    fun testScalar() {
+    fun `enum is converted when fetched as a scalar`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
         }.rowsUpdated()
 
+        // when & then
         val result: SampleEnum = kueryClient.sql {
             +"SELECT text FROM converter"
         }.single()
@@ -56,11 +60,13 @@ class EnumConversionTest {
     }
 
     @Test
-    fun testInCollection() {
+    fun `enum in an IN clause matches the row stored by name`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
         }.rowsUpdated()
 
+        // when & then
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter WHERE text IN (${listOf(SampleEnum.HOGE)})"
         }.single()
@@ -68,11 +74,13 @@ class EnumConversionTest {
     }
 
     @Test
-    fun testCompositeIn() {
+    fun `enum in a composite IN tuple matches the row stored by name`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
         }.rowsUpdated()
 
+        // when & then
         val record: Record = kueryClient.sql {
             val pairs = listOf(arrayOf<Any>(1L, SampleEnum.HOGE))
             +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/NullReturningWritingConverterTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/NullReturningWritingConverterTest.kt
@@ -34,11 +34,13 @@ class NullReturningWritingConverterTest {
     }
 
     @Test
-    fun testNull() {
+    fun `null converter result is bound as SQL NULL`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${NullableText(null)})"
         }.rowsUpdated()
 
+        // when & then
         val map = kueryClient.sql {
             +"SELECT * FROM converter"
         }.singleMap()
@@ -46,11 +48,13 @@ class NullReturningWritingConverterTest {
     }
 
     @Test
-    fun testNonNull() {
+    fun `non-null converter result is bound as the converted value`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${NullableText("hoge")})"
         }.rowsUpdated()
 
+        // when & then
         val map = kueryClient.sql {
             +"SELECT * FROM converter"
         }.singleMap()

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ObservationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ObservationTest.kt
@@ -41,7 +41,7 @@ class ObservationTest {
     }
 
     @AfterEach
-    fun testDown() {
+    fun tearDown() {
         h2.jdbcClient.sql(
             """
             DROP TABLE users;
@@ -50,7 +50,7 @@ class ObservationTest {
     }
 
     @Test
-    fun singleMap() {
+    fun `singleMap records an observation with sqlId and sql`() {
         userRepository.singleMap(1)
         assertObservation(
             sqlId = "com.example.spring.jdbc.UserRepository.singleMap",
@@ -59,7 +59,7 @@ class ObservationTest {
     }
 
     @Test
-    fun singleMapOrNull() {
+    fun `singleMapOrNull records an observation with sqlId and sql`() {
         userRepository.singleMapOrNull(1)
         assertObservation(
             sqlId = "com.example.spring.jdbc.UserRepository.singleMapOrNull",
@@ -68,7 +68,7 @@ class ObservationTest {
     }
 
     @Test
-    fun single() {
+    fun `single records an observation with sqlId and sql`() {
         userRepository.single(1)
         assertObservation(
             sqlId = "com.example.spring.jdbc.UserRepository.single",
@@ -77,7 +77,7 @@ class ObservationTest {
     }
 
     @Test
-    fun singleOrNull() {
+    fun `singleOrNull records an observation with sqlId and sql`() {
         userRepository.singleOrNull(1)
         assertObservation(
             sqlId = "com.example.spring.jdbc.UserRepository.singleOrNull",
@@ -86,7 +86,7 @@ class ObservationTest {
     }
 
     @Test
-    fun listMap() {
+    fun `listMap records an observation with sqlId and sql`() {
         userRepository.listMap()
         assertObservation(
             sqlId = "com.example.spring.jdbc.UserRepository.listMap",
@@ -95,7 +95,7 @@ class ObservationTest {
     }
 
     @Test
-    fun list() {
+    fun `list records an observation with sqlId and sql`() {
         userRepository.list()
         assertObservation(
             sqlId = "com.example.spring.jdbc.UserRepository.list",
@@ -104,7 +104,7 @@ class ObservationTest {
     }
 
     @Test
-    fun rowUpdated() {
+    fun `rowsUpdated records an observation with sqlId and sql`() {
         userRepository.rowUpdated("user3", "user3@example.com")
         assertObservation(
             sqlId = "com.example.spring.jdbc.UserRepository.rowUpdated",
@@ -113,7 +113,7 @@ class ObservationTest {
     }
 
     @Test
-    fun generatedValues() {
+    fun `generatedValues records an observation with sqlId and sql`() {
         userRepository.generatedValues("user3", "user3@example.com")
         assertObservation(
             sqlId = "com.example.spring.jdbc.UserRepository.generatedValues",
@@ -159,6 +159,8 @@ class ObservationTest {
     @Test
     fun `scope is closed before the observation is stopped`() {
         // The documented Micrometer lifecycle order: close the scope, then stop the observation.
+
+        // given
         val events = mutableListOf<String>()
         val recordingRegistry = TestObservationRegistry.create().apply {
             observationConfig().observationHandler(object : ObservationHandler<Observation.Context> {
@@ -175,8 +177,10 @@ class ObservationTest {
         }
         val client = h2.kueryClient(observationRegistry = recordingRegistry)
 
+        // when
         UserRepository(client).singleMap(1)
 
+        // then
         assertThat(events).isEqualTo(listOf("scopeClosed", "stop"))
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SequenceExecutionTimingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SequenceExecutionTimingTest.kt
@@ -41,7 +41,10 @@ class SequenceExecutionTimingTest {
 
     @Test
     fun `sequenceMap executes the query eagerly at call time`() {
+        // when
         val sequence = kueryClient.sql { +"SELECT * FROM converter" }.sequenceMap()
+
+        // then
         sequence.use {
             // The connection was already acquired (and the statement executed) by sequenceMap()
             // itself, before the first element was consumed.

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SequenceResourceManagementTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SequenceResourceManagementTest.kt
@@ -40,7 +40,10 @@ class SequenceResourceManagementTest {
 
     @Test
     fun `sequence releases the connection after full iteration`() {
+        // when
         val result: List<User> = kueryClient.sql { +"SELECT * FROM users" }.sequence<User>().toList()
+
+        // then
         assertThat(result).isEqualTo(
             listOf(
                 User(userId = 1, username = "user1"),
@@ -52,7 +55,10 @@ class SequenceResourceManagementTest {
 
     @Test
     fun `sequenceMap releases the connection after full iteration`() {
+        // when
         val result = kueryClient.sql { +"SELECT * FROM users" }.sequenceMap().toList()
+
+        // then
         assertThat(result).isEqualTo(
             listOf(
                 mapOf("user_id" to 1, "username" to "user1"),
@@ -72,17 +78,25 @@ class SequenceResourceManagementTest {
 
     @Test
     fun `sequence releases the connection when closed via use after partial iteration`() {
+        // when
         val result = kueryClient.sql { +"SELECT * FROM users" }.sequence<User>().use { seq ->
             seq.first()
         }
+
+        // then
         assertThat(result).isEqualTo(User(userId = 1, username = "user1"))
         assertAllTrackedConnectionsClosed()
     }
 
     @Test
     fun `sequence can be iterated only once`() {
+        // given
         val seq = kueryClient.sql { +"SELECT * FROM users" }.sequence<User>()
+
+        // when
         seq.toList()
+
+        // then
         assertFailure { seq.toList() }.isInstanceOf(IllegalStateException::class)
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SqlIdThreadLocalTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/SqlIdThreadLocalTest.kt
@@ -43,66 +43,66 @@ class SqlIdThreadLocalTest {
     }
 
     @AfterEach
-    fun testDown() {
+    fun tearDown() {
         h2.jdbcClient.sql("DROP TABLE users").update()
     }
 
     @Test
-    fun singleMap() {
+    fun `singleMap propagates the auto-generated sqlId to statement execution`() {
         userRepository.singleMap(1)
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.singleMap")
     }
 
     @Test
-    fun singleMapOrNull() {
+    fun `singleMapOrNull propagates the auto-generated sqlId to statement execution`() {
         userRepository.singleMapOrNull(1)
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.singleMapOrNull")
     }
 
     @Test
-    fun single() {
+    fun `single propagates the auto-generated sqlId to statement execution`() {
         userRepository.single(1)
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.single")
     }
 
     @Test
-    fun singleOrNull() {
+    fun `singleOrNull propagates the auto-generated sqlId to statement execution`() {
         userRepository.singleOrNull(1)
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.singleOrNull")
     }
 
     @Test
-    fun listMap() {
+    fun `listMap propagates the auto-generated sqlId to statement execution`() {
         userRepository.listMap()
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.listMap")
     }
 
     @Test
-    fun list() {
+    fun `list propagates the auto-generated sqlId to statement execution`() {
         userRepository.list()
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.list")
     }
 
     @Test
-    fun sequenceMap() {
+    fun `sequenceMap propagates the auto-generated sqlId to statement execution`() {
         userRepository.sequenceMap().use { it.toList() }
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.sequenceMap")
     }
 
     @Test
-    fun sequence() {
+    fun `sequence propagates the auto-generated sqlId to statement execution`() {
         userRepository.sequence().use { it.toList() }
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.sequence")
     }
 
     @Test
-    fun rowsUpdated() {
+    fun `rowsUpdated propagates the auto-generated sqlId to statement execution`() {
         userRepository.rowUpdated("user3", "user3@example.com")
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.rowUpdated")
     }
 
     @Test
-    fun generatedValues() {
+    fun `generatedValues propagates the auto-generated sqlId to statement execution`() {
         userRepository.generatedValues("user3", "user3@example.com")
         assertThat(capturedSqlIds).containsExactly("com.example.spring.jdbc.UserRepository.generatedValues")
     }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/StatementOptionsTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/StatementOptionsTest.kt
@@ -55,7 +55,7 @@ class StatementOptionsTest {
     }
 
     @Test
-    fun `chain of options works correctly`() {
+    fun `chained fetchSize, maxRows, and queryTimeoutSeconds limit results to maxRows`() {
         val result = kueryClient.sql { +"SELECT * FROM users" }
             .fetchSize(3)
             .maxRows(4)
@@ -92,7 +92,7 @@ class StatementOptionsTest {
     }
 
     @Test
-    fun `chain of options works correctly for sequence`() {
+    fun `chained fetchSize, maxRows, and queryTimeoutSeconds limit sequence results to maxRows`() {
         val result = kueryClient.sql { +"SELECT * FROM users" }
             .fetchSize(3)
             .maxRows(4)
@@ -104,12 +104,15 @@ class StatementOptionsTest {
 
     @Test
     fun `options are applied immutably`() {
+        // given
         val base = kueryClient.sql { +"SELECT * FROM users" }
         val limited = base.maxRows(3)
 
+        // when
         val baseResult = base.listMap()
         val limitedResult = limited.listMap()
 
+        // then
         assertThat(baseResult).hasSize(10)
         assertThat(limitedResult).hasSize(3)
     }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/StringCaseTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/StringCaseTest.kt
@@ -35,16 +35,19 @@ class StringCaseTest {
     )
 
     @Test
-    fun test() {
+    fun `snake_case and camelCase columns both map to data class properties`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO string_case (hoge_bar, fugaPiyo) VALUES ('a', 'b')"
         }.rowsUpdated()
 
+        // when
         val record: Record = kueryClient.sql {
             +"SELECT * FROM string_case"
         }.single()
         println(record)
 
+        // then
         assertThat(record.hogeBar).isEqualTo("a")
         assertThat(record.fugaPiyo).isEqualTo("b")
     }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/StringWrapperConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/StringWrapperConversionTest.kt
@@ -43,15 +43,18 @@ class StringWrapperConversionTest {
     }
 
     @Test
-    fun test() {
+    fun `wrapper type round-trips through registered writing and reading converters`() {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${StringWrapper("hoge")})"
         }.rowsUpdated()
 
+        // when
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter"
         }.single()
 
+        // then
         assertThat(record.text).isEqualTo(StringWrapper("hoge"))
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/TransactionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/TransactionTest.kt
@@ -31,25 +31,30 @@ class TransactionTest {
 
     @Test
     fun `commit persists the changes`() {
+        // when
         transactionTemplate.execute {
             kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
         }
 
+        // then
         assertThat(count()).isEqualTo(1L)
     }
 
     @Test
     fun `setRollbackOnly discards the changes`() {
+        // when
         transactionTemplate.execute { status ->
             kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
             status.setRollbackOnly()
         }
 
+        // then
         assertThat(count()).isEqualTo(0L)
     }
 
     @Test
     fun `an exception rolls back the changes`() {
+        // when & then
         assertFailure {
             transactionTemplate.execute<Nothing> {
                 kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
@@ -57,6 +62,7 @@ class TransactionTest {
             }
         }.isInstanceOf(IllegalStateException::class)
 
+        // then
         assertThat(count()).isEqualTo(0L)
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ValueClassFetchTest.kt
@@ -54,7 +54,10 @@ class ValueClassFetchTest {
 
     @Test
     fun `value class as a data class property is not supported either`() {
+        // given
         val kueryClient = h2.kueryClient(listOf(StringToUserNameConverter()))
+
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"SELECT id, text FROM converter ORDER BY id"

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ValuesHelperTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/ValuesHelperTest.kt
@@ -26,7 +26,7 @@ class ValuesHelperTest {
     }
 
     @AfterEach
-    fun testDown() {
+    fun tearDown() {
         h2.jdbcClient.sql(
             """
             DROP TABLE users
@@ -42,13 +42,15 @@ class ValuesHelperTest {
     )
 
     @Test
-    fun test() {
+    fun `values expands a list of rows into a multi-row INSERT`() {
+        // given
         val input = listOf(
             listOf("user1", "user1@example.com", 1),
             listOf("user2", null, 2),
             listOf("user3", "user3@example.com", 3),
         )
 
+        // when & then
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO users (username, email, age)"
             values(input)
@@ -68,19 +70,21 @@ class ValuesHelperTest {
     }
 
     @Test
-    fun `test with transformer`() {
+    fun `values with a transformer maps objects to rows before binding`() {
         data class UserParam(
             val username: String,
             val email: String?,
             val age: Int,
         )
 
+        // given
         val input = listOf(
             UserParam("user1", "user1@example.com", 1),
             UserParam("user2", null, 2),
             UserParam("user3", "user3@example.com", 3),
         )
 
+        // when & then
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO users (username, email, age)"
             values(input) { listOf(it.username, it.email, it.age) }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequenceTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/StreamCloseableSequenceTest.kt
@@ -15,10 +15,12 @@ import java.util.stream.StreamSupport
 
 class StreamCloseableSequenceTest {
     @Test
-    fun `iterator throws ISE when the sequence is already closed`() {
+    fun `iterator throws IllegalStateException when the sequence is already closed`() {
+        // given
         val sequence = Stream.of("a", "b").asCloseableSequence()
         sequence.close()
 
+        // when & then
         assertFailure { sequence.iterator() }
             .isInstanceOf(IllegalStateException::class)
             .hasMessage("This sequence is already closed.")
@@ -26,19 +28,24 @@ class StreamCloseableSequenceTest {
 
     @Test
     fun `close is idempotent`() {
+        // given
         val closeCount = AtomicInteger()
         val sequence = Stream.of("a", "b").onClose { closeCount.incrementAndGet() }.asCloseableSequence()
 
+        // when
         sequence.close()
         sequence.close()
 
+        // then
         assertThat(closeCount.get()).isEqualTo(1)
     }
 
     @Test
     fun `hasNext stays false after exhaustion without touching the closed stream`() {
+        // given
         val iterator = resultSetLikeStream("a", "b").asCloseableSequence().iterator()
 
+        // when & then
         assertThat(iterator.next()).isEqualTo("a")
         assertThat(iterator.next()).isEqualTo("b")
         assertThat(iterator.hasNext()).isFalse()
@@ -50,8 +57,10 @@ class StreamCloseableSequenceTest {
 
     @Test
     fun `next after exhaustion throws NoSuchElementException`() {
+        // given
         val iterator = resultSetLikeStream("a").asCloseableSequence().iterator()
 
+        // when & then
         assertThat(iterator.next()).isEqualTo("a")
         assertThat(iterator.hasNext()).isFalse()
 
@@ -60,9 +69,11 @@ class StreamCloseableSequenceTest {
 
     @Test
     fun `explicit close after full iteration does not close the stream twice`() {
+        // given
         val closeCount = AtomicInteger()
         val sequence = Stream.of("a", "b").onClose { closeCount.incrementAndGet() }.asCloseableSequence()
 
+        // when & then
         // Reaching the end of the iteration closes the underlying stream.
         assertThat(sequence.toList()).isEqualTo(listOf("a", "b"))
         assertThat(closeCount.get()).isEqualTo(1)

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlByteArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlByteArrayBindingTest.kt
@@ -35,12 +35,16 @@ class MySqlByteArrayBindingTest {
 
     @Test
     fun `bind ByteArray as a single binary value`() {
+        // given
         val id = ByteArray(16) { it.toByte() }
         val data = byteArrayOf(1, 2, 3)
 
+        // when
         val inserted = kueryClient
             .sql { +"INSERT INTO binaries (id, data) VALUES ($id, $data)" }
             .rowsUpdated()
+
+        // then
         assertThat(inserted).isEqualTo(1L)
 
         val stored = kueryClient
@@ -51,24 +55,33 @@ class MySqlByteArrayBindingTest {
 
     @Test
     fun `bind the same ByteArray twice in one statement`() {
+        // given
         val id = ByteArray(16) { it.toByte() }
         val data = byteArrayOf(1, 2, 3)
         kueryClient
             .sql { +"INSERT INTO binaries (id, data) VALUES ($id, $data)" }
             .rowsUpdated()
 
+        // when
         val count = kueryClient
             .sql { +"SELECT COUNT(*) FROM binaries WHERE id = $id AND data = $data AND data = $data" }
             .single<Long>()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `singleOrNull ByteArray returns null when no row matches`() {
+        // given
         val id = ByteArray(16) { it.toByte() }
+
+        // when
         val stored = kueryClient
             .sql { +"SELECT data FROM binaries WHERE id = $id" }
             .singleOrNull<ByteArray>()
+
+        // then
         assertThat(stored).isNull()
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlDuplicateKeyTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlDuplicateKeyTest.kt
@@ -35,7 +35,10 @@ class MySqlDuplicateKeyTest {
 
     @Test
     fun `unique constraint violation throws DuplicateKeyException`() {
+        // given
         val email = "user1@example.com"
+
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"INSERT INTO dup_users (user_id, email) VALUES (2, $email)"

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlGeneratedValuesTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlGeneratedValuesTest.kt
@@ -36,17 +36,22 @@ class MySqlGeneratedValuesTest {
     }
 
     @Test
-    fun generatedValues() {
+    fun `generatedValues returns the generated key of a single insert`() {
+        // given
         val username = "user1"
         val email = "user1@example.com"
+
+        // when
         val result = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .generatedValues("user_id")
+
+        // then
         assertThat(result).isEqualTo(mapOf("GENERATED_KEY" to BigInteger.valueOf(1)))
     }
 
     @Test
-    fun `generatedValues no generated keys`() {
+    fun `generatedValues throws EmptyResultDataAccessException when no keys are generated`() {
         // Unlike H2 (which reports the affected row's identity even for UPDATE), MySQL emits no
         // generated keys here, exercising the EmptyResultDataAccessException failure path.
         assertFailure {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlKeysetPaginationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlKeysetPaginationTest.kt
@@ -43,29 +43,37 @@ class MySqlKeysetPaginationTest {
 
     @Test
     fun `keyset pagination ascending`() {
+        // given
         val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0)
         val cursorId = 1
 
+        // when
         val page = kueryClient.sql {
             +"SELECT id FROM events"
             +"WHERE (created_at, id) > ($cursorCreatedAt, $cursorId)"
             +"ORDER BY created_at, id"
             +"LIMIT 2"
         }.listMap()
+
+        // then
         assertThat(page.map { it["id"] }).isEqualTo(listOf(2, 3))
     }
 
     @Test
     fun `keyset pagination descending`() {
+        // given
         val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 5, 0)
         val cursorId = 4
 
+        // when
         val page = kueryClient.sql {
             +"SELECT id FROM events"
             +"WHERE (created_at, id) < ($cursorCreatedAt, $cursorId)"
             +"ORDER BY created_at DESC, id DESC"
             +"LIMIT 2"
         }.listMap()
+
+        // then
         assertThat(page.map { it["id"] }).isEqualTo(listOf(3, 2))
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlNullBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlNullBindingTest.kt
@@ -33,21 +33,31 @@ class MySqlNullBindingTest {
 
     @Test
     fun `bind non-null value`() {
+        // given
         val username = "user1"
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `bind null value`() {
+        // given
         val username: String? = null
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -58,39 +68,59 @@ class MySqlNullBindingTest {
 
     @Test
     fun `bind null value to an int column`() {
+        // given
         val age: Int? = null
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (email, age) VALUES ($email, $age)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `compare with null value in WHERE clause`() {
+        // given
         val username: String? = null
+
+        // when
         val list = kueryClient
             .sql { +"SELECT * FROM users WHERE username = $username" }
             .listMap()
+
+        // then
         assertThat(list).isEqualTo(emptyList())
     }
 
     @Test
     fun `select null value directly`() {
+        // given
         val value: String? = null
+
+        // when
         val record = kueryClient
             .sql { +"SELECT $value AS v" }
             .singleMap()
+
+        // then
         assertThat(record["v"]).isNull()
     }
 
     @Test
     fun `bind null value via typed SqlParameterValue as an escape hatch`() {
+        // given
         val username = SqlParameterValue(Types.VARCHAR, null)
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlNullScalarResultTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlNullScalarResultTest.kt
@@ -36,8 +36,13 @@ class MySqlNullScalarResultTest {
 
     @Test
     fun `singleOrNull returns null for a NULL column`() {
+        // given
         insert("user1@example.com", age = null)
+
+        // when
         val age: Int? = kueryClient.sql { +"SELECT age FROM users" }.singleOrNull()
+
+        // then
         assertThat(age).isNull()
     }
 
@@ -49,14 +54,22 @@ class MySqlNullScalarResultTest {
 
     @Test
     fun `singleOrNull returns null for a NULL string column`() {
+        // given
         insert("user1@example.com", age = null)
+
+        // when
         val username: String? = kueryClient.sql { +"SELECT username FROM users" }.singleOrNull()
+
+        // then
         assertThat(username).isNull()
     }
 
     @Test
     fun `single throws for a NULL column`() {
+        // given
         insert("user1@example.com", age = null)
+
+        // when & then
         assertFailure {
             kueryClient.sql { +"SELECT age FROM users" }.single<Int>()
         }.isInstanceOf(TypeMismatchDataAccessException::class)
@@ -64,19 +77,29 @@ class MySqlNullScalarResultTest {
 
     @Test
     fun `list preserves NULL elements`() {
+        // given
         insert("user1@example.com", age = 20)
         insert("user2@example.com", age = null)
+
+        // when
         val ages: List<Int?> = kueryClient.sql { +"SELECT age FROM users ORDER BY user_id" }.list(Int::class)
+
+        // then
         assertThat(ages).isEqualTo(listOf(20, null))
     }
 
     @Test
     fun `sequence preserves NULL elements`() {
+        // given
         insert("user1@example.com", age = 20)
         insert("user2@example.com", age = null)
+
+        // when
         val ages: List<Int?> = kueryClient.sql { +"SELECT age FROM users ORDER BY user_id" }
             .sequence(Int::class)
             .use { it.toList() }
+
+        // then
         assertThat(ages).isEqualTo(listOf(20, null))
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlSingleBasicTypeTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlSingleBasicTypeTest.kt
@@ -32,20 +32,22 @@ class MySqlSingleBasicTypeTest {
     @OptIn(DelicateKueryClientApi::class)
     @ParameterizedTest
     @MethodSource("singleValues")
-    fun testSingleValues(
+    fun `single maps a single-column result to each basic type`(
         query: String,
         expected: Any,
         type: KClass<*>,
     ) {
+        // when
         val result = kueryClient.sql {
             addUnsafe(query)
         }.single(type)
 
+        // then
         assertThat(result).isEqualTo(expected)
     }
 
     @Test
-    fun unSupportNotSimpleProperty() {
+    fun `single with a non-simple data class type is rejected`() {
         assertFailure {
             kueryClient.sql {
                 +"SELECT 'hoge'"
@@ -54,11 +56,13 @@ class MySqlSingleBasicTypeTest {
     }
 
     @Test
-    fun testSingleColumnWithMultiValue() {
+    fun `list maps each row of a single-column result`() {
+        // when
         val result = kueryClient.sql {
             +"SELECT 1 UNION SELECT 0"
         }.list(Int::class)
 
+        // then
         assertThat(result).isEqualTo(listOf(1, 0))
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlUpsertTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlUpsertTest.kt
@@ -34,16 +34,20 @@ class MySqlUpsertTest {
 
     @Test
     fun `values followed by ON DUPLICATE KEY UPDATE with row alias`() {
+        // given
         val input = listOf(
             listOf(1, "new1@example.com"),
             listOf(2, "new2@example.com"),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO upsert_users (user_id, email)"
             values(input)
             +"AS new ON DUPLICATE KEY UPDATE email = new.email"
         }.rowsUpdated()
+
+        // then
         // 2 for the updated row (user_id=1) + 1 for the inserted row (user_id=2)
         assertThat(rowsUpdated).isEqualTo(3L)
 
@@ -54,16 +58,21 @@ class MySqlUpsertTest {
     fun `values followed by ON DUPLICATE KEY UPDATE with VALUES function`() {
         // MySQL's VALUES(col) function (deprecated in 8.0.20 but widely used) shares its name
         // with the values() DSL; they must not interfere.
+
+        // given
         val input = listOf(
             listOf(1, "new1@example.com"),
             listOf(2, "new2@example.com"),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO upsert_users (user_id, email)"
             values(input)
             +"ON DUPLICATE KEY UPDATE email = VALUES(email)"
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(3L)
 
         assertUpserted()

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlValuesHelperTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlValuesHelperTest.kt
@@ -35,16 +35,20 @@ class MySqlValuesHelperTest {
 
     @Test
     fun `values mixing null and non-null rows on typed columns`() {
+        // given
         val createdAt = LocalDateTime.of(2026, 1, 1, 0, 0, 0)
         val input = listOf(
             listOf(1, ByteArray(16) { it.toByte() }, createdAt),
             listOf(2, null, null),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO documents (id, parent_id, created_at)"
             values(input)
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(2L)
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
@@ -45,38 +45,58 @@ class PostgresArrayBindingTest {
 
     @Test
     fun `bind array to ANY predicate`() {
+        // given
         val usernames = arrayOf("HOGE", "FUGA")
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind enum array to ANY predicate`() {
+        // given
         val usernames = arrayOf(SampleEnum.HOGE, SampleEnum.FUGA)
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind custom-converted array to ANY predicate`() {
+        // given
         val kueryClient = postgres.kueryClient(listOf(StringWrapperToStringConverter()))
         val usernames = arrayOf(StringWrapper("HOGE"), StringWrapper("FUGA"))
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind array to a native array column`() {
+        // given
         val tags = arrayOf("a", "b")
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -88,10 +108,15 @@ class PostgresArrayBindingTest {
 
     @Test
     fun `bind all-null enum array to a native array column`() {
+        // given
         val tags = arrayOf<SampleEnum?>(null, null)
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -103,10 +128,15 @@ class PostgresArrayBindingTest {
 
     @Test
     fun `bind empty enum array to a native array column`() {
+        // given
         val tags = arrayOf<SampleEnum>()
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -118,10 +148,15 @@ class PostgresArrayBindingTest {
 
     @Test
     fun `bind primitive int array to ANY predicate`() {
+        // given
         val userIds = intArrayOf(1, 2)
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresCastBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresCastBindingTest.kt
@@ -34,16 +34,20 @@ class PostgresCastBindingTest {
 
     @Test
     fun `casts right after placeholders are kept intact`() {
+        // given
         val id = "0f14d0ab-9605-4a62-a9e4-5ed26688389b"
         val settings = """{"theme": "dark"}"""
         val createdAt = "2026-01-01 00:00:00+00"
 
+        // when
         val inserted = kueryClient
             .sql {
                 +"INSERT INTO cast_targets (id, settings, created_at)"
                 +"VALUES ($id::uuid, $settings::jsonb, $createdAt::timestamptz)"
             }
             .rowsUpdated()
+
+        // then
         assertThat(inserted).isEqualTo(1L)
 
         val record = kueryClient

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresDuplicateKeyTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresDuplicateKeyTest.kt
@@ -34,7 +34,10 @@ class PostgresDuplicateKeyTest {
 
     @Test
     fun `unique constraint violation throws DuplicateKeyException`() {
+        // given
         val email = "user1@example.com"
+
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"INSERT INTO dup_users (user_id, email) VALUES (2, $email)"

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresKeysetPaginationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresKeysetPaginationTest.kt
@@ -43,29 +43,37 @@ class PostgresKeysetPaginationTest {
 
     @Test
     fun `keyset pagination ascending`() {
+        // given
         val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0)
         val cursorId = 1
 
+        // when
         val page = kueryClient.sql {
             +"SELECT id FROM events"
             +"WHERE (created_at, id) > ($cursorCreatedAt, $cursorId)"
             +"ORDER BY created_at, id"
             +"LIMIT 2"
         }.listMap()
+
+        // then
         assertThat(page.map { it["id"] }).isEqualTo(listOf(2, 3))
     }
 
     @Test
     fun `keyset pagination descending`() {
+        // given
         val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 5, 0)
         val cursorId = 4
 
+        // when
         val page = kueryClient.sql {
             +"SELECT id FROM events"
             +"WHERE (created_at, id) < ($cursorCreatedAt, $cursorId)"
             +"ORDER BY created_at DESC, id DESC"
             +"LIMIT 2"
         }.listMap()
+
+        // then
         assertThat(page.map { it["id"] }).isEqualTo(listOf(3, 2))
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresNullBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresNullBindingTest.kt
@@ -33,21 +33,31 @@ class PostgresNullBindingTest {
 
     @Test
     fun `bind non-null value`() {
+        // given
         val username = "user1"
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `bind null value`() {
+        // given
         val username: String? = null
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -58,39 +68,59 @@ class PostgresNullBindingTest {
 
     @Test
     fun `bind null value to an int column`() {
+        // given
         val age: Int? = null
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (email, age) VALUES ($email, $age)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `compare with null value in WHERE clause`() {
+        // given
         val username: String? = null
+
+        // when
         val list = kueryClient
             .sql { +"SELECT * FROM users WHERE username = $username" }
             .listMap()
+
+        // then
         assertThat(list).isEqualTo(emptyList())
     }
 
     @Test
     fun `select null value directly`() {
+        // given
         val value: String? = null
+
+        // when
         val record = kueryClient
             .sql { +"SELECT $value AS v" }
             .singleMap()
+
+        // then
         assertThat(record["v"]).isNull()
     }
 
     @Test
     fun `bind null value via typed SqlParameterValue as an escape hatch`() {
+        // given
         val username = SqlParameterValue(Types.VARCHAR, null)
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresUpsertTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresUpsertTest.kt
@@ -34,16 +34,20 @@ class PostgresUpsertTest {
 
     @Test
     fun `values followed by ON CONFLICT DO UPDATE`() {
+        // given
         val input = listOf(
             listOf(1, "new1@example.com"),
             listOf(2, "new2@example.com"),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO upsert_users (user_id, email)"
             values(input)
             +"ON CONFLICT (user_id) DO UPDATE SET email = EXCLUDED.email"
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(2L)
 
         val result = kueryClient

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresValuesHelperTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresValuesHelperTest.kt
@@ -49,31 +49,39 @@ class PostgresValuesHelperTest {
 
     @Test
     fun `values with non-null typed rows`() {
+        // given
         val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
         val input = listOf(
             listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
             listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO documents (id, parent_id, created_at)"
             values(input)
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(2L)
     }
 
     @Test
     fun `values mixing null and non-null rows on a typed column`() {
+        // given
         val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
         val input = listOf(
             listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
             listOf(UUID.randomUUID(), null, createdAt),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO documents (id, parent_id, created_at)"
             values(input)
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(2L)
     }
 
@@ -85,12 +93,15 @@ class PostgresValuesHelperTest {
         // row is properly typed: the column's common type resolves to varchar and then fails
         // against the uuid target column. (Historically this surfaced as "VALUES types
         // character varying and uuid cannot be matched" on older driver/server combinations.)
+
+        // given
         val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
         val input = listOf(
             listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
             listOf(UUID.randomUUID(), "0f14d0ab-9605-4a62-a9e4-5ed26688389b", createdAt),
         )
 
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"INSERT INTO documents (id, parent_id, created_at)"
@@ -103,10 +114,12 @@ class PostgresValuesHelperTest {
 
     @Test
     fun `values binding strings for typed columns is rejected`() {
+        // given
         val input = listOf(
             listOf("0f14d0ab-9605-4a62-a9e4-5ed26688389b", null, "2026-01-01 00:00:00+00"),
         )
 
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"INSERT INTO documents (id, parent_id, created_at)"

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/BasicUsageTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/BasicUsageTest.kt
@@ -93,7 +93,7 @@ open class BasicUsageTest {
     }
 
     @AfterEach
-    fun testDown() = runTest {
+    fun tearDown() = runTest {
         val queries = listOf(
             "DROP TABLE order_items",
             "DROP TABLE orders",
@@ -106,7 +106,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun singleMap() = runTest {
+    fun `singleMap returns the only row as a map`() = runTest {
         val userId = 1
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleMap()
         assertThat(result).isEqualTo(
@@ -119,7 +119,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `singleMap no record`() = runTest {
+    fun `singleMap throws when no rows match`() = runTest {
         val userId = 5
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleMap()
@@ -127,14 +127,14 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `singleMap more than 1 record`() = runTest {
+    fun `singleMap throws when more than one row matches`() = runTest {
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users" }.singleMap()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 
     @Test
-    fun singleMapOrNull() = runTest {
+    fun `singleMapOrNull returns the only row as a map`() = runTest {
         val userId = 1
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleMapOrNull()
         assertThat(result).isEqualTo(
@@ -147,21 +147,21 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `singleMapOrNull no record`() = runTest {
+    fun `singleMapOrNull returns null when no rows match`() = runTest {
         val userId = 5
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleMapOrNull()
         assertThat(result).isNull()
     }
 
     @Test
-    fun `singleMapOrNull more than 1 record`() = runTest {
+    fun `singleMapOrNull throws when more than one row matches`() = runTest {
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users" }.singleMap()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 
     @Test
-    fun single() = runTest {
+    fun `single returns the only row mapped to a data class`() = runTest {
         val userId = 1
         val result: User = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.single()
         assertThat(result).isEqualTo(
@@ -174,7 +174,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `single invalid type`() = runTest {
+    fun `single throws when the target class does not match the selected columns`() = runTest {
         data class InvalidUser(
             val userId: Int,
             val invalid: String,
@@ -187,7 +187,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `single no record`() = runTest {
+    fun `single throws when no rows match`() = runTest {
         val userId = 5
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.single<User>()
@@ -195,14 +195,14 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `single more than 1 record`() = runTest {
+    fun `single throws when more than one row matches`() = runTest {
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users" }.single<User>()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 
     @Test
-    fun singleOrNull() = runTest {
+    fun `singleOrNull returns the only row mapped to a data class`() = runTest {
         val userId = 1
         val result: User? = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleOrNull()
         assertThat(result).isEqualTo(
@@ -215,21 +215,21 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `singleOrNull no record`() = runTest {
+    fun `singleOrNull returns null when no rows match`() = runTest {
         val userId = 5
         val result: User? = kueryClient.sql { +"SELECT * FROM users WHERE user_id = $userId" }.singleOrNull()
         assertThat(result).isNull()
     }
 
     @Test
-    fun `singleOrNull more than 1 record`() = runTest {
+    fun `singleOrNull throws when more than one row matches`() = runTest {
         assertFailure {
             kueryClient.sql { +"SELECT * FROM users" }.singleOrNull<User>()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 
     @Test
-    fun listMap() = runTest {
+    fun `listMap returns all rows as maps`() = runTest {
         val result = kueryClient.sql { +"SELECT * FROM users" }.listMap()
         assertThat(result).isEqualTo(
             listOf(
@@ -248,14 +248,14 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `listMap empty`() = runTest {
+    fun `listMap returns an empty list when no rows match`() = runTest {
         val userId = 3
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }.listMap()
         assertThat(result).isEmpty()
     }
 
     @Test
-    fun list() = runTest {
+    fun `list returns all rows mapped to data classes`() = runTest {
         val result: List<User> = kueryClient.sql { +"SELECT * FROM users" }.list()
         assertThat(result).isEqualTo(
             listOf(
@@ -274,14 +274,14 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `list empty`() = runTest {
+    fun `list returns an empty list when no rows match`() = runTest {
         val userId = 3
         val result: List<User> = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }.list()
         assertThat(result).isEmpty()
     }
 
     @Test
-    fun flowMap() = runTest {
+    fun `flowMap returns all rows as maps`() = runTest {
         val result = kueryClient.sql { +"SELECT * FROM users" }.flowMap().toList()
         assertThat(result).isEqualTo(
             listOf(
@@ -300,14 +300,14 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `flowMap empty`() = runTest {
+    fun `flowMap returns an empty flow when no rows match`() = runTest {
         val userId = 3
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }.flowMap().toList()
         assertThat(result).isEmpty()
     }
 
     @Test
-    fun flow() = runTest {
+    fun `flow returns all rows mapped to data classes`() = runTest {
         val result = kueryClient.sql { +"SELECT * FROM users" }.flow<User>().toList()
         assertThat(result).isEqualTo(
             listOf(
@@ -326,14 +326,14 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `flow empty`() = runTest {
+    fun `flow returns an empty flow when no rows match`() = runTest {
         val userId = 3
         val result = kueryClient.sql { +"SELECT * FROM users WHERE user_id > $userId" }.flow<User>().toList()
         assertThat(result).isEmpty()
     }
 
     @Test
-    fun rowUpdated() = runTest {
+    fun `rowsUpdated returns the number of inserted rows`() = runTest {
         val username = "user3"
         val email = "user3"
         val result = kueryClient
@@ -345,7 +345,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `rowUpdated 0`() = runTest {
+    fun `rowsUpdated returns zero when no rows are affected`() = runTest {
         val userId = 5
         val result = kueryClient
             .sql {
@@ -356,7 +356,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `rowUpdated multi`() = runTest {
+    fun `rowsUpdated returns the count across all updated rows`() = runTest {
         val result = kueryClient
             .sql {
                 +"UPDATE users SET username = 'updated'"
@@ -366,7 +366,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun generatedValues() = runTest {
+    fun `generatedValues returns the auto-generated key of the inserted row`() = runTest {
         val username = "user3"
         val email = "user3"
         val result = kueryClient
@@ -378,7 +378,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun userOrder() = runTest {
+    fun `two-table join maps combined columns to a data class`() = runTest {
         data class UserOrder(
             val username: String,
             val orderId: Int,
@@ -411,7 +411,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun orderProduct() = runTest {
+    fun `three-table join maps combined columns to data classes`() = runTest {
         data class OrderProduct(
             val orderId: Int,
             val productName: String,
@@ -439,7 +439,7 @@ open class BasicUsageTest {
     }
 
     @Test
-    fun `using extension function`() = runTest {
+    fun `sql fragments can be composed via an extension function using addUnsafe and bind`() = runTest {
         @OptIn(DelicateKueryClientApi::class)
         fun SqlBuilder.userIdEqualsTo(userId: Int) {
             addUnsafe("users.user_id = ${bind(userId)}")

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CSVConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CSVConversionTest.kt
@@ -24,16 +24,19 @@ class CSVConversionTest {
     }
 
     @Test
-    fun test() = runTest {
+    fun `comma-separated text is read into a List property with trimmed elements`() = runTest {
+        // given
         val text = "a, b,c"
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES ($text)"
         }.rowsUpdated()
 
+        // when
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter"
         }.single()
 
+        // then
         assertThat(record.text).isEqualTo(listOf("a", "b", "c"))
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CodeEnumConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CodeEnumConversionTest.kt
@@ -95,27 +95,32 @@ class CodeEnumConversionTest {
     }
 
     @Test
-    fun test() = runTest {
+    fun `code enums are written as their codes and mapped back to enum properties`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO code_enum (int_enum, string_enum)"
             +"VALUES (${SampleIntCodeEnum.HOGE}, ${SampleStringCodeEnum.BAR})"
         }.rowsUpdated()
 
+        // when
         val record: Record = kueryClient.sql {
             +"SELECT * FROM code_enum"
         }.single()
 
+        // then
         assertThat(record.intEnum).isEqualTo(SampleIntCodeEnum.HOGE)
         assertThat(record.stringEnum).isEqualTo(SampleStringCodeEnum.BAR)
     }
 
     @Test
-    fun testScalar() = runTest {
+    fun `code enum is converted when fetched as a scalar`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO code_enum (int_enum, string_enum)"
             +"VALUES (${SampleIntCodeEnum.HOGE}, ${SampleStringCodeEnum.BAR})"
         }.rowsUpdated()
 
+        // when & then
         val intEnum: SampleIntCodeEnum = kueryClient.sql {
             +"SELECT int_enum FROM code_enum"
         }.single()

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CollectionConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/CollectionConversionTest.kt
@@ -44,7 +44,8 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun test() = runTest {
+    fun `list in an IN clause is expanded with each element converted`() = runTest {
+        // given
         kueryClient.sql {
             +"""
             INSERT INTO converter (text) VALUES
@@ -54,6 +55,7 @@ class CollectionConversionTest {
             """.trimIndent()
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             val inList = listOf(StringWrapper("text1"), StringWrapper("text2"))
             +"SELECT * FROM converter WHERE text IN ($inList)"
@@ -62,7 +64,8 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testCompositeIn() = runTest {
+    fun `list of arrays expands into composite IN tuples`() = runTest {
+        // given
         kueryClient.sql {
             +"""
             INSERT INTO converter (text) VALUES
@@ -71,6 +74,7 @@ class CollectionConversionTest {
             """.trimIndent()
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             val pairs = listOf(arrayOf<Any>(1L, StringWrapper("text1")))
             +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"
@@ -79,15 +83,18 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testEmptyCollection() = runTest {
+    fun `empty collection in an IN clause returns no rows on H2`() = runTest {
         // An empty collection is bound as-is; Spring's named parameter expansion then renders
         // it as `IN ()`. Whether that is valid SQL depends on the database: H2 accepts it and
         // returns no rows, while MySQL/PostgreSQL reject it (see the mysql/postgres packages).
         // Callers targeting those databases must guard against empty collections themselves.
+
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES ('text1')"
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             val emptyIds = emptyList<Long>()
             +"SELECT * FROM converter WHERE id IN ($emptyIds)"
@@ -97,7 +104,8 @@ class CollectionConversionTest {
 
     @OptIn(DelicateKueryClientApi::class)
     @Test
-    fun testHandBuiltTupleIn() = runTest {
+    fun `tuple IN clause hand-built with addUnsafe and bind matches the given pairs`() = runTest {
+        // given
         kueryClient.sql {
             +"""
             INSERT INTO converter (text) VALUES
@@ -107,6 +115,7 @@ class CollectionConversionTest {
             """.trimIndent()
         }.rowsUpdated()
 
+        // when & then
         val pairs = listOf(1L to "text1", 3L to "text3")
         val result = kueryClient.sql {
             +"SELECT * FROM converter"
@@ -117,7 +126,8 @@ class CollectionConversionTest {
 
     @OptIn(DelicateKueryClientApi::class)
     @Test
-    fun testBindCollectionViaAddUnsafe() = runTest {
+    fun `collection bound via bind inside addUnsafe is expanded in the IN clause`() = runTest {
+        // given
         kueryClient.sql {
             +"""
             INSERT INTO converter (text) VALUES
@@ -127,6 +137,7 @@ class CollectionConversionTest {
             """.trimIndent()
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             val texts = listOf("text1", "text2")
             addUnsafe("SELECT * FROM converter WHERE text IN (${bind(texts)})")
@@ -135,9 +146,11 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testSet() = runTest {
+    fun `set in an IN clause is expanded like a list`() = runTest {
+        // given
         insertThreeRows()
 
+        // when & then
         val result = kueryClient.sql {
             val inSet = setOf(StringWrapper("text1"), StringWrapper("text2"))
             +"SELECT * FROM converter WHERE text IN ($inSet)"
@@ -146,9 +159,11 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testMapKeysView() = runTest {
+    fun `map keys view in an IN clause is expanded like a collection`() = runTest {
+        // given
         insertThreeRows()
 
+        // when & then
         val map = mapOf(StringWrapper("text1") to 1, StringWrapper("text3") to 3)
         val result = kueryClient.sql {
             +"SELECT * FROM converter WHERE text IN (${map.keys})"
@@ -157,13 +172,15 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testCustomCollectionSubtype() = runTest {
+    fun `custom Collection subtype in an IN clause is expanded like a list`() = runTest {
         // Non-standard Collection implementations (e.g. NonEmptyList of functional libraries)
         // must expand like any other Collection.
         class NonEmptyList<T>(private val delegate: List<T>) : Collection<T> by delegate
 
+        // given
         insertThreeRows()
 
+        // when & then
         val result = kueryClient.sql {
             val inList = NonEmptyList(listOf(StringWrapper("text1"), StringWrapper("text2")))
             +"SELECT * FROM converter WHERE text IN ($inList)"
@@ -172,12 +189,15 @@ class CollectionConversionTest {
     }
 
     @Test
-    fun testNullElement() = runTest {
+    fun `null element in an IN list is rejected by r2dbc binding`() = runTest {
         // Unlike JDBC (where a null element binds as SQL NULL and simply never matches),
         // R2DBC's Statement.bind rejects null values, so a collection containing null cannot
         // be expanded. This pins the asymmetry.
+
+        // given
         insertThreeRows()
 
+        // when & then
         assertFailure {
             kueryClient.sql {
                 val inList = listOf(StringWrapper("text1"), null)

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ConverterRegistrationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ConverterRegistrationTest.kt
@@ -77,6 +77,7 @@ class ConverterRegistrationTest {
 
     @Test
     fun `GenericConverter is supported for reading`() = runTest {
+        // given
         val kueryClient = h2.kueryClient(
             listOf(StringToStringWrapperGenericConverter(), StringWrapperToStringConverter()),
         )
@@ -84,6 +85,7 @@ class ConverterRegistrationTest {
             +"INSERT INTO converter (text) VALUES ('hoge')"
         }.rowsUpdated()
 
+        // when & then
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter"
         }.single()
@@ -92,8 +94,10 @@ class ConverterRegistrationTest {
 
     @Test
     fun `GenericConverter for a Kotlin Int works via javaObjectType`() = runTest {
+        // given
         val kueryClient = h2.kueryClient(listOf(IntToIntWrapperGenericConverter()))
 
+        // when & then
         val record: IntRecord = kueryClient.sql {
             +"SELECT CAST(42 AS INT) AS num"
         }.single()
@@ -104,12 +108,15 @@ class ConverterRegistrationTest {
     fun `converter without annotation infers direction from the store-typed side`() = runTest {
         // Converter<StringWrapper, String> targets a store type, so Spring infers it as a
         // writing converter even without @WritingConverter.
+
+        // given
         val kueryClient = h2.kueryClient(listOf(UnannotatedStringWrapperToStringConverter()))
 
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${StringWrapper("hoge")})"
         }.rowsUpdated()
 
+        // when & then
         val result = kueryClient.sql {
             +"SELECT text FROM converter"
         }.single<String>()

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/EnumConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/EnumConversionTest.kt
@@ -28,11 +28,13 @@ class EnumConversionTest {
     }
 
     @Test
-    fun test() = runTest {
+    fun `enum is stored as its name and mapped back to the enum`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
         }.rowsUpdated()
 
+        // when & then
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter"
         }.single()
@@ -45,11 +47,13 @@ class EnumConversionTest {
     }
 
     @Test
-    fun testScalar() = runTest {
+    fun `enum is converted when fetched as a scalar`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
         }.rowsUpdated()
 
+        // when & then
         val result: SampleEnum = kueryClient.sql {
             +"SELECT text FROM converter"
         }.single()
@@ -57,11 +61,13 @@ class EnumConversionTest {
     }
 
     @Test
-    fun testInCollection() = runTest {
+    fun `enum in an IN clause matches the row stored by name`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
         }.rowsUpdated()
 
+        // when & then
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter WHERE text IN (${listOf(SampleEnum.HOGE)})"
         }.single()
@@ -69,11 +75,13 @@ class EnumConversionTest {
     }
 
     @Test
-    fun testCompositeIn() = runTest {
+    fun `enum in a composite IN tuple matches the row stored by name`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${SampleEnum.HOGE})"
         }.rowsUpdated()
 
+        // when & then
         val record: Record = kueryClient.sql {
             val pairs = listOf(arrayOf<Any>(1L, SampleEnum.HOGE))
             +"SELECT * FROM converter WHERE (id, text) IN ($pairs)"

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/NullReturningWritingConverterTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/NullReturningWritingConverterTest.kt
@@ -35,11 +35,13 @@ class NullReturningWritingConverterTest {
     }
 
     @Test
-    fun testNull() = runTest {
+    fun `null converter result is bound as SQL NULL`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${NullableText(null)})"
         }.rowsUpdated()
 
+        // when & then
         val map = kueryClient.sql {
             +"SELECT * FROM converter"
         }.singleMap()
@@ -47,11 +49,13 @@ class NullReturningWritingConverterTest {
     }
 
     @Test
-    fun testNonNull() = runTest {
+    fun `non-null converter result is bound as the converted value`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${NullableText("hoge")})"
         }.rowsUpdated()
 
+        // when & then
         val map = kueryClient.sql {
             +"SELECT * FROM converter"
         }.singleMap()

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationReactorContextTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationReactorContextTest.kt
@@ -58,61 +58,64 @@ class ObservationReactorContextTest {
     }
 
     @AfterEach
-    fun testDown() = runTest {
+    fun tearDown() = runTest {
         h2.databaseClient.sql("DROP TABLE users").fetch().awaitRowsUpdated()
     }
 
     @Test
-    fun singleMap() = runTest {
+    fun `singleMap propagates an observation carrying the sqlId via the Reactor context`() = runTest {
         userRepository.singleMap(1)
         assertCapturedObservation("com.example.spring.r2dbc.UserRepository.singleMap")
     }
 
     @Test
-    fun singleMapOrNull() = runTest {
+    fun `singleMapOrNull propagates an observation carrying the sqlId via the Reactor context`() = runTest {
         userRepository.singleMapOrNull(1)
         assertCapturedObservation("com.example.spring.r2dbc.UserRepository.singleMapOrNull")
     }
 
     @Test
-    fun single() = runTest {
+    fun `single propagates an observation carrying the sqlId via the Reactor context`() = runTest {
         userRepository.single(1)
         assertCapturedObservation("com.example.spring.r2dbc.UserRepository.single")
     }
 
     @Test
-    fun singleOrNull() = runTest {
+    fun `singleOrNull propagates an observation carrying the sqlId via the Reactor context`() = runTest {
         userRepository.singleOrNull(1)
         assertCapturedObservation("com.example.spring.r2dbc.UserRepository.singleOrNull")
     }
 
     @Test
-    fun listMap() = runTest {
+    fun `listMap propagates an observation carrying the sqlId via the Reactor context`() = runTest {
         userRepository.listMap()
         assertCapturedObservation("com.example.spring.r2dbc.UserRepository.listMap")
     }
 
     @Test
-    fun list() = runTest {
+    fun `list propagates an observation carrying the sqlId via the Reactor context`() = runTest {
         userRepository.list()
         assertCapturedObservation("com.example.spring.r2dbc.UserRepository.list")
     }
 
     @Test
-    fun rowsUpdated() = runTest {
+    fun `rowsUpdated propagates an observation carrying the sqlId via the Reactor context`() = runTest {
         userRepository.rowUpdated("user3", "user3@example.com")
         assertCapturedObservation("com.example.spring.r2dbc.UserRepository.rowUpdated")
     }
 
     @Test
-    fun generatedValues() = runTest {
+    fun `generatedValues propagates an observation carrying the sqlId via the Reactor context`() = runTest {
         userRepository.generatedValues("user3", "user3@example.com")
         assertCapturedObservation("com.example.spring.r2dbc.UserRepository.generatedValues")
     }
 
     @Test
     fun `links parent observation from the Reactor context`() = runTest {
+        // given
         val parent = Observation.start("parent", registry)
+
+        // when
         try {
             withContext(Context.of(ObservationThreadLocalAccessor.KEY, parent).asCoroutineContext()) {
                 userRepository.singleMap(1)
@@ -121,6 +124,7 @@ class ObservationReactorContextTest {
             parent.stop()
         }
 
+        // then
         assertThat(capturedObservations).hasSize(1)
         val observation = assertThat(capturedObservations.single()).isNotNull()
         observation.transform { it.context.parentObservation }.isEqualTo(parent)

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ObservationTest.kt
@@ -48,12 +48,12 @@ class ObservationTest {
     }
 
     @AfterEach
-    fun testDown() = runTest {
+    fun tearDown() = runTest {
         h2.databaseClient.sql("DROP TABLE users").fetch().awaitRowsUpdated()
     }
 
     @Test
-    fun singleMap() = runTest {
+    fun `singleMap records an observation with sqlId and sql`() = runTest {
         userRepository.singleMap(1)
         assertObservation(
             sqlId = "com.example.spring.r2dbc.UserRepository.singleMap",
@@ -62,7 +62,7 @@ class ObservationTest {
     }
 
     @Test
-    fun singleMapOrNull() = runTest {
+    fun `singleMapOrNull records an observation with sqlId and sql`() = runTest {
         userRepository.singleMapOrNull(1)
         assertObservation(
             sqlId = "com.example.spring.r2dbc.UserRepository.singleMapOrNull",
@@ -71,7 +71,7 @@ class ObservationTest {
     }
 
     @Test
-    fun single() = runTest {
+    fun `single records an observation with sqlId and sql`() = runTest {
         userRepository.single(1)
         assertObservation(
             sqlId = "com.example.spring.r2dbc.UserRepository.single",
@@ -80,7 +80,7 @@ class ObservationTest {
     }
 
     @Test
-    fun singleOrNull() = runTest {
+    fun `singleOrNull records an observation with sqlId and sql`() = runTest {
         userRepository.singleOrNull(1)
         assertObservation(
             sqlId = "com.example.spring.r2dbc.UserRepository.singleOrNull",
@@ -89,7 +89,7 @@ class ObservationTest {
     }
 
     @Test
-    fun listMap() = runTest {
+    fun `listMap records an observation with sqlId and sql`() = runTest {
         userRepository.listMap()
         assertObservation(
             sqlId = "com.example.spring.r2dbc.UserRepository.listMap",
@@ -98,7 +98,7 @@ class ObservationTest {
     }
 
     @Test
-    fun list() = runTest {
+    fun `list records an observation with sqlId and sql`() = runTest {
         userRepository.list()
         assertObservation(
             sqlId = "com.example.spring.r2dbc.UserRepository.list",
@@ -107,7 +107,7 @@ class ObservationTest {
     }
 
     @Test
-    fun rowUpdated() = runTest {
+    fun `rowsUpdated records an observation with sqlId and sql`() = runTest {
         userRepository.rowUpdated("user3", "user3@example.com")
         assertObservation(
             sqlId = "com.example.spring.r2dbc.UserRepository.rowUpdated",
@@ -116,7 +116,7 @@ class ObservationTest {
     }
 
     @Test
-    fun generatedValues() = runTest {
+    fun `generatedValues records an observation with sqlId and sql`() = runTest {
         userRepository.generatedValues("user3", "user3@example.com")
         assertObservation(
             sqlId = "com.example.spring.r2dbc.UserRepository.generatedValues",
@@ -161,11 +161,13 @@ class ObservationTest {
 
     @Test
     fun `stops the observation without error when the fetch is cancelled`() = runTest {
+        // given
         val neverClient = SpringR2dbcKueryClient.builder()
             .connectionFactory(NeverExecutingConnectionFactory(h2.connectionFactory))
             .observationRegistry(registry)
             .build()
 
+        // when
         // UNDISPATCHED runs the coroutine up to its first suspension point, so the fetch is
         // guaranteed to have subscribed (and the observation to have started) before we cancel.
         val job = launch(start = CoroutineStart.UNDISPATCHED) {
@@ -173,6 +175,7 @@ class ObservationTest {
         }
         job.cancelAndJoin()
 
+        // then
         TestObservationRegistryAssert.assertThat(registry)
             .doesNotHaveAnyRemainingCurrentObservation()
             .hasObservationWithNameEqualTo("kuery.client.fetches")

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SqlIdReactorContextTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SqlIdReactorContextTest.kt
@@ -47,66 +47,66 @@ class SqlIdReactorContextTest {
     }
 
     @AfterEach
-    fun testDown() = runTest {
+    fun tearDown() = runTest {
         h2.databaseClient.sql("DROP TABLE users").fetch().awaitRowsUpdated()
     }
 
     @Test
-    fun singleMap() = runTest {
+    fun `singleMap propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.singleMap(1)
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.singleMap")
     }
 
     @Test
-    fun singleMapOrNull() = runTest {
+    fun `singleMapOrNull propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.singleMapOrNull(1)
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.singleMapOrNull")
     }
 
     @Test
-    fun single() = runTest {
+    fun `single propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.single(1)
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.single")
     }
 
     @Test
-    fun singleOrNull() = runTest {
+    fun `singleOrNull propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.singleOrNull(1)
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.singleOrNull")
     }
 
     @Test
-    fun listMap() = runTest {
+    fun `listMap propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.listMap()
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.listMap")
     }
 
     @Test
-    fun list() = runTest {
+    fun `list propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.list()
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.list")
     }
 
     @Test
-    fun flowMap() = runTest {
+    fun `flowMap propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.flowMap().collect()
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.flowMap")
     }
 
     @Test
-    fun flow() = runTest {
+    fun `flow propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.flow().collect()
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.flow")
     }
 
     @Test
-    fun rowsUpdated() = runTest {
+    fun `rowsUpdated propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.rowUpdated("user3", "user3@example.com")
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.rowUpdated")
     }
 
     @Test
-    fun generatedValues() = runTest {
+    fun `generatedValues propagates the auto-generated sqlId to statement execution`() = runTest {
         userRepository.generatedValues("user3", "user3@example.com")
         assertThat(capturedSqlIds).containsExactly("com.example.spring.r2dbc.UserRepository.generatedValues")
     }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/StatementOptionsTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/StatementOptionsTest.kt
@@ -43,12 +43,15 @@ class StatementOptionsTest {
 
     @Test
     fun `options are applied immutably`() = runTest {
+        // given
         val base = kueryClient.sql { +"SELECT * FROM users" }
         val withFetchSize = base.fetchSize(3)
 
+        // when
         val baseResult = base.listMap()
         val withFetchSizeResult = withFetchSize.listMap()
 
+        // then
         assertThat(baseResult).hasSize(10)
         assertThat(withFetchSizeResult).hasSize(10)
     }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/StringCaseTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/StringCaseTest.kt
@@ -37,16 +37,19 @@ class StringCaseTest {
     )
 
     @Test
-    fun test() = runTest {
+    fun `snake_case and camelCase columns both map to data class properties`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO string_case (hoge_bar, fugaPiyo) VALUES ('a', 'b')"
         }.rowsUpdated()
 
+        // when
         val record: Record = kueryClient.sql {
             +"SELECT * FROM string_case"
         }.single()
         println(record)
 
+        // then
         assertThat(record.hogeBar).isEqualTo("a")
         assertThat(record.fugaPiyo).isEqualTo("b")
     }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/StringWrapperConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/StringWrapperConversionTest.kt
@@ -44,15 +44,18 @@ class StringWrapperConversionTest {
     }
 
     @Test
-    fun test() = runTest {
+    fun `wrapper type round-trips through registered writing and reading converters`() = runTest {
+        // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${StringWrapper("hoge")})"
         }.rowsUpdated()
 
+        // when
         val record: Record = kueryClient.sql {
             +"SELECT * FROM converter"
         }.single()
 
+        // then
         assertThat(record.text).isEqualTo(StringWrapper("hoge"))
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/TransactionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/TransactionTest.kt
@@ -33,25 +33,30 @@ class TransactionTest {
 
     @Test
     fun `commit persists the changes`() = runTest {
+        // when
         transactionalOperator.executeAndAwait {
             kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
         }
 
+        // then
         assertThat(count()).isEqualTo(1L)
     }
 
     @Test
     fun `setRollbackOnly discards the changes`() = runTest {
+        // when
         transactionalOperator.executeAndAwait { status ->
             kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
             status.setRollbackOnly()
         }
 
+        // then
         assertThat(count()).isEqualTo(0L)
     }
 
     @Test
     fun `an exception rolls back the changes`() = runTest {
+        // when & then
         assertFailure {
             transactionalOperator.executeAndAwait<Nothing> {
                 kueryClient.sql { +"INSERT INTO converter (text) VALUES ('text1')" }.rowsUpdated()
@@ -59,6 +64,7 @@ class TransactionTest {
             }
         }.isInstanceOf(IllegalStateException::class)
 
+        // then
         assertThat(count()).isEqualTo(0L)
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ValueClassFetchTest.kt
@@ -56,7 +56,10 @@ class ValueClassFetchTest {
 
     @Test
     fun `value class as a data class property is not supported either`() = runTest {
+        // given
         val kueryClient = h2.kueryClient(listOf(StringToUserNameConverter()))
+
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"SELECT id, text FROM converter ORDER BY id"

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ValuesHelperTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/ValuesHelperTest.kt
@@ -28,7 +28,7 @@ class ValuesHelperTest {
     }
 
     @AfterEach
-    fun testDown() = runTest {
+    fun tearDown() = runTest {
         h2.databaseClient.sql(
             """
             DROP TABLE users
@@ -44,13 +44,15 @@ class ValuesHelperTest {
     )
 
     @Test
-    fun test() = runTest {
+    fun `values expands a list of rows into a multi-row INSERT`() = runTest {
+        // given
         val input = listOf(
             listOf("user1", "user1@example.com", 1),
             listOf("user2", null, 2),
             listOf("user3", "user3@example.com", 3),
         )
 
+        // when & then
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO users (username, email, age)"
             values(input)
@@ -70,19 +72,21 @@ class ValuesHelperTest {
     }
 
     @Test
-    fun `test with transformer`() = runTest {
+    fun `values with a transformer maps objects to rows before binding`() = runTest {
         data class UserParam(
             val username: String,
             val email: String?,
             val age: Int,
         )
 
+        // given
         val input = listOf(
             UserParam("user1", "user1@example.com", 1),
             UserParam("user2", null, 2),
             UserParam("user3", "user3@example.com", 3),
         )
 
+        // when & then
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO users (username, email, age)"
             values(input) { listOf(it.username, it.email, it.age) }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlByteArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlByteArrayBindingTest.kt
@@ -38,12 +38,16 @@ class MySqlByteArrayBindingTest {
 
     @Test
     fun `bind ByteArray as a single binary value`() = runTest {
+        // given
         val id = ByteArray(16) { it.toByte() }
         val data = byteArrayOf(1, 2, 3)
 
+        // when
         val inserted = kueryClient
             .sql { +"INSERT INTO binaries (id, data) VALUES ($id, $data)" }
             .rowsUpdated()
+
+        // then
         assertThat(inserted).isEqualTo(1L)
 
         val stored = kueryClient
@@ -54,24 +58,33 @@ class MySqlByteArrayBindingTest {
 
     @Test
     fun `bind the same ByteArray twice in one statement`() = runTest {
+        // given
         val id = ByteArray(16) { it.toByte() }
         val data = byteArrayOf(1, 2, 3)
         kueryClient
             .sql { +"INSERT INTO binaries (id, data) VALUES ($id, $data)" }
             .rowsUpdated()
 
+        // when
         val count = kueryClient
             .sql { +"SELECT COUNT(*) FROM binaries WHERE id = $id AND data = $data AND data = $data" }
             .single<Long>()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `singleOrNull ByteArray returns null when no row matches`() = runTest {
+        // given
         val id = ByteArray(16) { it.toByte() }
+
+        // when
         val stored = kueryClient
             .sql { +"SELECT data FROM binaries WHERE id = $id" }
             .singleOrNull<ByteArray>()
+
+        // then
         assertThat(stored).isNull()
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlDuplicateKeyTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlDuplicateKeyTest.kt
@@ -38,7 +38,10 @@ class MySqlDuplicateKeyTest {
 
     @Test
     fun `unique constraint violation throws DuplicateKeyException`() = runTest {
+        // given
         val email = "user1@example.com"
+
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"INSERT INTO dup_users (user_id, email) VALUES (2, $email)"

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlGeneratedValuesTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlGeneratedValuesTest.kt
@@ -35,12 +35,17 @@ class MySqlGeneratedValuesTest {
     }
 
     @Test
-    fun generatedValues() = runTest {
+    fun `generatedValues returns the generated key of a single insert`() = runTest {
+        // given
         val username = "user1"
         val email = "user1@example.com"
+
+        // when
         val result = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .generatedValues("user_id")
+
+        // then
         assertThat(result).isEqualTo(mapOf("user_id" to 1L))
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlKeysetPaginationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlKeysetPaginationTest.kt
@@ -45,29 +45,37 @@ class MySqlKeysetPaginationTest {
 
     @Test
     fun `keyset pagination ascending`() = runTest {
+        // given
         val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0)
         val cursorId = 1
 
+        // when
         val page = kueryClient.sql {
             +"SELECT id FROM events"
             +"WHERE (created_at, id) > ($cursorCreatedAt, $cursorId)"
             +"ORDER BY created_at, id"
             +"LIMIT 2"
         }.listMap()
+
+        // then
         assertThat(page.map { it["id"] }).isEqualTo(listOf(2, 3))
     }
 
     @Test
     fun `keyset pagination descending`() = runTest {
+        // given
         val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 5, 0)
         val cursorId = 4
 
+        // when
         val page = kueryClient.sql {
             +"SELECT id FROM events"
             +"WHERE (created_at, id) < ($cursorCreatedAt, $cursorId)"
             +"ORDER BY created_at DESC, id DESC"
             +"LIMIT 2"
         }.listMap()
+
+        // then
         assertThat(page.map { it["id"] }).isEqualTo(listOf(3, 2))
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlNullBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlNullBindingTest.kt
@@ -35,21 +35,31 @@ class MySqlNullBindingTest {
 
     @Test
     fun `bind non-null value`() = runTest {
+        // given
         val username = "user1"
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `bind null value`() = runTest {
+        // given
         val username: String? = null
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -60,39 +70,59 @@ class MySqlNullBindingTest {
 
     @Test
     fun `bind null value to an int column`() = runTest {
+        // given
         val age: Int? = null
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (email, age) VALUES ($email, $age)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `compare with null value in WHERE clause`() = runTest {
+        // given
         val username: String? = null
+
+        // when
         val list = kueryClient
             .sql { +"SELECT * FROM users WHERE username = $username" }
             .listMap()
+
+        // then
         assertThat(list).isEqualTo(emptyList())
     }
 
     @Test
     fun `select null value directly`() = runTest {
+        // given
         val value: String? = null
+
+        // when
         val record = kueryClient
             .sql { +"SELECT $value AS v" }
             .singleMap()
+
+        // then
         assertThat(record["v"]).isNull()
     }
 
     @Test
     fun `bind null value via typed Parameter as an escape hatch`() = runTest {
+        // given
         val username = Parameters.`in`(R2dbcType.VARCHAR)
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlNullScalarResultTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlNullScalarResultTest.kt
@@ -40,8 +40,13 @@ class MySqlNullScalarResultTest {
 
     @Test
     fun `singleOrNull returns null for a NULL column`() = runTest {
+        // given
         insert("user1@example.com", age = null)
+
+        // when
         val age: Int? = kueryClient.sql { +"SELECT age FROM users" }.singleOrNull()
+
+        // then
         assertThat(age).isNull()
     }
 
@@ -53,14 +58,22 @@ class MySqlNullScalarResultTest {
 
     @Test
     fun `singleOrNull returns null for a NULL string column`() = runTest {
+        // given
         insert("user1@example.com", age = null)
+
+        // when
         val username: String? = kueryClient.sql { +"SELECT username FROM users" }.singleOrNull()
+
+        // then
         assertThat(username).isNull()
     }
 
     @Test
     fun `single throws for a NULL column`() = runTest {
+        // given
         insert("user1@example.com", age = null)
+
+        // when & then
         assertFailure {
             kueryClient.sql { +"SELECT age FROM users" }.single<Int>()
         }.isInstanceOf(TypeMismatchDataAccessException::class)
@@ -68,17 +81,27 @@ class MySqlNullScalarResultTest {
 
     @Test
     fun `list preserves NULL elements`() = runTest {
+        // given
         insert("user1@example.com", age = 20)
         insert("user2@example.com", age = null)
+
+        // when
         val ages: List<Int?> = kueryClient.sql { +"SELECT age FROM users ORDER BY user_id" }.list(Int::class)
+
+        // then
         assertThat(ages).isEqualTo(listOf(20, null))
     }
 
     @Test
     fun `flow preserves NULL elements`() = runTest {
+        // given
         insert("user1@example.com", age = 20)
         insert("user2@example.com", age = null)
+
+        // when
         val ages: List<Int?> = kueryClient.sql { +"SELECT age FROM users ORDER BY user_id" }.flow<Int>().toList()
+
+        // then
         assertThat(ages).isEqualTo(listOf(20, null))
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlSingleBasicTypeTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlSingleBasicTypeTest.kt
@@ -33,20 +33,22 @@ class MySqlSingleBasicTypeTest {
     @OptIn(DelicateKueryClientApi::class)
     @ParameterizedTest
     @MethodSource("singleValues")
-    fun testSingleValues(
+    fun `single maps a single-column result to each basic type`(
         query: String,
         expected: Any,
         type: KClass<*>,
     ) = runTest {
+        // when
         val result = kueryClient.sql {
             addUnsafe(query)
         }.single(type)
 
+        // then
         assertThat(result).isEqualTo(expected)
     }
 
     @Test
-    fun unSupportNotSimpleProperty() = runTest {
+    fun `single with a non-simple data class type is rejected`() = runTest {
         assertFailure {
             kueryClient.sql {
                 +"SELECT 'hoge'"
@@ -55,11 +57,13 @@ class MySqlSingleBasicTypeTest {
     }
 
     @Test
-    fun testSingleColumnWithMultiValue() = runTest {
+    fun `list maps each row of a single-column result`() = runTest {
+        // when
         val result = kueryClient.sql {
             +"SELECT 1 UNION SELECT 0"
         }.list(Int::class)
 
+        // then
         assertThat(result).isEqualTo(listOf(1, 0))
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlUpsertTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlUpsertTest.kt
@@ -37,16 +37,20 @@ class MySqlUpsertTest {
 
     @Test
     fun `values followed by ON DUPLICATE KEY UPDATE with row alias`() = runTest {
+        // given
         val input = listOf(
             listOf(1, "new1@example.com"),
             listOf(2, "new2@example.com"),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO upsert_users (user_id, email)"
             values(input)
             +"AS new ON DUPLICATE KEY UPDATE email = new.email"
         }.rowsUpdated()
+
+        // then
         // 2 for the updated row (user_id=1) + 1 for the inserted row (user_id=2)
         assertThat(rowsUpdated).isEqualTo(3L)
 
@@ -57,16 +61,21 @@ class MySqlUpsertTest {
     fun `values followed by ON DUPLICATE KEY UPDATE with VALUES function`() = runTest {
         // MySQL's VALUES(col) function (deprecated in 8.0.20 but widely used) shares its name
         // with the values() DSL; they must not interfere.
+
+        // given
         val input = listOf(
             listOf(1, "new1@example.com"),
             listOf(2, "new2@example.com"),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO upsert_users (user_id, email)"
             values(input)
             +"ON DUPLICATE KEY UPDATE email = VALUES(email)"
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(3L)
 
         assertUpserted()

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlValuesHelperTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlValuesHelperTest.kt
@@ -37,16 +37,20 @@ class MySqlValuesHelperTest {
 
     @Test
     fun `values mixing null and non-null rows on typed columns`() = runTest {
+        // given
         val createdAt = LocalDateTime.of(2026, 1, 1, 0, 0, 0)
         val input = listOf(
             listOf(1, ByteArray(16) { it.toByte() }, createdAt),
             listOf(2, null, null),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO documents (id, parent_id, created_at)"
             values(input)
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(2L)
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
@@ -47,38 +47,58 @@ class PostgresArrayBindingTest {
 
     @Test
     fun `bind array to ANY predicate`() = runTest {
+        // given
         val usernames = arrayOf("HOGE", "FUGA")
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind enum array to ANY predicate`() = runTest {
+        // given
         val usernames = arrayOf(SampleEnum.HOGE, SampleEnum.FUGA)
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind custom-converted array to ANY predicate`() = runTest {
+        // given
         val kueryClient = postgres.kueryClient(listOf(StringWrapperToStringConverter()))
         val usernames = arrayOf(StringWrapper("HOGE"), StringWrapper("FUGA"))
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind array to a native array column`() = runTest {
+        // given
         val tags = arrayOf("a", "b")
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -90,10 +110,15 @@ class PostgresArrayBindingTest {
 
     @Test
     fun `bind all-null enum array to a native array column`() = runTest {
+        // given
         val tags = arrayOf<SampleEnum?>(null, null)
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -105,10 +130,15 @@ class PostgresArrayBindingTest {
 
     @Test
     fun `bind empty enum array to a native array column`() = runTest {
+        // given
         val tags = arrayOf<SampleEnum>()
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -120,64 +150,99 @@ class PostgresArrayBindingTest {
 
     @Test
     fun `bind primitive int array to ANY predicate`() = runTest {
+        // given
         val userIds = intArrayOf(1, 2)
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind primitive long array to ANY predicate`() = runTest {
+        // given
         val userIds = longArrayOf(1, 2)
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind primitive short array to ANY predicate`() = runTest {
+        // given
         val userIds = shortArrayOf(1, 2)
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind primitive double array to ANY predicate`() = runTest {
+        // given
         val userIds = doubleArrayOf(1.0, 2.0)
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind primitive float array to ANY predicate`() = runTest {
+        // given
         val userIds = floatArrayOf(1.0f, 2.0f)
+
+        // when
         val list = kueryClient
             .sql { +"SELECT username FROM users WHERE user_id = ANY($userIds) ORDER BY user_id" }
             .listMap()
+
+        // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
     }
 
     @Test
     fun `bind primitive boolean array round-trips through select`() = runTest {
+        // given
         val flags = booleanArrayOf(true, false)
+
+        // when
         val record = kueryClient
             .sql { +"SELECT $flags AS flags" }
             .singleMap()
+
+        // then
         assertThat((record["flags"] as Array<*>).toList()).isEqualTo(listOf(true, false))
     }
 
     @Test
     fun `bind primitive char array round-trips through select`() = runTest {
+        // given
         val chars = charArrayOf('a', 'b')
+
+        // when
         val record = kueryClient
             .sql { +"SELECT $chars AS chars" }
             .singleMap()
+
+        // then
         assertThat((record["chars"] as Array<*>).toList()).isEqualTo(listOf("a", "b"))
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresCastBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresCastBindingTest.kt
@@ -36,16 +36,20 @@ class PostgresCastBindingTest {
 
     @Test
     fun `casts right after placeholders are kept intact`() = runTest {
+        // given
         val id = "0f14d0ab-9605-4a62-a9e4-5ed26688389b"
         val settings = """{"theme": "dark"}"""
         val createdAt = "2026-01-01 00:00:00+00"
 
+        // when
         val inserted = kueryClient
             .sql {
                 +"INSERT INTO cast_targets (id, settings, created_at)"
                 +"VALUES ($id::uuid, $settings::jsonb, $createdAt::timestamptz)"
             }
             .rowsUpdated()
+
+        // then
         assertThat(inserted).isEqualTo(1L)
 
         val record = kueryClient

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresDuplicateKeyTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresDuplicateKeyTest.kt
@@ -37,7 +37,10 @@ class PostgresDuplicateKeyTest {
 
     @Test
     fun `unique constraint violation throws DuplicateKeyException`() = runTest {
+        // given
         val email = "user1@example.com"
+
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"INSERT INTO dup_users (user_id, email) VALUES (2, $email)"

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresGeneratedValuesTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresGeneratedValuesTest.kt
@@ -43,15 +43,18 @@ class PostgresGeneratedValuesTest {
     }
 
     @Test
-    fun generatedValues() = runTest {
+    fun `generatedValues returns the generated key of a single insert`() = runTest {
+        // when
         val result = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ('user1', 'user1@example.com')" }
             .generatedValues("user_id")
+
+        // then
         assertThat(result).isEqualTo(mapOf("user_id" to 1))
     }
 
     @Test
-    fun `generatedValues no generated keys`() = runTest {
+    fun `generatedValues throws EmptyResultDataAccessException when no keys are generated`() = runTest {
         assertFailure {
             kueryClient
                 .sql { +"UPDATE users SET username = 'updated' WHERE user_id = 1" }
@@ -60,7 +63,7 @@ class PostgresGeneratedValuesTest {
     }
 
     @Test
-    fun `generatedValues multiple generated keys`() = runTest {
+    fun `generatedValues throws IncorrectResultSizeDataAccessException for multiple keys`() = runTest {
         assertFailure {
             kueryClient
                 .sql {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresKeysetPaginationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresKeysetPaginationTest.kt
@@ -45,29 +45,37 @@ class PostgresKeysetPaginationTest {
 
     @Test
     fun `keyset pagination ascending`() = runTest {
+        // given
         val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0)
         val cursorId = 1
 
+        // when
         val page = kueryClient.sql {
             +"SELECT id FROM events"
             +"WHERE (created_at, id) > ($cursorCreatedAt, $cursorId)"
             +"ORDER BY created_at, id"
             +"LIMIT 2"
         }.listMap()
+
+        // then
         assertThat(page.map { it["id"] }).isEqualTo(listOf(2, 3))
     }
 
     @Test
     fun `keyset pagination descending`() = runTest {
+        // given
         val cursorCreatedAt = LocalDateTime.of(2026, 1, 1, 10, 5, 0)
         val cursorId = 4
 
+        // when
         val page = kueryClient.sql {
             +"SELECT id FROM events"
             +"WHERE (created_at, id) < ($cursorCreatedAt, $cursorId)"
             +"ORDER BY created_at DESC, id DESC"
             +"LIMIT 2"
         }.listMap()
+
+        // then
         assertThat(page.map { it["id"] }).isEqualTo(listOf(3, 2))
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresNullBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresNullBindingTest.kt
@@ -35,21 +35,31 @@ class PostgresNullBindingTest {
 
     @Test
     fun `bind non-null value`() = runTest {
+        // given
         val username = "user1"
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `bind null value`() = runTest {
+        // given
         val username: String? = null
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
 
         val record = kueryClient
@@ -60,39 +70,59 @@ class PostgresNullBindingTest {
 
     @Test
     fun `bind null value to an int column`() = runTest {
+        // given
         val age: Int? = null
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (email, age) VALUES ($email, $age)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 
     @Test
     fun `compare with null value in WHERE clause`() = runTest {
+        // given
         val username: String? = null
+
+        // when
         val list = kueryClient
             .sql { +"SELECT * FROM users WHERE username = $username" }
             .listMap()
+
+        // then
         assertThat(list).isEqualTo(emptyList())
     }
 
     @Test
     fun `select null value directly`() = runTest {
+        // given
         val value: String? = null
+
+        // when
         val record = kueryClient
             .sql { +"SELECT $value AS v" }
             .singleMap()
+
+        // then
         assertThat(record["v"]).isNull()
     }
 
     @Test
     fun `bind null value via typed Parameter as an escape hatch`() = runTest {
+        // given
         val username = Parameters.`in`(R2dbcType.VARCHAR)
         val email = "user1@example.com"
+
+        // when
         val count = kueryClient
             .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
             .rowsUpdated()
+
+        // then
         assertThat(count).isEqualTo(1L)
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresUpsertTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresUpsertTest.kt
@@ -37,16 +37,20 @@ class PostgresUpsertTest {
 
     @Test
     fun `values followed by ON CONFLICT DO UPDATE`() = runTest {
+        // given
         val input = listOf(
             listOf(1, "new1@example.com"),
             listOf(2, "new2@example.com"),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO upsert_users (user_id, email)"
             values(input)
             +"ON CONFLICT (user_id) DO UPDATE SET email = EXCLUDED.email"
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(2L)
 
         val result = kueryClient

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresValuesHelperTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresValuesHelperTest.kt
@@ -51,31 +51,39 @@ class PostgresValuesHelperTest {
 
     @Test
     fun `values with non-null typed rows`() = runTest {
+        // given
         val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
         val input = listOf(
             listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
             listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO documents (id, parent_id, created_at)"
             values(input)
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(2L)
     }
 
     @Test
     fun `values mixing null and non-null rows on a typed column`() = runTest {
+        // given
         val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
         val input = listOf(
             listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
             listOf(UUID.randomUUID(), null, createdAt),
         )
 
+        // when
         val rowsUpdated = kueryClient.sql {
             +"INSERT INTO documents (id, parent_id, created_at)"
             values(input)
         }.rowsUpdated()
+
+        // then
         assertThat(rowsUpdated).isEqualTo(2L)
     }
 
@@ -87,12 +95,15 @@ class PostgresValuesHelperTest {
         // row is properly typed: the column's common type resolves to varchar and then fails
         // against the uuid target column. (Historically this surfaced as "VALUES types
         // character varying and uuid cannot be matched" on older driver/server combinations.)
+
+        // given
         val createdAt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
         val input = listOf(
             listOf(UUID.randomUUID(), UUID.randomUUID(), createdAt),
             listOf(UUID.randomUUID(), "0f14d0ab-9605-4a62-a9e4-5ed26688389b", createdAt),
         )
 
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"INSERT INTO documents (id, parent_id, created_at)"
@@ -105,10 +116,12 @@ class PostgresValuesHelperTest {
 
     @Test
     fun `values binding strings for typed columns is rejected`() = runTest {
+        // given
         val input = listOf(
             listOf("0f14d0ab-9605-4a62-a9e4-5ed26688389b", null, "2026-01-01 00:00:00+00"),
         )
 
+        // when & then
         assertFailure {
             kueryClient.sql {
                 +"INSERT INTO documents (id, parent_id, created_at)"


### PR DESCRIPTION
## Summary

Readability-only cleanup of the whole test suite. No test case is added, removed, or changed — every assertion and piece of logic is exactly as before (446 `@Test`/`@ParameterizedTest` annotations before and after).

### 1. Test method names: backtick spec-style sentences

Test method naming was a mix of three styles (`testXXX`, plain camelCase like `singleMap()`, and backtick sentences — sometimes within a single class). All ~240 non-conforming names are now backtick English sentences that state the condition and the expected result, so the method list of a class reads as its spec:

- `testEmptyCollection()` → `` `empty collection in IN clause is rejected` ``
- `singleMap()` → `` `singleMap returns the only row as a map` ``
- `` `singleMap no record` `` → `` `singleMap throws when no rows match` ``

Conventions: no `should`, no `test` prefix, third-person present tense, subject is the exact API name where natural. Mirror classes in `spring-data-jdbc` / `spring-data-r2dbc` use identical method names; the only deliberate divergence is `CollectionConversionTest`'s null-element case, where the two drivers intentionally behave differently.

### 2. Test bodies: given-when-then structure

Bodies are structured with `// given` / `// when` / `// then` (or `// when & then` where execution and verification are one expression). Comments are inserted only — no code was reordered or rewritten — and omitted where they would not help (trivial one-liners, repetitive execute-assert loops).

### 3. Drive-by fix

Lifecycle method typo `testDown()` → `tearDown()` (8 occurrences).

## Notes

- A pre-existing copy-paste issue was found but intentionally **not** fixed here (kept for a separate PR): `` `singleMapOrNull throws when more than one row matches` `` in both `BasicUsageTest`s calls `singleMap()` instead of `singleMapOrNull()`, duplicating the `singleMap` case.

## Verification

- `./gradlew check detektMain detektTest` (CI-equivalent, incl. Testcontainers MySQL/Postgres): **BUILD SUCCESSFUL**, 469 tests executed, 0 failures.
- Annotation count identical before/after (446), confirming no test method was lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)