### PR TITLE
Add @Language annotation to the unaryPlus receiver for IDE language injection

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
@@ -48,7 +48,7 @@ public sealed interface SqlBuilder {
      * +"SELECT * FROM users WHERE user_id = $userId"
      * ```
      */
-    public operator fun String.unaryPlus()
+    public operator fun @receiver:Language("sql") String.unaryPlus()
 
     /**
      * Adds a SQL fragment to the statement being built, WITHOUT rewriting string interpolation


### PR DESCRIPTION
## Summary

IntelliJ's SQL language injection works for `add()` because its parameter is annotated with `@Language("sql")`, but not for the `+"..."` form: the SQL string there is the *extension receiver* of `String.unaryPlus()`, which had no annotation.

This PR annotates the receiver:

```kotlin
public operator fun @receiver:Language("sql") String.unaryPlus()
```

## Current IDE support status

IDE-side support for this annotation is still partial, tracked by JetBrains:

- [KTIJ-5643](https://youtrack.jetbrains.com/issue/KTIJ-5643) — `@Language` on extension receivers was ignored entirely. **Fixed in IntelliJ 2025.3**, but only for the explicit call form (`"...".unaryPlus()`).
- [KTIJ-37480](https://youtrack.jetbrains.com/issue/KTIJ-37480) — injection still does not work when the function is invoked via the unary operator syntax (`+"..."`). **Still open** as of IntelliJ 2026.1.

So this change doesn't light up `+"..."` injection today, but once KTIJ-37480 is fixed it will start working with no further library change. The annotation is CLASS-retention, so it is present in the published jar and benefits library consumers as well.

## Verification

- `compileKotlin` / `ktlintCheck` / `checkKotlinAbi` all green (annotations don't affect the ABI dump)
- `kuery-client-core` tests and the compiler plugin `functional-test` pass — the plugin resolves `unaryPlus` by symbol, so the receiver annotation doesn't affect the IR transformation

🤖 Generated with [Claude Code](https://claude.com/claude-code)