### PR TITLE
Split multi-spec test functions into one test per behavior

### DIFF
--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/SqlGenerationTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/SqlGenerationTest.kt
@@ -147,7 +147,7 @@ class SqlGenerationTest {
     }
 
     @Test
-    fun `an empty collection is bound as a single parameter without expansion`() {
+    fun `an empty list is bound as a single parameter without expansion`() {
         // An empty collection is NOT expanded at the core level. It is bound as a single
         // parameter whose value is the empty collection; what happens next is up to the
         // executing layer (e.g. Spring's named parameter expansion).
@@ -175,17 +175,20 @@ class SqlGenerationTest {
                 ),
             ),
         )
+    }
 
+    @Test
+    fun `an empty set is bound as a single parameter without expansion`() {
         // given
         val emptyIdSet = emptySet<Int>()
 
         // when
-        val sql2 = Sql {
+        val sql = Sql {
             +"SELECT * FROM user WHERE id IN ($emptyIdSet)"
         }
 
         // then
-        assertThat(sql2).isEqualTo(
+        assertThat(sql).isEqualTo(
             Sql(
                 "SELECT * FROM user WHERE id IN (:p0)",
                 listOf(

--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
@@ -142,22 +142,24 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `a string literal value is inlined while a computed string is bound`() {
-        // In such cases, string interpolation will not be executed.
-        val sql1 = Sql {
+    fun `a string literal value is inlined as raw text`() {
+        // A string literal is a compile-time constant, so it is not bound as a parameter.
+        val sql = Sql {
             +"a ${"hoge"}"
         }
-        assertThat(sql1).isEqualTo(
+        assertThat(sql).isEqualTo(
             Sql(
                 "a hoge",
             ),
         )
+    }
 
-        // On the other hand, in such cases, it will be executed.
-        val sql2 = Sql {
+    @Test
+    fun `a computed string value is bound as a parameter`() {
+        val sql = Sql {
             +"a ${"hoge".removePrefix("h").removePrefix("o")}"
         }
-        assertThat(sql2).isEqualTo(
+        assertThat(sql).isEqualTo(
             Sql(
                 "a :p0",
                 listOf(NamedSqlParameter("p0", "ge")),
@@ -575,23 +577,25 @@ class StringInterpolationTest {
     }
 
     @Test
-    fun `a null constant is bound as null and a computed null string as text`() {
-        // In such cases, string interpolation will not be executed.
-        val sql1 = Sql {
+    fun `a null constant is bound as a null parameter`() {
+        val sql = Sql {
             +"a ${null}"
         }
-        assertThat(sql1).isEqualTo(
+        assertThat(sql).isEqualTo(
             Sql(
                 "a :p0",
                 listOf(NamedSqlParameter("p0", null)),
             ),
         )
+    }
 
-        // On the other hand, in such cases, it will be executed.
-        val sql2 = Sql {
+    @Test
+    fun `a computed null string is bound as the string null`() {
+        // The expression evaluates to the string "null", not to a null reference.
+        val sql = Sql {
             +"a ${null.toStr()}"
         }
-        assertThat(sql2).isEqualTo(
+        assertThat(sql).isEqualTo(
             Sql(
                 "a :p0",
                 listOf(NamedSqlParameter("p0", "null")),

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/DefaultSqlBuilderTest.kt
@@ -139,11 +139,15 @@ class DefaultSqlBuilderTest {
     }
 
     @Test
-    fun `interpolate weaves placeholders between fragments and throws IllegalStateException on count mismatch`() {
+    fun `interpolate weaves placeholders between fragments`() {
         assertThat(DefaultSqlBuilder().interpolate(emptyList(), emptyList())).isEqualTo("")
         assertThat(DefaultSqlBuilder().interpolate(listOf("a"), emptyList())).isEqualTo("a")
         assertThat(DefaultSqlBuilder().interpolate(listOf("a"), listOf(1))).isEqualTo("a:p0")
         assertThat(DefaultSqlBuilder().interpolate(listOf("a", "b"), listOf(1))).isEqualTo("a:p0b")
+    }
+
+    @Test
+    fun `interpolate throws IllegalStateException when fragment and value counts mismatch`() {
         assertFailure {
             DefaultSqlBuilder().interpolate(listOf("a", "b"), emptyList())
         }.isInstanceOf(IllegalStateException::class)

--- a/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
+++ b/kuery-client-core/src/test/kotlin/dev/hsbrysk/kuery/core/internal/SqlIdsTest.kt
@@ -17,12 +17,28 @@ class SqlIdsTest {
     @Test
     fun `id resolves the fully qualified class and method name of the call site`() {
         assertThat(ClassA().sql1 {}).isEqualTo("com.example.core.ClassA.sql1")
+    }
+
+    @Test
+    fun `id resolves a suspend call site across dispatcher switches`() {
         runBlocking { assertThat(ClassA().sql2 {}).isEqualTo("com.example.core.ClassA.sql2") }
+    }
+
+    @Test
+    fun `id resolves a nested class call site with its enclosing class names`() {
         assertThat(ClassA.ClassB().sql3 {}).isEqualTo("com.example.core.ClassA.ClassB.sql3")
         assertThat(
             ClassA.ClassB.ClassC().sql4 {},
         ).isEqualTo("com.example.core.ClassA.ClassB.ClassC.sql4")
+    }
+
+    @Test
+    fun `id resolves the call site through a lambda passed to a higher-order function`() {
         assertThat(ClassA().sql5 {}).isEqualTo("com.example.core.ClassA.sql5")
+    }
+
+    @Test
+    fun `id resolves the call site through a class-compiled lambda`() {
         assertThat(ClassA().sql6 {}).isEqualTo("com.example.core.ClassA.sql6")
     }
 
@@ -37,8 +53,12 @@ class SqlIdsTest {
     }
 
     @Test
-    fun `removeSuffixes strips a matching suffix and leaves the string unchanged otherwise`() {
+    fun `removeSuffixes strips a matching suffix`() {
         assertThat("a.b.c".removeSuffixes(listOf(".b", ".c"))).isEqualTo("a.b")
+    }
+
+    @Test
+    fun `removeSuffixes leaves the string unchanged when no suffix matches`() {
         assertThat("a.b.c".removeSuffixes(listOf(".a", ".d"))).isEqualTo("a.b.c")
     }
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlScalarFetchTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mysql/MySqlScalarFetchTest.kt
@@ -39,16 +39,19 @@ class MySqlScalarFetchTest {
     }
 
     @Test
-    fun `COUNT maps to Long and narrows to Int`() {
-        val asLong: Long = kueryClient
+    fun `COUNT maps to Long`() {
+        val count: Long = kueryClient
             .sql { +"SELECT COUNT(*) FROM scalar_users" }
             .single()
-        assertThat(asLong).isEqualTo(2L)
+        assertThat(count).isEqualTo(2L)
+    }
 
-        val asInt: Int = kueryClient
+    @Test
+    fun `COUNT narrows to Int`() {
+        val count: Int = kueryClient
             .sql { +"SELECT COUNT(*) FROM scalar_users" }
             .single()
-        assertThat(asInt).isEqualTo(2)
+        assertThat(count).isEqualTo(2)
     }
 
     companion object {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlScalarFetchTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mysql/MySqlScalarFetchTest.kt
@@ -38,7 +38,10 @@ class MySqlScalarFetchTest {
                 .sql { +"SELECT EXISTS(SELECT 1 FROM scalar_users WHERE user_id = 1)" }
                 .single<Boolean>()
         }.isInstanceOf(IllegalArgumentException::class)
+    }
 
+    @Test
+    fun `EXISTS maps to Long`() = runTest {
         val exists: Long = kueryClient
             .sql { +"SELECT EXISTS(SELECT 1 FROM scalar_users WHERE user_id = 1)" }
             .single()
@@ -46,16 +49,19 @@ class MySqlScalarFetchTest {
     }
 
     @Test
-    fun `COUNT maps to Long and narrows to Int`() = runTest {
-        val asLong: Long = kueryClient
+    fun `COUNT maps to Long`() = runTest {
+        val count: Long = kueryClient
             .sql { +"SELECT COUNT(*) FROM scalar_users" }
             .single()
-        assertThat(asLong).isEqualTo(2L)
+        assertThat(count).isEqualTo(2L)
+    }
 
-        val asInt: Int = kueryClient
+    @Test
+    fun `COUNT narrows to Int`() = runTest {
+        val count: Int = kueryClient
             .sql { +"SELECT COUNT(*) FROM scalar_users" }
             .single()
-        assertThat(asInt).isEqualTo(2)
+        assertThat(count).isEqualTo(2)
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Follow-up to the test cleanup series (#397/#398 naming + GWT, #399 package reorganization). Some test functions verified two or more independently specifiable behaviors in one body; this splits them so each backtick name states exactly one spec. No assertion is changed, added, or removed — only regrouped under new test functions.

- **DefaultSqlBuilderTest**: `interpolate` happy-path weaving vs `IllegalStateException` on fragment/value count mismatch
- **SqlIdsTest**: call-site id resolution split by shape — plain method, suspend across dispatcher switches, nested classes, lambda passed to a higher-order function, class-compiled lambda; `removeSuffixes` match vs no-match
- **SqlGenerationTest**: empty-collection binding split into empty list / empty set (was two full given-when-then cycles in one function)
- **StringInterpolationTest**: string literal inlined vs computed string bound; null constant bound as null vs computed `"null"` string bound as text
- **MySqlScalarFetchTest** (jdbc & r2dbc): `COUNT` maps to Long vs narrows to Int; r2dbc `EXISTS` does-not-map-to-Boolean vs the fetch-as-Long workaround

Intentionally **not** split: deliberate side-by-side contrasts whose point is the comparison (e.g. `addUnsafe is not trimmed`), escalating examples of a single rule (e.g. placeholder positions), and single-scenario tests whose branching expression is asserted per input (if/when branch conversion).

## Test plan

- [x] `./gradlew build` passes; 499 tests, 0 failures
- [x] Test-result XML confirms every split test runs under its new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)