### PR TITLE
Declare least-privilege permissions in CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -32,6 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: github.event_name == 'pull_request'
+    # gradle-dependency-diff-action reports via GitHub Checks and a PR comment/label
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
+# Publishing uses external credentials (Maven Central / Plugin Portal secrets), not GITHUB_TOKEN
+permissions:
+  contents: read
+
 jobs:
   publish-maven-central:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Neither the CI nor the publish workflow declared a `permissions` block, so their jobs ran with the repository's default `GITHUB_TOKEN` grants. This pins them to least privilege:

- `ci.yml`: top-level `contents: read`. The `report-gradle-dependency-diff` job gets a job-level override with `checks: write` and `pull-requests: write`, which `gradle-dependency-diff-action` needs to report via GitHub Checks and a PR comment/label.
- `publish.yml`: top-level `contents: read`. The publish jobs authenticate to Maven Central and the Gradle Plugin Portal with dedicated secrets, not `GITHUB_TOKEN`.

`docs.yml` already declares the permissions required for Pages deployment and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)