### PR TITLE
Declare Gradle 8.4 as the minimum supported version and pin it in CI

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -52,9 +52,6 @@ kueryClient {
 }
 ```
 
-(On Gradle versions without Kotlin DSL property assignment — before 8.2 — write
-`autoTrimIndent.set(true)` instead.)
-
 Every string passed to `+` / `add()` then gets `trimIndent()` applied automatically. For string
 literals and templates the trimming is computed **at compile time** by the compiler plugin, so it
 adds no runtime cost. Arguments the plugin cannot see through (e.g. a variable) are trimmed at

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -37,6 +37,13 @@ release, as long as there are no other breaking changes).
 
 Kuery Client is built with a Java 17 toolchain, so Java 17 or later is required at runtime.
 
+## Gradle version
+
+The Gradle plugin supports **Gradle 8.4 or later** — the first version where the Kotlin DSL property
+assignment syntax used throughout this documentation (e.g. `autoTrimIndent = true`) is enabled by default.
+The minimum version is exercised in CI by running the published plugin against it, so it only changes
+deliberately and will be noted here when it does.
+
 ## Compatibility matrix
 
 The following table lists the versions of Kotlin, Spring Boot, and Spring Data that each kuery-client release

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,8 +7,8 @@ description: Install via Gradle plugin and dependency, build a KueryClient from 
 ## Requirements
 
 - Java 17 or later
-- Gradle — parameter binding relies on a Kotlin compiler plugin that is applied via the Gradle plugin, so Maven
-  is currently not supported
+- Gradle 8.4 or later — parameter binding relies on a Kotlin compiler plugin that is applied via the Gradle
+  plugin, so Maven is currently not supported
 - See [Compatibility](/compatibility) for the recommended Kotlin / Spring versions for each release
 
 ## Install

--- a/docs/sql-syntax-check.md
+++ b/docs/sql-syntax-check.md
@@ -16,9 +16,6 @@ kueryClient {
 }
 ```
 
-(On Gradle versions without Kotlin DSL property assignment — before 8.2 — write
-`sqlSyntaxCheck.set("generic")` instead.)
-
 A block whose SQL fails to parse is then reported as a `KUERY_SQL_SYNTAX` **warning**, anchored
 to the offending line:
 

