### PR TITLE
Build the VitePress docs on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,22 @@ jobs:
           ./gradlew check detektMain detektTest
           ./gradlew -p examples check detektMain detektTest
 
+  build-docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build with VitePress
+        run: npm run docs:build
+
   report-gradle-dependency-diff:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,9 +2,25 @@ import {execSync} from 'node:child_process'
 import {defineConfig} from 'vitepress'
 import llmstxt from 'vitepress-plugin-llms'
 
-// Latest release version, derived from the latest git tag (e.g. "v1.0.0" -> "1.0.0").
-// Used to replace `{{version}}` placeholders in markdown files at build time.
-const version = execSync('git describe --tags --abbrev=0').toString().trim().replace(/^v/, '')
+// Latest release version, used to replace `{{version}}` placeholders in markdown files at
+// build time. Resolution order: the DOCS_VERSION env var, the latest git tag
+// (e.g. "v1.0.0" -> "1.0.0"), then "latest" for environments where no tag is reachable
+// (shallow clones, source archives).
+const version = resolveVersion()
+
+function resolveVersion(): string {
+    if (process.env.DOCS_VERSION) {
+        return process.env.DOCS_VERSION
+    }
+    try {
+        return execSync('git describe --tags --abbrev=0', {stdio: ['ignore', 'pipe', 'ignore']})
+            .toString()
+            .trim()
+            .replace(/^v/, '')
+    } catch {
+        return 'latest'
+    }
+}
 
 const hostname = "https://kuery-client.hsbrysk.dev"
 


### PR DESCRIPTION
## Summary

The VitePress docs were only built by the Pages workflow when a release tag was pushed, so a broken docs config, markdown processing error, or plugin incompatibility would go unnoticed until release time.

- Add a `build-docs` job to the CI workflow that runs `npm ci && npm run docs:build` on every PR and push to main.
- CI checkouts are shallow and may have no reachable tag, so version resolution in `docs/.vitepress/config.mts` now falls back in order: `DOCS_VERSION` env var → `git describe --tags` → `"latest"`. Previously an unreachable tag made the build crash.

## Verification

Verified locally that all three resolution paths build successfully:

- normal build (version resolved from the latest git tag)
- `GIT_DIR` pointed at a tagless repo (falls back to `latest`)
- `DOCS_VERSION=9.9.9` (the placeholder output contains `9.9.9`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)