### PR TITLE
Make KUERY_BIND_CALL_IN_SQL_TEMPLATE a compile error

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -56,5 +56,10 @@ Feel free to extend it as you wish.
 Some SQL fragments cannot be expressed with plain string interpolation — for example, a dynamically sized list
 of placeholders. In such cases, use `addUnsafe` and `bind` (the `values` function above is a good example).
 
+`bind` only makes sense together with `addUnsafe`. Calling it inside a string template passed to `add()` / `+`
+is a compile error (`KUERY_BIND_CALL_IN_SQL_TEMPLATE`): interpolated values there are bound automatically, so
+the placeholder returned by `bind` would itself be re-bound as a value and the SQL would compare against the
+literal string `:pN`.
+
 Note that `addUnsafe` and `bind` are annotated with `@DelicateKueryClientApi` and require an explicit opt-in, since
 misusing them can lead to SQL injection. See [Compiler Safety Check](/compiler-safety-check) for details.

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientDiagnostics.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientDiagnostics.kt
@@ -3,6 +3,7 @@ package dev.hsbrysk.kuery.compiler.fir
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
 import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
+import org.jetbrains.kotlin.diagnostics.error0
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
 import org.jetbrains.kotlin.diagnostics.warning0
@@ -12,7 +13,10 @@ import org.jetbrains.kotlin.psi.KtExpression
 internal object KueryClientDiagnostics : KtDiagnosticsContainer() {
     // The property name is the diagnostic name, i.e. the key for @Suppress and -Xwarning-level.
     val KUERY_UNSAFE_SQL_STRING by warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
-    val KUERY_BIND_CALL_IN_SQL_TEMPLATE by warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
+
+    // An error, not a warning: SQL that fires this always compares against the literal string
+    // ":pN" at runtime, so there is no valid program in which it may be left as-is.
+    val KUERY_BIND_CALL_IN_SQL_TEMPLATE by error0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
     val KUERY_REDUNDANT_TRIM_INDENT by warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
     val KUERY_SQL_SYNTAX by warning1<KtExpression, String>(SourceElementPositioningStrategies.DEFAULT)
     val KUERY_SQL_DIALECT by warning1<KtExpression, String>(SourceElementPositioningStrategies.DEFAULT)
@@ -47,8 +51,7 @@ internal object KueryClientDiagnosticRenderers : BaseDiagnosticRendererFactory()
                 "plugin already converts every interpolated value into a bind parameter, so the placeholder " +
                 "name returned by bind() would itself be re-bound as a new parameter value and the SQL would " +
                 "compare against the literal string ':pN'. Interpolate the value directly (\$value instead " +
-                "of \${bind(value)}), or use addUnsafe() when you need bind(). If this is intentional, " +
-                "annotate the enclosing declaration with @Suppress(\"KUERY_BIND_CALL_IN_SQL_TEMPLATE\").",
+                "of \${bind(value)}), or use addUnsafe() when you need bind().",
         )
         map.put(
             KueryClientDiagnostics.KUERY_SQL_SYNTAX,

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/BindCallInSqlTemplateCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/BindCallInSqlTemplateCheckerTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 @OptIn(ExperimentalCompilerApi::class)
 class BindCallInSqlTemplateCheckerTest {
     @Test
-    fun `warn when bind is called inside a template passed to unaryPlus`() {
+    fun `bind call inside a template passed to unaryPlus is a compile error`() {
         // when
         val result = compile(
             """
@@ -26,12 +26,12 @@ class BindCallInSqlTemplateCheckerTest {
         )
 
         // then
-        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains(DIAGNOSTIC_MESSAGE)
     }
 
     @Test
-    fun `warn when bind is called inside a template passed to add`() {
+    fun `bind call inside a template passed to add is a compile error`() {
         // when
         val result = compile(
             """
@@ -46,12 +46,12 @@ class BindCallInSqlTemplateCheckerTest {
         )
 
         // then
-        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains(DIAGNOSTIC_MESSAGE)
     }
 
     @Test
-    fun `warn when bind is called indirectly inside an interpolated value`() {
+    fun `indirect bind call inside an interpolated value is a compile error`() {
         // when
         val result = compile(
             """
@@ -66,12 +66,12 @@ class BindCallInSqlTemplateCheckerTest {
         )
 
         // then
-        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains(DIAGNOSTIC_MESSAGE)
     }
 
     @Test
-    fun `warn when bind is called inside a template in an if branch passed to add`() {
+    fun `bind call inside a template in an if branch passed to add is a compile error`() {
         // when
         val result = compile(
             """
@@ -86,12 +86,12 @@ class BindCallInSqlTemplateCheckerTest {
         )
 
         // then
-        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains(DIAGNOSTIC_MESSAGE)
     }
 
     @Test
-    fun `no warning when bind is used with addUnsafe`() {
+    fun `no diagnostic when bind is used with addUnsafe`() {
         // when
         val result = compile(
             """
@@ -107,12 +107,12 @@ class BindCallInSqlTemplateCheckerTest {
         )
 
         // then
-        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_MESSAGE)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
-    fun `no warning for plain interpolation`() {
+    fun `no diagnostic for plain interpolation`() {
         // when
         val result = compile(
             """
@@ -127,12 +127,15 @@ class BindCallInSqlTemplateCheckerTest {
         )
 
         // then
-        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_MESSAGE)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
+    // Pins K2 behavior: @Suppress by diagnostic name silences even error-severity plugin
+    // diagnostics. Not advertised in the error message (there is no valid reason to keep the
+    // code), but recorded here so a Kotlin upgrade that changes it is noticed.
     @Test
-    fun `warning can be suppressed by diagnostic name`() {
+    fun `the error can still be suppressed by diagnostic name`() {
         // when
         val result = compile(
             """
@@ -149,32 +152,15 @@ class BindCallInSqlTemplateCheckerTest {
         )
 
         // then
-        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_MESSAGE)
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-    }
-
-    @Test
-    fun `warning becomes an error with -Werror`() {
-        // when
-        val result = compile(
-            """
-            import dev.hsbrysk.kuery.core.DelicateKueryClientApi
-            import dev.hsbrysk.kuery.core.Sql
-
-            @OptIn(DelicateKueryClientApi::class)
-            fun query(id: Int) {
-                Sql { +"SELECT * FROM users WHERE id = ${'$'}{bind(id)}" }
-            }
-            """.trimIndent(),
-            allWarningsAsErrors = true,
-        )
-
-        // then
-        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
     }
 
     companion object {
         private const val DIAGNOSTIC_NAME = "KUERY_BIND_CALL_IN_SQL_TEMPLATE"
+
+        // The CLI renders the message text without the diagnostic name, so assertions match on
+        // a distinctive fragment of the message instead.
+        private const val DIAGNOSTIC_MESSAGE = "bind() must not be called inside a string template"
     }
 }

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/SqlBuilder.kt
@@ -70,7 +70,10 @@ public sealed interface SqlBuilder {
      * to embed in the SQL fragment.
      *
      * It is intended to be used together with [addUnsafe]; fragments passed to [add] /
-     * [String.unaryPlus] bind interpolated values automatically.
+     * [String.unaryPlus] bind interpolated values automatically. Calling it inside a string
+     * template passed to [add] / [String.unaryPlus] is therefore a compile error
+     * (`KUERY_BIND_CALL_IN_SQL_TEMPLATE`): the returned placeholder would be re-bound as a
+     * value and the SQL would compare against the literal string `:pN`.
      */
     @DelicateKueryClientApi
     public fun bind(parameter: Any?): String


### PR DESCRIPTION
## Summary

`KUERY_BIND_CALL_IN_SQL_TEMPLATE` fires when `bind()` is called inside a string template passed to `add()` / `unaryPlus`. Code that fires it is broken in 100% of cases: the compiler plugin converts every interpolated value into a bind parameter, so the placeholder returned by `bind()` is itself re-bound as a value and the SQL compares against the literal string `:pN` at runtime. There is no valid program in which this construct may be left as-is, so it is now a **compile error** instead of a warning.

This is intentionally unconditional (not gated behind the upcoming strict-safety option): a diagnostic with zero false positives and a guaranteed runtime bug has no reason to stay a warning.

## Notes

- The rendered message no longer suggests `@Suppress` — there is no "intentional" case. Suppression by diagnostic name technically still works (K2 honors `@Suppress` even for error-severity plugin diagnostics); a test pins that behavior so a Kotlin upgrade changing it is noticed.
- Assertions in the checker test now match on the message text: the Kotlin CLI renders messages without diagnostic names, and the name only appeared in output via the removed `@Suppress` suggestion.
- Documented on the `bind()` KDoc and in `docs/helpers.md`.

## Compatibility

Strictly speaking this can break compilation of existing code, but only code that is already guaranteed to misbehave at runtime (comparing against the literal `:pN` string). Surfacing it at compile time is the fix.

## Verification

`:kuery-client-compiler:check`, both compiler functional-test modules, `:kuery-client-core` compile/lint, and the VitePress build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)