--- a/kuery-client-gradle-plugin/functional-test/src/test/kotlin/dev/hsbrysk/kuery/gradle/PublishedPluginFunctionalTest.kt
+++ b/kuery-client-gradle-plugin/functional-test/src/test/kotlin/dev/hsbrysk/kuery/gradle/PublishedPluginFunctionalTest.kt
@@ -24,42 +24,27 @@ class PublishedPluginFunctionalTest {
 
     @Test
     fun `string interpolation in a consumer project is converted into bind parameters`() {
-        writeSettings()
-        writeBuild(
-            """
-            plugins {
-                kotlin("jvm") version "$kotlinVersion"
-                id("dev.hsbrysk.kuery-client") version "$version"
-                application
-            }
-
-            dependencies {
-                implementation("dev.hsbrysk.kuery-client:kuery-client-core:$version")
-            }
-
-            application {
-                mainClass = "MainKt"
-            }
-            """,
-        )
-        writeSource(
-            "src/main/kotlin/Main.kt",
-            """
-            import dev.hsbrysk.kuery.core.Sql
-
-            fun main() {
-                val userId = 42
-                val sql = Sql { +"SELECT * FROM users WHERE user_id = ${'$'}userId" }
-                println("body=" + sql.body)
-                println("params=" + sql.parameters.joinToString(",") { it.name + "=" + it.value })
-            }
-            """,
-        )
+        writeInterpolationConsumer()
 
         val output = runner("run", "--quiet").build().output
 
-        assertThat(output).contains("body=SELECT * FROM users WHERE user_id = :p0")
-        assertThat(output).contains("params=p0=42")
+        assertInterpolatedSql(output)
+    }
+
+    // The hard floor is Gradle's embedded Kotlin being able to read the metadata of the plugin
+    // jar, so upgrading the Kotlin version the plugin is built with can silently raise it — this
+    // test pins the declared minimum (docs/compatibility.md) so such a change fails CI instead
+    // of failing users.
+    @Test
+    fun `the plugin works on the minimum supported Gradle version`() {
+        writeInterpolationConsumer()
+
+        val output = runner("run", "--quiet")
+            .withGradleVersion(MINIMUM_SUPPORTED_GRADLE_VERSION)
+            .build()
+            .output
+
+        assertInterpolatedSql(output)
     }
 
     @Test
@@ -196,6 +181,45 @@ class PublishedPluginFunctionalTest {
         assertThat(jsLine).doesNotContain("kuery-client-compiler")
     }
 
+    private fun writeInterpolationConsumer() {
+        writeSettings()
+        writeBuild(
+            """
+            plugins {
+                kotlin("jvm") version "$kotlinVersion"
+                id("dev.hsbrysk.kuery-client") version "$version"
+                application
+            }
+
+            dependencies {
+                implementation("dev.hsbrysk.kuery-client:kuery-client-core:$version")
+            }
+
+            application {
+                mainClass = "MainKt"
+            }
+            """,
+        )
+        writeSource(
+            "src/main/kotlin/Main.kt",
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun main() {
+                val userId = 42
+                val sql = Sql { +"SELECT * FROM users WHERE user_id = ${'$'}userId" }
+                println("body=" + sql.body)
+                println("params=" + sql.parameters.joinToString(",") { it.name + "=" + it.value })
+            }
+            """,
+        )
+    }
+
+    private fun assertInterpolatedSql(output: String) {
+        assertThat(output).contains("body=SELECT * FROM users WHERE user_id = :p0")
+        assertThat(output).contains("params=p0=42")
+    }
+
     private fun runner(vararg arguments: String): GradleRunner = GradleRunner.create()
         .withProjectDir(projectDir)
         .withArguments(*arguments, "--stacktrace")
@@ -255,5 +279,11 @@ class PublishedPluginFunctionalTest {
         val file = projectDir.resolve(path)
         file.parentFile.mkdirs()
         file.writeText(content.trimIndent())
+    }
+
+    companion object {
+        // Keep in sync with the declared minimum in docs/compatibility.md and
+        // docs/getting-started.md.
+        private const val MINIMUM_SUPPORTED_GRADLE_VERSION = "8.4"
     }
 }


### PR DESCRIPTION
## Summary

The Gradle plugin never declared a minimum supported Gradle version. This declares **Gradle 8.4** and makes it an executable contract.

## How the number was chosen

The effective floor is not KGP's compatibility range (7.6.3+): it is whether **Gradle's embedded Kotlin can read the metadata of the plugin jar**, which is built with Kotlin 2.4.10. Verified empirically by running the published plugin (via the functional-test local repository) against real Gradle distributions:

| Gradle | Result |
|---|---|
| 7.6.3 | ❌ `InvalidProtocolBufferException` at Kotlin DSL script compilation |
| 8.0.2 | ❌ same |
| 8.2.1 | ✅ |
| 8.4 / 8.5 / 8.14.3 / 9.x | ✅ |

8.4 is declared instead of the technical floor 8.2 because it is the first version where the Kotlin DSL property assignment syntax used throughout the docs examples (`autoTrimIndent = true`) is enabled by default — the declared floor is one where the documentation works verbatim. It also stays well below Spring Boot 4.0's own floor (8.14), so Boot 3.x users on 8.x are not excluded.

## Changes

- `docs/compatibility.md`: new "Gradle version" section.
- `docs/getting-started.md`: Requirements now states Gradle 8.4 or later.
- `docs/basics.md` / `docs/sql-syntax-check.md`: removed the now-obsolete "on Gradle versions without Kotlin DSL property assignment, write `.set(...)`" caveats — the declared minimum makes the assignment syntax always available.
- `PublishedPluginFunctionalTest`: new test running the basic interpolation scenario with `withGradleVersion("8.4")`. The floor can silently move when the Kotlin version the plugin is built with is upgraded — this test makes such a change fail CI instead of failing users. The basic scenario setup is extracted and shared with the existing test; it uses the property assignment syntax (`mainClass = "MainKt"`), so the run on 8.4 also exercises exactly the syntax the docs rely on.

## Verification

`:kuery-client-gradle-plugin:functional-test:check` + `detektTest` — 5 tests, all passing (including the run on Gradle 8.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
