### PR TITLE
Improve KDoc coverage for public APIs

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DelicateKueryClientApi.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/DelicateKueryClientApi.kt
@@ -1,5 +1,13 @@
 package dev.hsbrysk.kuery.core
 
+/**
+ * Marks declarations that bypass the safety mechanisms of Kuery Client (e.g.
+ * [SqlBuilder.addUnsafe], which skips the compiler plugin's automatic parameter binding) and can
+ * introduce SQL injection when misused.
+ *
+ * Such APIs are still needed for dynamic SQL that the compiler plugin cannot handle, but make
+ * sure you fully read and understand the documentation of the declaration before opting in.
+ */
 @MustBeDocumented
 @Retention(value = AnnotationRetention.BINARY)
 @RequiresOptIn(

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
@@ -3,12 +3,33 @@ package dev.hsbrysk.kuery.core
 import dev.hsbrysk.kuery.core.KueryBlockingClient.FetchSpec
 import kotlin.reflect.KClass
 
+/**
+ * A blocking SQL client.
+ *
+ * SQL is written with plain Kotlin string interpolation inside the [sql] block; the Kuery Client
+ * compiler plugin rewrites every interpolated value into a named bind parameter, so values are
+ * never concatenated into the SQL text.
+ *
+ * ```kotlin
+ * val user: User = client.sql { +"SELECT * FROM users WHERE user_id = $userId" }.single()
+ * ```
+ *
+ * Implementations are expected to be thread-safe; a single instance can be shared across the
+ * whole application.
+ *
+ * For a coroutine-based (R2DBC) counterpart, see [KueryClient].
+ */
 public interface KueryBlockingClient {
     /**
-     * Returns a [FetchSpec] to obtain the execution results based on the received [SqlBuilder].
+     * Builds SQL using the received [SqlBuilder] block and returns a [FetchSpec] to obtain the
+     * execution results.
      *
-     * @param sqlId An ID that uniquely identifies the query. It is used for purposes such as metrics.
-     * @param block [SqlBuilder] for constructing SQL.
+     * Note that the statement is not executed until one of the terminal operations on
+     * [FetchSpec] is invoked.
+     *
+     * @param sqlId an ID that uniquely identifies the query, used for purposes such as metrics
+     * @param block [SqlBuilder] block that constructs the SQL
+     * @return a [FetchSpec] for retrieving the execution results
      */
     public fun sql(
         sqlId: String,
@@ -16,56 +37,92 @@ public interface KueryBlockingClient {
     ): FetchSpec
 
     /**
-     * Returns a [FetchSpec] to obtain the execution results based on the received [SqlBuilder].
+     * Builds SQL using the received [SqlBuilder] block and returns a [FetchSpec] to obtain the
+     * execution results.
      *
-     * @param block [SqlBuilder] for constructing SQL.
+     * Note that the statement is not executed until one of the terminal operations on
+     * [FetchSpec] is invoked.
+     *
+     * The sqlId is generated automatically from the call site when auto sqlId generation is
+     * enabled; otherwise `"NONE"` is used.
+     *
+     * @param block [SqlBuilder] block that constructs the SQL
+     * @return a [FetchSpec] for retrieving the execution results
      */
     public fun sql(block: SqlBuilder.() -> Unit): FetchSpec
 
+    /**
+     * Specifies how to execute the built SQL and retrieve the results.
+     *
+     * Each terminal operation ([singleMap], [single], [list], [sequence], [rowsUpdated],
+     * [generatedValues], ...) executes the statement when invoked.
+     *
+     * Rows are mapped to the specified type as follows: simple scalar types (numbers, strings,
+     * date/time types, ...) are read from the first column of the row, while other types
+     * (e.g. data classes) are mapped by matching column names to constructor parameters.
+     */
     @Suppress("TooManyFunctions")
     public interface FetchSpec {
         /**
-         * Set the fetch size to use when executing this query.
+         * Sets the fetch size (the number of rows fetched from the database at a time) to use
+         * when executing this query.
+         *
+         * @return a new [FetchSpec] with the given fetch size applied
          */
         public fun fetchSize(fetchSize: Int): FetchSpec
 
         /**
-         * Set the maximum number of rows to return from this query.
+         * Sets the maximum number of rows to return from this query.
+         *
+         * @return a new [FetchSpec] with the given limit applied
          */
         public fun maxRows(maxRows: Int): FetchSpec
 
         /**
-         * Set the query timeout (in seconds) for this query.
+         * Sets the query timeout (in seconds) for this query.
+         *
+         * @return a new [FetchSpec] with the given timeout applied
          */
         public fun queryTimeoutSeconds(queryTimeoutSeconds: Int): FetchSpec
 
         /**
-         * Receives the results as a map.
+         * Executes the query and returns exactly one row as a map keyed by column name.
+         *
+         * Fails with an exception if the query returns no rows or more than one row.
          */
         public fun singleMap(): Map<String, Any?>
 
         /**
-         * Receives the results as a map.
+         * Executes the query and returns at most one row as a map keyed by column name, or
+         * `null` if the query returns no rows.
+         *
+         * Fails with an exception if the query returns more than one row.
          */
         public fun singleMapOrNull(): Map<String, Any?>?
 
         /**
-         * Receives the results converted to the specified type.
+         * Executes the query and returns exactly one row converted to [returnType].
+         *
+         * Fails with an exception if the query returns no rows, more than one row, or a single
+         * scalar value that is SQL NULL.
          */
         public fun <T : Any> single(returnType: KClass<T>): T
 
         /**
-         * Receives the results converted to the specified type.
+         * Executes the query and returns at most one row converted to [returnType], or `null`
+         * if the query returns no rows.
+         *
+         * Fails with an exception if the query returns more than one row.
          */
         public fun <T : Any> singleOrNull(returnType: KClass<T>): T?
 
         /**
-         * Receives the results of multiple rows as a map.
+         * Executes the query and returns all rows as a list of maps keyed by column name.
          */
         public fun listMap(): List<Map<String, Any?>>
 
         /**
-         * Receives the results of multiple rows converted to the specified type.
+         * Executes the query and returns all rows converted to [returnType].
          *
          * When fetching a simple scalar type from a single-column query, SQL NULL is kept as a null
          * element even though this cannot be expressed in the `List<T>` type.
@@ -73,20 +130,26 @@ public interface KueryBlockingClient {
         public fun <T : Any> list(returnType: KClass<T>): List<T>
 
         /**
-         * Receives the results of multiple rows as a sequence of maps.
-         * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active transaction.
-         * It is closed automatically when fully iterated or when fetching the next element throws; exceptions
-         * thrown by your own processing code do not close it. Unless you fully iterate the sequence, close it
-         * explicitly (e.g., with [use]). It can be iterated only once. See [CloseableSequence].
+         * Executes the query and returns each row as a map keyed by column name, as a sequence
+         * that streams rows without accumulating them all in memory.
+         *
+         * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active
+         * transaction. It is closed automatically when fully iterated or when fetching the next
+         * element throws; exceptions thrown by your own processing code do not close it. Unless
+         * you fully iterate the sequence, close it explicitly (e.g., with [use]). It can be
+         * iterated only once. See [CloseableSequence].
          */
         public fun sequenceMap(): CloseableSequence<Map<String, Any?>>
 
         /**
-         * Receives the results of multiple rows converted to the specified type as a sequence.
-         * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active transaction.
-         * It is closed automatically when fully iterated or when fetching the next element throws; exceptions
-         * thrown by your own processing code do not close it. Unless you fully iterate the sequence, close it
-         * explicitly (e.g., with [use]). It can be iterated only once. See [CloseableSequence].
+         * Executes the query and returns each row converted to [returnType], as a sequence that
+         * streams rows without accumulating them all in memory.
+         *
+         * The returned sequence is backed by an open JDBC ResultSet; iterate it within an active
+         * transaction. It is closed automatically when fully iterated or when fetching the next
+         * element throws; exceptions thrown by your own processing code do not close it. Unless
+         * you fully iterate the sequence, close it explicitly (e.g., with [use]). It can be
+         * iterated only once. See [CloseableSequence].
          *
          * When fetching a simple scalar type from a single-column query, SQL NULL is kept as a null
          * element even though this cannot be expressed in the `CloseableSequence<T>` type.
@@ -94,34 +157,48 @@ public interface KueryBlockingClient {
         public fun <T : Any> sequence(returnType: KClass<T>): CloseableSequence<T>
 
         /**
-         * Contract for fetching the number of affected rows
+         * Executes the statement (typically `INSERT`, `UPDATE`, or `DELETE`) and returns the
+         * number of affected rows.
          */
         public fun rowsUpdated(): Long
 
         /**
-         * Receives the values generated on the database side.
-         * For example, an auto increment value.
+         * Executes the statement and returns the values generated on the database side, such as
+         * an auto-increment ID, as a map keyed by column name.
+         *
+         * @param columns the names of the generated columns to return; when empty, the
+         * driver's default set of generated values is returned
          */
         public fun generatedValues(vararg columns: String): Map<String, Any>
     }
 }
 
 /**
- * Receives the results converted to the specified type.
+ * Executes the query and returns exactly one row converted to [T].
+ *
+ * A reified shortcut for [FetchSpec.single].
  */
 public inline fun <reified T : Any> FetchSpec.single(): T = single(T::class)
 
 /**
- * Receives the results converted to the specified type.
+ * Executes the query and returns at most one row converted to [T], or `null` if the query
+ * returns no rows.
+ *
+ * A reified shortcut for [FetchSpec.singleOrNull].
  */
 public inline fun <reified T : Any> FetchSpec.singleOrNull(): T? = singleOrNull(T::class)
 
 /**
- * Receives the results of multiple rows converted to the specified type.
+ * Executes the query and returns all rows converted to [T].
+ *
+ * A reified shortcut for [FetchSpec.list].
  */
 public inline fun <reified T : Any> FetchSpec.list(): List<T> = list(T::class)
 
 /**
- * Receives the results of multiple rows converted to the specified type as a sequence.
+ * Executes the query and returns each row converted to [T], as a sequence that streams rows
+ * without accumulating them all in memory.
+ *
+ * A reified shortcut for [FetchSpec.sequence]; see it for the resource-handling caveats.
  */
 public inline fun <reified T : Any> FetchSpec.sequence(): CloseableSequence<T> = sequence(T::class)

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
@@ -4,12 +4,33 @@ import dev.hsbrysk.kuery.core.KueryClient.FetchSpec
 import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
+/**
+ * A coroutine-based SQL client.
+ *
+ * SQL is written with plain Kotlin string interpolation inside the [sql] block; the Kuery Client
+ * compiler plugin rewrites every interpolated value into a named bind parameter, so values are
+ * never concatenated into the SQL text.
+ *
+ * ```kotlin
+ * val user: User = client.sql { +"SELECT * FROM users WHERE user_id = $userId" }.single()
+ * ```
+ *
+ * Implementations are expected to be thread-safe; a single instance can be shared across the
+ * whole application.
+ *
+ * For a blocking (JDBC) counterpart, see [KueryBlockingClient].
+ */
 public interface KueryClient {
     /**
-     * Returns a [FetchSpec] to obtain the execution results based on the received [SqlBuilder].
+     * Builds SQL using the received [SqlBuilder] block and returns a [FetchSpec] to obtain the
+     * execution results.
      *
-     * @param sqlId An ID that uniquely identifies the query. It is used for purposes such as metrics.
-     * @param block [SqlBuilder] for constructing SQL.
+     * Note that the statement is not executed until one of the terminal operations on
+     * [FetchSpec] is invoked.
+     *
+     * @param sqlId an ID that uniquely identifies the query, used for purposes such as metrics
+     * @param block [SqlBuilder] block that constructs the SQL
+     * @return a [FetchSpec] for retrieving the execution results
      */
     public fun sql(
         sqlId: String,
@@ -17,46 +38,78 @@ public interface KueryClient {
     ): FetchSpec
 
     /**
-     * Returns a [FetchSpec] to obtain the execution results based on the received [SqlBuilder].
+     * Builds SQL using the received [SqlBuilder] block and returns a [FetchSpec] to obtain the
+     * execution results.
      *
-     * @param block [SqlBuilder] for constructing SQL.
+     * Note that the statement is not executed until one of the terminal operations on
+     * [FetchSpec] is invoked.
+     *
+     * The sqlId is generated automatically from the call site when auto sqlId generation is
+     * enabled; otherwise `"NONE"` is used.
+     *
+     * @param block [SqlBuilder] block that constructs the SQL
+     * @return a [FetchSpec] for retrieving the execution results
      */
     public fun sql(block: SqlBuilder.() -> Unit): FetchSpec
 
+    /**
+     * Specifies how to execute the built SQL and retrieve the results.
+     *
+     * Each terminal operation ([singleMap], [single], [list], [flow], [rowsUpdated],
+     * [generatedValues], ...) executes the statement when invoked.
+     *
+     * Rows are mapped to the specified type as follows: simple scalar types (numbers, strings,
+     * date/time types, ...) are read from the first column of the row, while other types
+     * (e.g. data classes) are mapped by matching column names to constructor parameters.
+     */
     @Suppress("TooManyFunctions")
     public interface FetchSpec {
         /**
-         * Set the fetch size to use when executing this query.
+         * Sets the fetch size (the number of rows fetched from the database at a time) to use
+         * when executing this query.
+         *
+         * @return a new [FetchSpec] with the given fetch size applied
          */
         public fun fetchSize(fetchSize: Int): FetchSpec
 
         /**
-         * Receives the results as a map.
+         * Executes the query and returns exactly one row as a map keyed by column name.
+         *
+         * Fails with an exception if the query returns no rows or more than one row.
          */
         public suspend fun singleMap(): Map<String, Any?>
 
         /**
-         * Receives the results as a map.
+         * Executes the query and returns at most one row as a map keyed by column name, or
+         * `null` if the query returns no rows.
+         *
+         * Fails with an exception if the query returns more than one row.
          */
         public suspend fun singleMapOrNull(): Map<String, Any?>?
 
         /**
-         * Receives the results converted to the specified type.
+         * Executes the query and returns exactly one row converted to [returnType].
+         *
+         * Fails with an exception if the query returns no rows, more than one row, or a single
+         * scalar value that is SQL NULL.
          */
         public suspend fun <T : Any> single(returnType: KClass<T>): T
 
         /**
-         * Receives the results converted to the specified type.
+         * Executes the query and returns at most one row converted to [returnType], or `null`
+         * if the query returns no rows.
+         *
+         * Fails with an exception if the query returns more than one row.
          */
         public suspend fun <T : Any> singleOrNull(returnType: KClass<T>): T?
 
         /**
-         * Receives the results of multiple rows as a map.
+         * Executes the query and returns all rows as a list of maps keyed by column name.
          */
         public suspend fun listMap(): List<Map<String, Any?>>
 
         /**
-         * Receives the results of multiple rows converted to the specified type.
+         * Executes the query and returns all rows converted to [returnType].
          *
          * When fetching a simple scalar type from a single-column query, SQL NULL is kept as a null
          * element even though this cannot be expressed in the `List<T>` type.
@@ -64,12 +117,18 @@ public interface KueryClient {
         public suspend fun <T : Any> list(returnType: KClass<T>): List<T>
 
         /**
-         * Receives the results of multiple rows as a map.
+         * Executes the query and emits each row as a map keyed by column name, without
+         * accumulating all rows in memory.
+         *
+         * The query is executed when the returned [Flow] is collected.
          */
         public fun flowMap(): Flow<Map<String, Any?>>
 
         /**
-         * Receives the results of multiple rows converted to the specified type.
+         * Executes the query and emits each row converted to [returnType], without accumulating
+         * all rows in memory.
+         *
+         * The query is executed when the returned [Flow] is collected.
          *
          * When fetching a simple scalar type from a single-column query, SQL NULL is kept as a null
          * element even though this cannot be expressed in the `Flow<T>` type.
@@ -77,34 +136,47 @@ public interface KueryClient {
         public fun <T : Any> flow(returnType: KClass<T>): Flow<T>
 
         /**
-         * Contract for fetching the number of affected rows
+         * Executes the statement (typically `INSERT`, `UPDATE`, or `DELETE`) and returns the
+         * number of affected rows.
          */
         public suspend fun rowsUpdated(): Long
 
         /**
-         * Receives the values generated on the database side.
-         * For example, an auto increment value.
+         * Executes the statement and returns the values generated on the database side, such as
+         * an auto-increment ID, as a map keyed by column name.
+         *
+         * @param columns the names of the generated columns to return; when empty, the
+         * driver's default set of generated values is returned
          */
         public suspend fun generatedValues(vararg columns: String): Map<String, Any>
     }
 }
 
 /**
- * Receives the results converted to the specified type.
+ * Executes the query and returns exactly one row converted to [T].
+ *
+ * A reified shortcut for [FetchSpec.single].
  */
 public suspend inline fun <reified T : Any> FetchSpec.single(): T = single(T::class)
 
 /**
- * Receives the results converted to the specified type.
+ * Executes the query and returns at most one row converted to [T], or `null` if the query
+ * returns no rows.
+ *
+ * A reified shortcut for [FetchSpec.singleOrNull].
  */
 public suspend inline fun <reified T : Any> FetchSpec.singleOrNull(): T? = singleOrNull(T::class)
 
 /**
- * Receives the results of multiple rows converted to the specified type.
+ * Executes the query and returns all rows converted to [T].
+ *
+ * A reified shortcut for [FetchSpec.list].
  */
 public suspend inline fun <reified T : Any> FetchSpec.list(): List<T> = list(T::class)
 
 /**
- * Receives the results of multiple rows converted to the specified type.
+ * Executes the query and emits each row converted to [T], without accumulating all rows in memory.
+ *
+ * A reified shortcut for [FetchSpec.flow].
  */
 public inline fun <reified T : Any> FetchSpec.flow(): Flow<T> = flow(T::class)

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClientInternalApi.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClientInternalApi.kt
@@ -1,5 +1,13 @@
 package dev.hsbrysk.kuery.core
 
+/**
+ * Marks declarations that are internal to Kuery Client even though they are `public` for
+ * technical reasons (e.g. they are referenced by other Kuery Client modules or by code the
+ * compiler plugin generates).
+ *
+ * They may be changed or removed without notice, are excluded from the ABI compatibility
+ * checks, and must not be used outside of Kuery Client itself.
+ */
 @MustBeDocumented
 @Retention(value = AnnotationRetention.BINARY)
 @RequiresOptIn(

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/NamedSqlParameter.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/NamedSqlParameter.kt
@@ -2,14 +2,18 @@ package dev.hsbrysk.kuery.core
 
 import dev.hsbrysk.kuery.core.internal.DefaultNamedSqlParameter
 
+/**
+ * A named SQL bind parameter: the pair of a placeholder name in [Sql.body] and the value bound
+ * to it.
+ */
 public interface NamedSqlParameter {
     /**
-     * parameter name
+     * The parameter name, without the leading colon (e.g. `p0` for the placeholder `:p0`).
      */
     public val name: String
 
     /**
-     * value
+     * The value bound to the parameter. `null` is bound as SQL NULL.
      */
     public val value: Any?
 
@@ -17,7 +21,7 @@ public interface NamedSqlParameter {
 }
 
 /**
- * Create [NamedSqlParameter]
+ * Creates a [NamedSqlParameter] with the given [name] and [value].
  */
 public fun NamedSqlParameter(
     name: String,

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/Sql.kt
@@ -2,14 +2,19 @@ package dev.hsbrysk.kuery.core
 
 import dev.hsbrysk.kuery.core.internal.DefaultSql
 
+/**
+ * An immutable SQL statement built by [SqlBuilder]: the SQL text with named placeholders and
+ * the parameters bound to them.
+ */
 public interface Sql {
     /**
-     * SQL body
+     * The SQL text, containing named placeholders (e.g. `:p0`) instead of the interpolated
+     * values.
      */
     public val body: String
 
     /**
-     * SQL parameters
+     * The parameters bound to the placeholders in [body].
      */
     public val parameters: List<NamedSqlParameter>
 
@@ -17,7 +22,7 @@ public interface Sql {
 }
 
 /**
- * Create [Sql]
+ * Creates a [Sql] from the given [body] and [parameters].
  */
 public fun Sql(
     body: String,
@@ -25,7 +30,11 @@ public fun Sql(
 ): Sql = DefaultSql(body, parameters.toList())
 
 /**
- * Create [Sql] using [SqlBuilder]
+ * Creates a [Sql] by running the given [SqlBuilder] block.
+ *
+ * ```kotlin
+ * val sql = Sql { +"SELECT * FROM users WHERE user_id = $userId" }
+ * ```
  */
 public fun Sql(block: SqlBuilder.() -> Unit): Sql {
     val builder = DefaultSqlBuilder()

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
@@ -5,6 +5,21 @@ import org.intellij.lang.annotations.Language
 /**
  * DSL scope for building SQL.
  *
+ * Add SQL fragments with [add] or [String.unaryPlus]; the fragments are joined with line breaks
+ * to form the final statement. Thanks to the Kuery Client compiler plugin, any value interpolated
+ * into those fragments (`$value`) is bound as a named parameter instead of being embedded in the
+ * SQL text, which prevents SQL injection.
+ *
+ * ```kotlin
+ * client.sql {
+ *     +"SELECT * FROM users"
+ *     +"WHERE user_id = $userId"
+ * }
+ * ```
+ *
+ * For dynamic SQL that cannot go through the compiler plugin (e.g. helper extension functions
+ * that assemble fragments programmatically), use [addUnsafe] together with [bind].
+ *
  * This interface is sealed because the compiler plugin assumes the receiver is the library's
  * internal implementation; a user implementation (e.g. a test fake) would fail with
  * [ClassCastException] at runtime.
@@ -12,35 +27,38 @@ import org.intellij.lang.annotations.Language
 @SqlBuilderMarker
 public sealed interface SqlBuilder {
     /**
-     * Specify the sql you want to execute. Appended to the internally held [StringBuilder].
-     * Due to the Kotlin compiler plugin, the string interpolation within the string template passed to
-     * this method will be expanded using placeholders.
+     * Adds a SQL fragment to the statement being built.
      *
-     * e.g.
-     * ```
+     * Due to the Kotlin compiler plugin, every value interpolated into [sql] is expanded into a
+     * named placeholder and bound as a parameter.
+     *
+     * ```kotlin
      * add("SELECT * FROM users WHERE user_id = $userId")
      * ```
      */
     public fun add(@Language("sql") sql: String)
 
     /**
-     * Specify the sql you want to execute. Appended to the internally held [StringBuilder].
-     * Due to the Kotlin compiler plugin, the string interpolation within the string template passed to
-     * this method will be expanded using placeholders.
+     * Adds a SQL fragment to the statement being built. Operator shorthand for [add].
      *
-     * e.g.
-     * ```
+     * Due to the Kotlin compiler plugin, every value interpolated into the receiver string is
+     * expanded into a named placeholder and bound as a parameter.
+     *
+     * ```kotlin
      * +"SELECT * FROM users WHERE user_id = $userId"
      * ```
      */
     public operator fun String.unaryPlus()
 
     /**
-     * Specify the sql you want to execute. Appended to the internally held [StringBuilder].
-     * Please note that string interpolation using placeholders will not be performed in this method.
+     * Adds a SQL fragment to the statement being built, WITHOUT rewriting string interpolation
+     * into bind parameters.
      *
-     * If you want to insert dynamic values using addUnsafe, please use bind.
-     * ```
+     * Any value interpolated into [sql] is embedded in the SQL text as-is, so passing
+     * user-controlled input directly can lead to SQL injection. To include dynamic values
+     * safely, bind them with [bind]:
+     *
+     * ```kotlin
      * addUnsafe("user_id = ${bind(userId)}")
      * ```
      */
@@ -48,8 +66,11 @@ public sealed interface SqlBuilder {
     public fun addUnsafe(@Language("sql") sql: String)
 
     /**
-     * Bind variables to SQL
-     * It is intended to be used together with addUnsafe.
+     * Binds [parameter] as a named parameter and returns the placeholder string (e.g. `:p0`)
+     * to embed in the SQL fragment.
+     *
+     * It is intended to be used together with [addUnsafe]; fragments passed to [add] /
+     * [String.unaryPlus] bind interpolated values automatically.
      */
     @DelicateKueryClientApi
     public fun bind(parameter: Any?): String

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilderMarker.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilderMarker.kt
@@ -1,4 +1,10 @@
 package dev.hsbrysk.kuery.core
 
+/**
+ * [DslMarker] for the [SqlBuilder] DSL.
+ *
+ * It prevents accidentally calling methods of an outer [SqlBuilder] receiver from within a
+ * nested builder block.
+ */
 @DslMarker
 public annotation class SqlBuilderMarker

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchContext.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchContext.kt
@@ -6,7 +6,12 @@ import dev.hsbrysk.kuery.core.Sql
 import io.micrometer.observation.Observation
 
 /**
- * [Observation.Context] for [KueryClient] and [KueryBlockingClient]
+ * [Observation.Context] for the fetch observations recorded by [KueryClient] and
+ * [KueryBlockingClient].
+ *
+ * @property sqlId the ID that identifies the executed query
+ * @property sql the executed SQL (with named placeholders; bound values are held separately
+ * in [Sql.parameters])
  */
 public class KueryClientFetchContext(
     public val sqlId: String,

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientFetchObservationConvention.kt
@@ -7,7 +7,11 @@ import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationConvention
 
 /**
- * [ObservationConvention] for [KueryClient] and [KueryBlockingClient]
+ * [ObservationConvention] for the fetch observations recorded by [KueryClient] and
+ * [KueryBlockingClient].
+ *
+ * Implement this and pass it to the client builder's `observationConvention(...)` to customize
+ * the observation name (`kuery.client.fetches` by default) or the recorded tags.
  */
 public interface KueryClientFetchObservationConvention : ObservationConvention<KueryClientFetchContext> {
     override fun getName(): String = "kuery.client.fetches"
@@ -15,6 +19,10 @@ public interface KueryClientFetchObservationConvention : ObservationConvention<K
     override fun supportsContext(context: Observation.Context): Boolean = context is KueryClientFetchContext
 
     public companion object {
+        /**
+         * Returns the default convention, which tags each observation with `sql.id`
+         * (low cardinality) and `sql` (high cardinality).
+         */
         public fun default(): KueryClientFetchObservationConvention = DefaultKueryClientFetchObservationConvention()
     }
 }

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentation.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/observation/KueryClientObservationDocumentation.kt
@@ -9,9 +9,14 @@ import io.micrometer.observation.ObservationConvention
 import io.micrometer.observation.docs.ObservationDocumentation
 
 /**
- * [ObservationDocumentation] for [KueryClient] and [KueryBlockingClient]
+ * [ObservationDocumentation] for the observations recorded by [KueryClient] and
+ * [KueryBlockingClient].
  */
 public enum class KueryClientObservationDocumentation : ObservationDocumentation {
+    /**
+     * The observation recorded for each fetch (i.e. each terminal operation of a `FetchSpec`),
+     * named `kuery.client.fetches` by default.
+     */
     FETCH {
         override fun getDefaultConvention(): Class<out ObservationConvention<out Observation.Context>> =
             DefaultKueryClientFetchObservationConvention::class.java

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClient.kt
@@ -2,14 +2,29 @@ package dev.hsbrysk.kuery.spring.jdbc
 
 import dev.hsbrysk.kuery.spring.jdbc.internal.DefaultSpringJdbcKueryClientBuilder
 
+/**
+ * Entry point for creating a [dev.hsbrysk.kuery.core.KueryBlockingClient] backed by
+ * Spring Data JDBC.
+ *
+ * ```kotlin
+ * val client = SpringJdbcKueryClient.builder()
+ *     .dataSource(dataSource)
+ *     .build()
+ * ```
+ */
 public object SpringJdbcKueryClient {
     /**
-     * Retrieve the running sqlId from thread local.
+     * Retrieves the sqlId of the query currently executing on this thread.
+     *
+     * This is useful for referring to the sqlId in downstream instrumentation, such as a
+     * datasource-proxy listener.
+     *
+     * @return the sqlId, or `null` if no query is executing on this thread
      */
     public fun sqlId(): String? = sqlIdThreadLocal.get()
 
     /**
-     * Create [SpringJdbcKueryClientBuilder]
+     * Creates a [SpringJdbcKueryClientBuilder].
      */
     public fun builder(): SpringJdbcKueryClientBuilder = DefaultSpringJdbcKueryClientBuilder()
 }

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder.kt
@@ -5,31 +5,41 @@ import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import io.micrometer.observation.ObservationRegistry
 import javax.sql.DataSource
 
+/**
+ * Builder for a [KueryBlockingClient] backed by Spring Data JDBC.
+ *
+ * Obtain an instance via [SpringJdbcKueryClient.builder]. [dataSource] is required; everything
+ * else is optional.
+ */
 public interface SpringJdbcKueryClientBuilder {
     /**
-     * Set [DataSource]
+     * Sets the [DataSource] to execute SQL against. Required.
      */
     public fun dataSource(dataSource: DataSource): SpringJdbcKueryClientBuilder
 
     /**
-     * Set converters
+     * Sets custom converters used for both binding parameters and mapping rows, typically
+     * Spring `Converter`s annotated with `@WritingConverter` / `@ReadingConverter`.
      */
     public fun converters(converters: List<Any>): SpringJdbcKueryClientBuilder
 
     /**
-     * Set [ObservationRegistry]
+     * Sets the [ObservationRegistry], enabling Micrometer Observation instrumentation
+     * (metrics/tracing) for each fetch.
      */
     public fun observationRegistry(observationRegistry: ObservationRegistry): SpringJdbcKueryClientBuilder
 
     /**
-     * Set [KueryClientFetchObservationConvention]
+     * Sets the [KueryClientFetchObservationConvention] used to customize the observation name
+     * and tags. When not set, [KueryClientFetchObservationConvention.default] is used.
      */
     public fun observationConvention(
         observationConvention: KueryClientFetchObservationConvention,
     ): SpringJdbcKueryClientBuilder
 
     /**
-     * It is a flag to automatically generate a sqlId for metrics.
+     * Sets whether to automatically generate a sqlId for metrics when `sql { ... }` is called
+     * without an explicit sqlId.
      * When [observationRegistry] is specified, the default is true; otherwise, the default is false.
      *
      * The sqlId is derived from the call site of the first invocation and cached per SQL block.
@@ -40,7 +50,9 @@ public interface SpringJdbcKueryClientBuilder {
     public fun enableAutoSqlIdGeneration(enableAutoSqlIdGeneration: Boolean): SpringJdbcKueryClientBuilder
 
     /**
-     * build [KueryBlockingClient]
+     * Builds the [KueryBlockingClient].
+     *
+     * @throws IllegalArgumentException if [dataSource] has not been set
      */
     public fun build(): KueryBlockingClient
 }

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClient.kt
@@ -3,16 +3,35 @@ package dev.hsbrysk.kuery.spring.r2dbc
 import dev.hsbrysk.kuery.spring.r2dbc.internal.DefaultSpringR2dbcKueryClientBuilder
 import reactor.util.context.ContextView
 
+/**
+ * Entry point for creating a [dev.hsbrysk.kuery.core.KueryClient] backed by Spring Data R2DBC.
+ *
+ * ```kotlin
+ * val client = SpringR2dbcKueryClient.builder()
+ *     .connectionFactory(connectionFactory)
+ *     .build()
+ * ```
+ */
 public object SpringR2dbcKueryClient {
+    /**
+     * The Reactor context key under which the sqlId of the currently executing query is stored.
+     *
+     * Usually you don't need this key directly; use [sqlId] instead.
+     */
     public val SQL_ID_REACTOR_CONTEXT_KEY: String = "${SpringR2dbcKueryClient::class.java.name}:sqlId"
 
     /**
-     * Retrieve the current sqlId from reactor context.
+     * Retrieves the sqlId of the currently executing query from the given Reactor context.
+     *
+     * This is useful for referring to the sqlId in downstream instrumentation, such as an
+     * r2dbc-proxy listener.
+     *
+     * @return the sqlId, or `null` if no query is executing in this context
      */
     public fun sqlId(context: ContextView): String? = context.getOrDefault(SQL_ID_REACTOR_CONTEXT_KEY, null)
 
     /**
-     * Create [SpringR2dbcKueryClientBuilder]
+     * Creates a [SpringR2dbcKueryClientBuilder].
      */
     public fun builder(): SpringR2dbcKueryClientBuilder = DefaultSpringR2dbcKueryClientBuilder()
 }

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder.kt
@@ -5,31 +5,41 @@ import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import io.micrometer.observation.ObservationRegistry
 import io.r2dbc.spi.ConnectionFactory
 
+/**
+ * Builder for a [KueryClient] backed by Spring Data R2DBC.
+ *
+ * Obtain an instance via [SpringR2dbcKueryClient.builder]. [connectionFactory] is required;
+ * everything else is optional.
+ */
 public interface SpringR2dbcKueryClientBuilder {
     /**
-     * Set [ConnectionFactory]
+     * Sets the [ConnectionFactory] to execute SQL against. Required.
      */
     public fun connectionFactory(connectionFactory: ConnectionFactory): SpringR2dbcKueryClientBuilder
 
     /**
-     * Set converters
+     * Sets custom converters used for both binding parameters and mapping rows, typically
+     * Spring `Converter`s annotated with `@WritingConverter` / `@ReadingConverter`.
      */
     public fun converters(converters: List<Any>): SpringR2dbcKueryClientBuilder
 
     /**
-     * Set [ObservationRegistry]
+     * Sets the [ObservationRegistry], enabling Micrometer Observation instrumentation
+     * (metrics/tracing) for each fetch.
      */
     public fun observationRegistry(observationRegistry: ObservationRegistry): SpringR2dbcKueryClientBuilder
 
     /**
-     * Set [KueryClientFetchObservationConvention]
+     * Sets the [KueryClientFetchObservationConvention] used to customize the observation name
+     * and tags. When not set, [KueryClientFetchObservationConvention.default] is used.
      */
     public fun observationConvention(
         observationConvention: KueryClientFetchObservationConvention,
     ): SpringR2dbcKueryClientBuilder
 
     /**
-     * It is a flag to automatically generate a sqlId for metrics.
+     * Sets whether to automatically generate a sqlId for metrics when `sql { ... }` is called
+     * without an explicit sqlId.
      * When [observationRegistry] is specified, the default is true; otherwise, the default is false.
      *
      * The sqlId is derived from the call site of the first invocation and cached per SQL block.
@@ -40,7 +50,9 @@ public interface SpringR2dbcKueryClientBuilder {
     public fun enableAutoSqlIdGeneration(enableAutoSqlIdGeneration: Boolean): SpringR2dbcKueryClientBuilder
 
     /**
-     * Build [KueryClient]
+     * Builds the [KueryClient].
+     *
+     * @throws IllegalArgumentException if [connectionFactory] has not been set
      */
     public fun build(): KueryClient
 }


### PR DESCRIPTION
Add missing KDoc and improve existing documentation across the public
API surface of kuery-client-core, kuery-client-spring-data-jdbc, and
kuery-client-spring-data-r2dbc:

- Document previously undocumented types: KueryClient/KueryBlockingClient
  interfaces, FetchSpec, Sql, NamedSqlParameter, SqlBuilderMarker,
  DelicateKueryClientApi, KueryClientInternalApi, the Spring entry-point
  objects, and the client builders.
- Clarify single/singleOrNull/singleMap/singleMapOrNull semantics
  (empty result vs. multiple rows) and generatedValues behavior.
- Document row-mapping behavior (scalar vs. data class) on FetchSpec and
  lazy execution of terminal operations.
- Rewrite awkward wording (e.g. rowsUpdated "Contract for fetching...")
  and stop referencing internal implementation details (StringBuilder)
  in SqlBuilder docs; document SQL-injection risk of addUnsafe and the
  placeholder returned by bind.
- Flesh out observation-related docs (context properties, default
  convention tags, FETCH observation).

Comment-only change: no code or ABI changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>