### PR TITLE
Enable ABI validation for kuery-client-gradle-plugin

### DIFF
--- a/build-logic/src/main/kotlin/conventions/abi-validation.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/abi-validation.gradle.kts
@@ -1,0 +1,18 @@
+package conventions
+
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
+plugins {
+    kotlin("jvm")
+}
+
+kotlin {
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation {
+        filters {
+            exclude {
+                annotatedWith.add("dev.hsbrysk.kuery.core.KueryClientInternalApi")
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/conventions/public-api.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/public-api.gradle.kts
@@ -1,20 +1,10 @@
 package conventions
 
-import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
-
 plugins {
     kotlin("jvm")
+    id("conventions.abi-validation")
 }
 
 kotlin {
     explicitApi()
-
-    @OptIn(ExperimentalAbiValidation::class)
-    abiValidation {
-        filters {
-            exclude {
-                annotatedWith.add("dev.hsbrysk.kuery.core.KueryClientInternalApi")
-            }
-        }
-    }
 }

--- a/kuery-client-gradle-plugin/api/kuery-client-gradle-plugin.api
+++ b/kuery-client-gradle-plugin/api/kuery-client-gradle-plugin.api
@@ -1,0 +1,19 @@
+public abstract interface class dev/hsbrysk/kuery/gradle/KueryClientExtension {
+	public abstract fun getAutoTrimIndent ()Lorg/gradle/api/provider/Property;
+	public abstract fun getSqlSyntaxCheck ()Lorg/gradle/api/provider/Property;
+}
+
+public final class dev/hsbrysk/kuery/gradle/KueryClientGradlePlugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {
+	public static final field Companion Ldev/hsbrysk/kuery/gradle/KueryClientGradlePlugin$Companion;
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+	public fun applyToCompilation (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Lorg/gradle/api/provider/Provider;
+	public fun getCompilerPluginId ()Ljava/lang/String;
+	public fun getPluginArtifact ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
+	public fun isApplicable (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Z
+}
+
+public final class dev/hsbrysk/kuery/gradle/KueryClientGradlePlugin$Companion {
+}
+

--- a/kuery-client-gradle-plugin/build.gradle.kts
+++ b/kuery-client-gradle-plugin/build.gradle.kts
@@ -1,5 +1,8 @@
 plugins {
     id("conventions.preset.base")
+    // ABI dump only (no explicit API mode): KueryClientExtension is public API consumed from
+    // build scripts, but Gradle plugin code doesn't follow library explicit-API conventions.
+    id("conventions.abi-validation")
     `java-gradle-plugin`
     signing
     alias(libs.plugins.plugin.publish)


### PR DESCRIPTION
## Summary

`KueryClientExtension` is public API consumed from users' build scripts, but `kuery-client-gradle-plugin` had no ABI guard (the v1.0 ABI contract covered only core / spring-data-jdbc / spring-data-r2dbc).

- Split the `abiValidation` setup out of `conventions.public-api` into a dedicated `conventions.abi-validation` convention plugin; `conventions.public-api` now composes `explicitApi()` + `conventions.abi-validation`, so the three existing modules are unaffected.
- Apply `conventions.abi-validation` to `kuery-client-gradle-plugin`. Explicit API mode is deliberately NOT applied — it is a library convention and would add noise to Gradle plugin code.
- Commit the initial ABI dump (`KueryClientExtension` + `KueryClientGradlePlugin`; internal declarations such as `BuildConfig` are excluded automatically).

## Verification

- `--dry-run` confirms `checkKotlinAbi` is wired into `:kuery-client-gradle-plugin:check`.
- `:kuery-client-gradle-plugin:check` and `checkKotlinAbi` of the three existing modules all pass; their `api/*.api` files are byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)