### PR TITLE
Document that value classes are not supported on the fetch side

### DIFF
--- a/docs/row-mapping.md
+++ b/docs/row-mapping.md
@@ -1,5 +1,5 @@
 ---
-description: "How query results are mapped to Kotlin types: single-column scalars, data classes via constructor mapping (snake_case to camelCase), enums, nullability, and raw maps."
+description: "How query results are mapped to Kotlin types: single-column scalars, data classes via constructor mapping (snake_case to camelCase), enums, nullability, value class limitations, and raw maps."
 ---
 
 # Row Mapping
@@ -86,6 +86,27 @@ registered converters. So a custom type as the return type (e.g. `single<StringW
 your `@ReadingConverter` — it goes down the constructor-mapping path and fails unless the column names happen to
 match. Receive custom types as properties of a data class instead.
 :::
+
+## Value classes
+
+Kotlin value classes are not supported on the fetch side, in either position:
+
+- As the return type itself (e.g. `single<UserName>()`): `DataClassRowMapper` cannot resolve the
+  parameter names of the value class's constructor and fails at runtime.
+- As a data class property: instantiation fails because the enclosing class's JVM constructor takes
+  the unboxed underlying type. Registering a `@ReadingConverter` for the value class does not help.
+
+```kotlin
+@JvmInline
+value class UserName(val value: String)
+
+data class User(
+    val userId: Int,
+    val username: UserName, // NG: fails at runtime
+)
+```
+
+Fetch the underlying type (or a regular data class) and wrap it yourself.
 
 ## Raw maps
 


### PR DESCRIPTION
## Summary

Adds a "Value classes" section to docs/row-mapping.md documenting a known fetch-side limitation, discovered during the unit-test improvement work and pinned by `ValueClassFetchTest` in both spring-data modules:

- A value class as the return type itself fails at runtime — `DataClassRowMapper` cannot resolve the parameter names of the value class's constructor.
- A value class as a data class property fails as well — the enclosing class's JVM constructor takes the unboxed underlying type, and a registered `@ReadingConverter` does not help.

The recommended workaround (fetch the underlying type and wrap it yourself) is stated explicitly.

Docs only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)