### PR TITLE
Fix singleMapOrNull test to actually call singleMapOrNull

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/BasicUsageTest.kt
@@ -158,7 +158,7 @@ class BasicUsageTest {
     @Test
     fun `singleMapOrNull throws when more than one row matches`() {
         assertFailure {
-            kueryClient.sql { +"SELECT * FROM users" }.singleMap()
+            kueryClient.sql { +"SELECT * FROM users" }.singleMapOrNull()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/BasicUsageTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/BasicUsageTest.kt
@@ -156,7 +156,7 @@ open class BasicUsageTest {
     @Test
     fun `singleMapOrNull throws when more than one row matches`() = runTest {
         assertFailure {
-            kueryClient.sql { +"SELECT * FROM users" }.singleMap()
+            kueryClient.sql { +"SELECT * FROM users" }.singleMapOrNull()
         }.isInstanceOf(IncorrectResultSizeDataAccessException::class)
     }
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing copy-paste slip noted in #397: in both `BasicUsageTest`s (spring-data-jdbc and spring-data-r2dbc), the test `` `singleMapOrNull throws when more than one row matches` `` called `singleMap()` instead of `singleMapOrNull()`. It therefore duplicated the `singleMap` case, and `singleMapOrNull`'s behavior on a multi-row result was not actually covered.

The fix changes the call to `singleMapOrNull()` in both mirror tests. The expected exception (`IncorrectResultSizeDataAccessException`) is unchanged.

## Verification

`./gradlew :kuery-client-spring-data-jdbc:test --tests "dev.hsbrysk.kuery.spring.jdbc.BasicUsageTest" :kuery-client-spring-data-r2dbc:test --tests "dev.hsbrysk.kuery.spring.r2dbc.BasicUsageTest"` — all 28 + 29 tests pass, confirming `singleMapOrNull` does throw `IncorrectResultSizeDataAccessException` when more than one row matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)