### PR TITLE
Update stale sqlId KDoc on client builders to the compile-time spec

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/SpringJdbcKueryClientBuilder.kt
@@ -42,10 +42,11 @@ public interface SpringJdbcKueryClientBuilder {
      * without an explicit sqlId.
      * When [observationRegistry] is specified, the default is true; otherwise, the default is false.
      *
-     * The sqlId is derived from the call site of the first invocation and cached per SQL block.
-     * If the same block (e.g. one stored in a property) is shared across multiple call sites,
-     * all of them observe the sqlId of whichever call site ran first.
-     * Define blocks inline if each call site should get its own sqlId.
+     * The sqlId is generated at compile time by the compiler plugin from the fully qualified name
+     * of the call site's enclosing declaration (e.g. `com.example.UserRepository.selectByUserId`),
+     * so no runtime stack inspection is involved and a given call site always produces the same
+     * sqlId. Blocks passed via a variable and call sites not compiled with the compiler plugin
+     * resolve to the fixed sqlId `NONE`; specify the sqlId explicitly in such cases.
      */
     public fun enableAutoSqlIdGeneration(enableAutoSqlIdGeneration: Boolean): SpringJdbcKueryClientBuilder
 

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/SpringR2dbcKueryClientBuilder.kt
@@ -42,10 +42,11 @@ public interface SpringR2dbcKueryClientBuilder {
      * without an explicit sqlId.
      * When [observationRegistry] is specified, the default is true; otherwise, the default is false.
      *
-     * The sqlId is derived from the call site of the first invocation and cached per SQL block.
-     * If the same block (e.g. one stored in a property) is shared across multiple call sites,
-     * all of them observe the sqlId of whichever call site ran first.
-     * Define blocks inline if each call site should get its own sqlId.
+     * The sqlId is generated at compile time by the compiler plugin from the fully qualified name
+     * of the call site's enclosing declaration (e.g. `com.example.UserRepository.selectByUserId`),
+     * so no runtime stack inspection is involved and a given call site always produces the same
+     * sqlId. Blocks passed via a variable and call sites not compiled with the compiler plugin
+     * resolve to the fixed sqlId `NONE`; specify the sqlId explicitly in such cases.
      */
     public fun enableAutoSqlIdGeneration(enableAutoSqlIdGeneration: Boolean): SpringR2dbcKueryClientBuilder
 


### PR DESCRIPTION
## Summary

The KDoc on `enableAutoSqlIdGeneration` in both `SpringJdbcKueryClientBuilder` and `SpringR2dbcKueryClientBuilder` still described the old runtime behavior — sqlId derived from the first invocation's call site and cached per SQL block — which was removed when sqlId generation moved to the compiler plugin (#403).

This updates both KDocs to match the current spec already documented in `docs/observation.md`:

- The sqlId is generated at compile time from the FQN of the call site's enclosing declaration.
- No runtime stack inspection; a given call site always produces the same sqlId.
- Blocks passed via a variable and call sites not compiled with the compiler plugin resolve to the fixed sqlId `NONE`.

Documentation-only change; no behavior or ABI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)