### PR TITLE
Mention llms.txt / llms-full.txt in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ More details are on the [document site](https://kuery-client.hsbrysk.dev/):
 - [Observation](https://kuery-client.hsbrysk.dev/observation) — Micrometer-based metrics, tracing, and logging
 - [Compatibility](https://kuery-client.hsbrysk.dev/compatibility) — supported Kotlin / Spring versions
 
+For AI assistants and LLM-based tools, the entire documentation is also available in
+the [llms.txt](https://llmstxt.org/) format: [llms.txt](https://kuery-client.hsbrysk.dev/llms.txt)
+(index) and [llms-full.txt](https://kuery-client.hsbrysk.dev/llms-full.txt) (full content in a single file).
+
 ## Examples
 
 Runnable example projects live in [examples/](examples):

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -135,3 +135,11 @@ This SQL builder is very simple. There are only two things you need to remember:
 - You can concatenate SQL strings using `+`(unaryPlus).
     - You can also directly express logic such as if statements in Kotlin.
 - You can bind parameters using string interpolation.
+
+## For LLMs
+
+The entire documentation is also available in the [llms.txt](https://llmstxt.org/) format,
+which is convenient for feeding into AI assistants and LLM-based tools:
+
+- [llms.txt](https://kuery-client.hsbrysk.dev/llms.txt) — an index of all documentation pages
+- [llms-full.txt](https://kuery-client.hsbrysk.dev/llms-full.txt) — the full documentation in a single file


### PR DESCRIPTION
## Summary

The documentation site generates `llms.txt` and `llms-full.txt` via `vitepress-plugin-llms`, but their existence was not mentioned anywhere in the README or the docs. This PR makes them discoverable:

- **README**: added a short note in the Documentation section pointing to https://kuery-client.hsbrysk.dev/llms.txt and https://kuery-client.hsbrysk.dev/llms-full.txt
- **docs/introduction.md**: added a "For LLMs" section describing both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)