### PR TITLE
Document that sequence() executes the query eagerly

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -309,6 +309,9 @@ val users: CloseableSequence<User> = kueryClient
 ```
 
 ::: warning
+`sequence()` is not lazy: the statement executes eagerly when the sequence is created, before any element
+is consumed. Only the consumption of rows is deferred.
+
 The sequence is backed by an open JDBC ResultSet — iterate within an active transaction. It is single-pass.
 `CloseableSequence` implements `AutoCloseable`; if you stop iterating midway (e.g., with `take` or `first`),
 close it explicitly, typically via `use`.


### PR DESCRIPTION
## Summary

Adds a note to the `sequence()` warning in docs/basics.md: the statement executes eagerly when the sequence is created, before any element is consumed — only row consumption is deferred. Discovered during the unit-test improvement work and pinned by `SequenceExecutionTimingTest` (the connection is acquired and the statement executed by `sequenceMap()` itself).

Docs only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)