### PR TITLE
Replace deprecated 'by plugins.creating' with plugins.create

### DIFF
--- a/kuery-client-gradle-plugin/build.gradle.kts
+++ b/kuery-client-gradle-plugin/build.gradle.kts
@@ -23,7 +23,7 @@ buildConfig {
 
 @Suppress("UnstableApiUsage")
 gradlePlugin {
-    val kueryClient by plugins.creating {
+    plugins.create("kueryClient") {
         id = "dev.hsbrysk.kuery-client"
         displayName = "Gradle plugin for the Kuery client compiler"
         description = """


### PR DESCRIPTION
## Summary

Running the build with `--warning-mode all` reports:

> The 'val name by creating { }' property delegate syntax has been deprecated. This is scheduled to be removed in Gradle 10. Use 'val element = create(name) { }' instead.

The plugin declaration in `kuery-client-gradle-plugin/build.gradle.kts` used this syntax, and the delegate variable was unused anyway, so this switches to a plain `plugins.create("kueryClient") { ... }` call.

## Notes

- Verified with `--warning-mode all` that this warning no longer appears; `:kuery-client-gradle-plugin:check` passes.
- The remaining `ReportingExtension.file(String)` deprecation warning comes from the detekt Gradle plugin itself (latest stable 1.23.8), not from our build scripts, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)