### PR TITLE
Add strict option to escalate SQL-safety warnings to errors

### DIFF
--- a/docs/compiler-safety-check.md
+++ b/docs/compiler-safety-check.md
@@ -1,5 +1,5 @@
 ---
-description: The KUERY_UNSAFE_SQL_STRING compiler warning that catches SQL strings the plugin cannot convert into bind parameters.
+description: The KUERY_UNSAFE_SQL_STRING compiler warning that catches SQL strings the plugin cannot convert into bind parameters, and the strict option that turns the safety warnings into compile errors.
 ---
 
 # Compiler Safety Check
@@ -53,18 +53,45 @@ In order of preference:
 2. **Suppress the warning** with `@Suppress("KUERY_UNSAFE_SQL_STRING")` on the declaration, when
    you know the string is safe but the checker cannot see it.
 
-## Configuring the severity
+## Strict mode
 
-The check is a regular Kotlin compiler diagnostic, so the standard
-mechanisms apply:
+Enable `strict` in the Gradle plugin to report the SQL-safety diagnostics as compile
+**errors** instead of warnings (recommended for security-sensitive projects):
 
-- Treat it as an error (recommended for security-sensitive projects):
-  `-Xwarning-level=KUERY_UNSAFE_SQL_STRING:error`, or enable
-  `allWarningsAsErrors` (`-Werror`)
-- Disable it project-wide (not recommended):
-  `-Xwarning-level=KUERY_UNSAFE_SQL_STRING:disabled`
+```kotlin
+kueryClient {
+    strict = true
+}
+```
 
-In Gradle:
+This makes the compiler plugin register `KUERY_UNSAFE_SQL_STRING` — and, when the
+[SQL Syntax Check](/sql-syntax-check) is enabled, `KUERY_SQL_SYNTAX` / `KUERY_SQL_DIALECT` —
+as **error**-severity diagnostics. `@Suppress` on the enclosing declaration keeps working for
+individual call sites, and `addUnsafe()` + `bind()` remain the sanctioned way to build SQL
+dynamically. `KUERY_REDUNDANT_TRIM_INDENT` stays a warning — a style issue, not a safety issue.
+
+The escalated set may grow in minor releases as new safety diagnostics are added — enabling
+strict mode opts into those too.
+
+An explicit `-Xwarning-level` for one of these diagnostics always wins over strict mode: strict
+only changes the **default** severity of the diagnostics you have not configured yourself. So a
+single diagnostic can still be lowered back to a warning (or disabled) module-wide with strict
+enabled:
+
+```kotlin
+kotlin {
+    compilerOptions {
+        // keep everything else strict, but let the dialect check stay advisory
+        freeCompilerArgs.add("-Xwarning-level=KUERY_SQL_DIALECT:warning")
+    }
+}
+```
+
+## Configuring the severity manually
+
+The checks are regular Kotlin compiler diagnostics, so `-Xwarning-level` works as usual —
+without strict mode to escalate a single diagnostic, with strict mode to lower one back (see
+above), or to disable one project-wide (not recommended):
 
 ```kotlin
 kotlin {
@@ -73,6 +100,8 @@ kotlin {
     }
 }
 ```
+
+`allWarningsAsErrors` (`-Werror`) likewise turns all warnings into errors.
 
 ## See also
 

--- a/docs/sql-syntax-check.md
+++ b/docs/sql-syntax-check.md
@@ -16,8 +16,9 @@ kueryClient {
 }
 ```
 
-A block whose SQL fails to parse is then reported as a `KUERY_SQL_SYNTAX` **warning**, anchored
-to the offending line:
+A block whose SQL fails to parse is then reported as a `KUERY_SQL_SYNTAX` **warning** (or a
+compile **error** when `strict` is enabled — see
+[Compiler Safety Check](/compiler-safety-check#strict-mode)), anchored to the offending line:
 
 ```kotlin
 kueryClient.sql {

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerCommandLineProcessor.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerCommandLineProcessor.kt
@@ -14,6 +14,7 @@ class KueryClientCompilerCommandLineProcessor : CommandLineProcessor {
     override val pluginOptions: Collection<AbstractCliOption> = listOf(
         AUTO_TRIM_INDENT_OPTION,
         SQL_SYNTAX_CHECK_OPTION,
+        STRICT_OPTION,
     )
 
     override fun processOption(
@@ -26,6 +27,8 @@ class KueryClientCompilerCommandLineProcessor : CommandLineProcessor {
                 configuration.put(AUTO_TRIM_INDENT_KEY, parseBoolean(AUTO_TRIM_INDENT_OPTION_NAME, value))
             SQL_SYNTAX_CHECK_OPTION.optionName ->
                 configuration.put(SQL_SYNTAX_CHECK_KEY, parseSqlSyntaxCheck(value))
+            STRICT_OPTION.optionName ->
+                configuration.put(STRICT_KEY, parseBoolean(STRICT_OPTION_NAME, value))
             else -> error("Unexpected plugin option: ${option.optionName}")
         }
     }
@@ -45,6 +48,7 @@ class KueryClientCompilerCommandLineProcessor : CommandLineProcessor {
         const val PLUGIN_ID = "dev.hsbrysk.kuery-client"
         const val AUTO_TRIM_INDENT_OPTION_NAME = "autoTrimIndent"
         const val SQL_SYNTAX_CHECK_OPTION_NAME = "sqlSyntaxCheck"
+        const val STRICT_OPTION_NAME = "strict"
 
         val AUTO_TRIM_INDENT_KEY: CompilerConfigurationKey<Boolean> =
             CompilerConfigurationKey.create("auto trimIndent")
@@ -52,6 +56,9 @@ class KueryClientCompilerCommandLineProcessor : CommandLineProcessor {
         // Absent = the check is disabled; present = enabled with the selected strictness.
         val SQL_SYNTAX_CHECK_KEY: CompilerConfigurationKey<SqlSyntaxCheck> =
             CompilerConfigurationKey.create("sql syntax check")
+
+        val STRICT_KEY: CompilerConfigurationKey<Boolean> =
+            CompilerConfigurationKey.create("strict SQL safety")
 
         private val AUTO_TRIM_INDENT_OPTION = CliOption(
             optionName = AUTO_TRIM_INDENT_OPTION_NAME,
@@ -65,6 +72,14 @@ class KueryClientCompilerCommandLineProcessor : CommandLineProcessor {
             valueDescription = "<${SqlSyntaxCheck.SUPPORTED_VALUES}>",
             description = "Validate statically-known SQL in sql blocks: 'generic' for syntax only, or a " +
                 "dialect name to also check its feature set",
+            required = false,
+            allowMultipleOccurrences = false,
+        )
+        private val STRICT_OPTION = CliOption(
+            optionName = STRICT_OPTION_NAME,
+            valueDescription = "<true|false>",
+            description = "Report the SQL-safety diagnostics (KUERY_UNSAFE_SQL_STRING, KUERY_SQL_SYNTAX, " +
+                "KUERY_SQL_DIALECT) as errors instead of warnings",
             required = false,
             allowMultipleOccurrences = false,
         )

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerCommandLineProcessor.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerCommandLineProcessor.kt
@@ -1,5 +1,6 @@
 package dev.hsbrysk.kuery.compiler
 
+import dev.hsbrysk.kuery.compiler.fir.KueryClientDiagnostics
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOptionProcessingException
@@ -78,8 +79,9 @@ class KueryClientCompilerCommandLineProcessor : CommandLineProcessor {
         private val STRICT_OPTION = CliOption(
             optionName = STRICT_OPTION_NAME,
             valueDescription = "<true|false>",
-            description = "Report the SQL-safety diagnostics (KUERY_UNSAFE_SQL_STRING, KUERY_SQL_SYNTAX, " +
-                "KUERY_SQL_DIALECT) as errors instead of warnings",
+            description = "Report the SQL-safety diagnostics " +
+                "(${KueryClientDiagnostics.STRICT_DIAGNOSTIC_NAMES.joinToString(", ")}) " +
+                "as errors instead of warnings",
             required = false,
             allowMultipleOccurrences = false,
         )

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerPluginRegistrar.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/KueryClientCompilerPluginRegistrar.kt
@@ -2,12 +2,14 @@ package dev.hsbrysk.kuery.compiler
 
 import dev.hsbrysk.kuery.compiler.KueryClientCompilerCommandLineProcessor.Companion.AUTO_TRIM_INDENT_KEY
 import dev.hsbrysk.kuery.compiler.KueryClientCompilerCommandLineProcessor.Companion.SQL_SYNTAX_CHECK_KEY
+import dev.hsbrysk.kuery.compiler.KueryClientCompilerCommandLineProcessor.Companion.STRICT_KEY
 import dev.hsbrysk.kuery.compiler.fir.KueryClientFirExtensionRegistrar
 import dev.hsbrysk.kuery.compiler.ir.KueryClientIrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.AnalysisFlags
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
@@ -23,9 +25,19 @@ class KueryClientCompilerPluginRegistrar : CompilerPluginRegistrar() {
         val autoTrimIndent = configuration.get(AUTO_TRIM_INDENT_KEY, false)
         // Null when the option is absent, i.e. the syntax check is disabled.
         val sqlSyntaxCheck = configuration.get(SQL_SYNTAX_CHECK_KEY)
+        val strict = configuration.get(STRICT_KEY, false)
+        // An explicit -Xwarning-level always wins over strict mode: diagnostics the user
+        // configured keep their warning-severity registration so the chosen level applies as
+        // usual. Registering them as errors instead would make kotlinc reject the user's flag
+        // ("Changing the severity of errors is prohibited") — strict only changes the default
+        // severity of the diagnostics the user has not configured.
+        val userConfiguredWarningLevels = configuration.get(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS)
+            ?.getFlag(AnalysisFlags.warningLevels)
+            ?.keys
+            .orEmpty()
         val messageCollector = configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
         FirExtensionRegistrarAdapter.registerExtension(
-            KueryClientFirExtensionRegistrar(autoTrimIndent, sqlSyntaxCheck),
+            KueryClientFirExtensionRegistrar(autoTrimIndent, sqlSyntaxCheck, strict, userConfiguredWarningLevels),
         )
         IrGenerationExtension.registerExtension(KueryClientIrGenerationExtension(autoTrimIndent, messageCollector))
     }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/BindCallInSqlTemplateChecker.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/BindCallInSqlTemplateChecker.kt
@@ -12,18 +12,19 @@ import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.visitors.FirVisitorVoid
 
 /**
- * Reports [KueryClientDiagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE] when `SqlBuilder.bind()` is called
+ * Reports [diagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE] when `SqlBuilder.bind()` is called
  * anywhere inside the SQL string argument of `add()` / `unaryPlus`. The IR transformation converts every
  * interpolated value into a bind parameter, so the placeholder name returned by `bind()` would itself be
  * re-bound as a new parameter value and the SQL would compare against the literal string ":pN".
  * `bind()` is only meaningful together with `addUnsafe()`, which is not transformed.
  */
-internal object BindCallInSqlTemplateChecker : FirFunctionCallChecker(MppCheckerKind.Common) {
+internal class BindCallInSqlTemplateChecker(private val diagnostics: KueryClientDiagnostics) :
+    FirFunctionCallChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(expression: FirFunctionCall) {
         val sqlArgument = SqlBuilderCalls.sqlArgumentOrNull(expression) ?: return
         collectBindCalls(sqlArgument).forEach {
-            reporter.reportOn(it.source ?: expression.source, KueryClientDiagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE)
+            reporter.reportOn(it.source ?: expression.source, diagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE)
         }
     }
 

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientDiagnostics.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientDiagnostics.kt
@@ -33,9 +33,13 @@ internal class KueryClientDiagnostics(
     // is initialized.
     private val rendererFactory = KueryClientDiagnosticRenderers(this)
 
-    // The name literal must match the property name it decides for (the property name is the
-    // diagnostic name); the strict-mode tests exercise each escalated diagnostic by name.
-    private val escalate: (String) -> Boolean = { name -> strict && name !in userConfiguredWarningLevels }
+    // Whether the diagnostic with the given name is registered as an error. The name literal at
+    // each call site must match the property name it decides for (the property name is the
+    // diagnostic name); KueryClientDiagnosticsTest pins the severity of every diagnostic per
+    // mode, so a mismatch cannot go unnoticed.
+    private val escalate: (String) -> Boolean = { name ->
+        strict && name in STRICT_DIAGNOSTIC_NAMES && name !in userConfiguredWarningLevels
+    }
 
     val KUERY_UNSAFE_SQL_STRING by (
         if (escalate("KUERY_UNSAFE_SQL_STRING")) {
@@ -50,8 +54,13 @@ internal class KueryClientDiagnostics(
     // as-is.
     val KUERY_BIND_CALL_IN_SQL_TEMPLATE by error0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
 
-    // Not escalated by strict mode: a style issue, not a safety issue.
-    val KUERY_REDUNDANT_TRIM_INDENT by warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
+    val KUERY_REDUNDANT_TRIM_INDENT by (
+        if (escalate("KUERY_REDUNDANT_TRIM_INDENT")) {
+            error0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
+        } else {
+            warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
+        }
+        )
 
     val KUERY_SQL_SYNTAX by (
         if (escalate("KUERY_SQL_SYNTAX")) {
@@ -70,6 +79,19 @@ internal class KueryClientDiagnostics(
         )
 
     override fun getRendererFactory(): BaseDiagnosticRendererFactory = rendererFactory
+
+    companion object {
+        // The single source of truth for which diagnostics the strict option escalates to
+        // errors. Membership here is the decision — every warning-default property above routes
+        // through [escalate] — and the CLI option description is derived from it too.
+        // KUERY_REDUNDANT_TRIM_INDENT is deliberately absent (a style issue, not a safety
+        // issue); KUERY_BIND_CALL_IN_SQL_TEMPLATE is an unconditional error.
+        val STRICT_DIAGNOSTIC_NAMES: Set<String> = setOf(
+            "KUERY_UNSAFE_SQL_STRING",
+            "KUERY_SQL_SYNTAX",
+            "KUERY_SQL_DIALECT",
+        )
+    }
 }
 
 internal class KueryClientDiagnosticRenderers(diagnostics: KueryClientDiagnostics) : BaseDiagnosticRendererFactory() {

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientDiagnostics.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientDiagnostics.kt
@@ -4,31 +4,79 @@ import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
 import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
 import org.jetbrains.kotlin.diagnostics.error0
+import org.jetbrains.kotlin.diagnostics.error1
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
 import org.jetbrains.kotlin.diagnostics.warning0
 import org.jetbrains.kotlin.diagnostics.warning1
 import org.jetbrains.kotlin.psi.KtExpression
 
-internal object KueryClientDiagnostics : KtDiagnosticsContainer() {
-    // The property name is the diagnostic name, i.e. the key for @Suppress and -Xwarning-level.
-    val KUERY_UNSAFE_SQL_STRING by warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
+/**
+ * One instance exists per compilation (created by [KueryClientFirExtensionRegistrar]), because
+ * the severity of the SQL-safety diagnostics is decided per compilation: under the `strict`
+ * plugin option they are registered as errors instead of warnings — except the ones the user
+ * explicitly configured with `-Xwarning-level`, which keep their warning registration so the
+ * user's chosen level applies (strict only changes the default). The diagnostic NAME is the
+ * same at either severity — the property name is the key for `@Suppress` and `-Xwarning-level`,
+ * and both keep working identically.
+ */
+// The SCREAMING_SNAKE property names are the diagnostic names themselves and must stay as-is.
+@Suppress("VariableNaming", "ktlint:standard:property-naming")
+internal class KueryClientDiagnostics(
+    strict: Boolean,
+    userConfiguredWarningLevels: Set<String>,
+) : KtDiagnosticsContainer() {
+    // Declared before the factory properties: their provideDelegate links each factory to the
+    // container's renderer factory, i.e. getRendererFactory() is called from this class's own
+    // constructor, so this field must already be initialized by then. Constructing the renderers
+    // that early is safe — its MAP is a Lazy built on first rendering, after every factory below
+    // is initialized.
+    private val rendererFactory = KueryClientDiagnosticRenderers(this)
 
-    // An error, not a warning: SQL that fires this always compares against the literal string
-    // ":pN" at runtime, so there is no valid program in which it may be left as-is.
+    // The name literal must match the property name it decides for (the property name is the
+    // diagnostic name); the strict-mode tests exercise each escalated diagnostic by name.
+    private val escalate: (String) -> Boolean = { name -> strict && name !in userConfiguredWarningLevels }
+
+    val KUERY_UNSAFE_SQL_STRING by (
+        if (escalate("KUERY_UNSAFE_SQL_STRING")) {
+            error0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
+        } else {
+            warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
+        }
+        )
+
+    // An error regardless of strict mode: SQL that fires this always compares against the
+    // literal string ":pN" at runtime, so there is no valid program in which it may be left
+    // as-is.
     val KUERY_BIND_CALL_IN_SQL_TEMPLATE by error0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
-    val KUERY_REDUNDANT_TRIM_INDENT by warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
-    val KUERY_SQL_SYNTAX by warning1<KtExpression, String>(SourceElementPositioningStrategies.DEFAULT)
-    val KUERY_SQL_DIALECT by warning1<KtExpression, String>(SourceElementPositioningStrategies.DEFAULT)
 
-    override fun getRendererFactory(): BaseDiagnosticRendererFactory = KueryClientDiagnosticRenderers
+    // Not escalated by strict mode: a style issue, not a safety issue.
+    val KUERY_REDUNDANT_TRIM_INDENT by warning0<KtExpression>(SourceElementPositioningStrategies.DEFAULT)
+
+    val KUERY_SQL_SYNTAX by (
+        if (escalate("KUERY_SQL_SYNTAX")) {
+            error1<KtExpression, String>(SourceElementPositioningStrategies.DEFAULT)
+        } else {
+            warning1<KtExpression, String>(SourceElementPositioningStrategies.DEFAULT)
+        }
+        )
+
+    val KUERY_SQL_DIALECT by (
+        if (escalate("KUERY_SQL_DIALECT")) {
+            error1<KtExpression, String>(SourceElementPositioningStrategies.DEFAULT)
+        } else {
+            warning1<KtExpression, String>(SourceElementPositioningStrategies.DEFAULT)
+        }
+        )
+
+    override fun getRendererFactory(): BaseDiagnosticRendererFactory = rendererFactory
 }
 
-internal object KueryClientDiagnosticRenderers : BaseDiagnosticRendererFactory() {
+internal class KueryClientDiagnosticRenderers(diagnostics: KueryClientDiagnostics) : BaseDiagnosticRendererFactory() {
     @Suppress("ktlint:standard:property-naming")
     override val MAP by KtDiagnosticFactoryToRendererMap("KueryClient") { map ->
         map.put(
-            KueryClientDiagnostics.KUERY_UNSAFE_SQL_STRING,
+            diagnostics.KUERY_UNSAFE_SQL_STRING,
             "This expression is not a string literal/template, so the kuery-client compiler plugin cannot " +
                 "guarantee that its string interpolation is converted into bind parameters; it may be executed " +
                 "as raw SQL (SQL injection risk). Pass a string literal/template directly, or use addUnsafe() " +
@@ -36,7 +84,7 @@ internal object KueryClientDiagnosticRenderers : BaseDiagnosticRendererFactory()
                 "declaration with @Suppress(\"KUERY_UNSAFE_SQL_STRING\").",
         )
         map.put(
-            KueryClientDiagnostics.KUERY_REDUNDANT_TRIM_INDENT,
+            diagnostics.KUERY_REDUNDANT_TRIM_INDENT,
             // Describes the behavior of StringInterpolationTransformer.autoTrimmedArgument —
             // keep the two in sync.
             "This trimIndent() is redundant: autoTrimIndent is enabled, so the kuery-client compiler plugin " +
@@ -46,7 +94,7 @@ internal object KueryClientDiagnosticRenderers : BaseDiagnosticRendererFactory()
                 "enclosing declaration with @Suppress(\"KUERY_REDUNDANT_TRIM_INDENT\").",
         )
         map.put(
-            KueryClientDiagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE,
+            diagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE,
             "bind() must not be called inside a string template passed to add()/unaryPlus. The compiler " +
                 "plugin already converts every interpolated value into a bind parameter, so the placeholder " +
                 "name returned by bind() would itself be re-bound as a new parameter value and the SQL would " +
@@ -54,7 +102,7 @@ internal object KueryClientDiagnosticRenderers : BaseDiagnosticRendererFactory()
                 "of \${bind(value)}), or use addUnsafe() when you need bind().",
         )
         map.put(
-            KueryClientDiagnostics.KUERY_SQL_SYNTAX,
+            diagnostics.KUERY_SQL_SYNTAX,
             "The SQL assembled from this block failed to parse: {0} The check uses a generic SQL parser " +
                 "(JSqlParser), which does not know every vendor-specific syntax, so this may be a false " +
                 "positive. If the SQL is valid, annotate the enclosing declaration with " +
@@ -62,7 +110,7 @@ internal object KueryClientDiagnosticRenderers : BaseDiagnosticRendererFactory()
             CommonRenderers.STRING,
         )
         map.put(
-            KueryClientDiagnostics.KUERY_SQL_DIALECT,
+            diagnostics.KUERY_SQL_DIALECT,
             "The SQL assembled from this block uses a feature the configured dialect does not support: {0} " +
                 "The dialect check is a feature-level allow-list (JSqlParser), so this may be a false " +
                 "positive. If the SQL is valid for your database, annotate the enclosing declaration with " +

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientFirExtensionRegistrar.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/KueryClientFirExtensionRegistrar.kt
@@ -10,13 +10,18 @@ import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 class KueryClientFirExtensionRegistrar(
     private val autoTrimIndent: Boolean,
     private val sqlSyntaxCheck: SqlSyntaxCheck?,
+    private val strict: Boolean,
+    private val userConfiguredWarningLevels: Set<String>,
 ) : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
+        // The diagnostics container is per compilation: the strict option decides whether the
+        // SQL-safety diagnostics are registered as warnings or errors.
+        val diagnostics = KueryClientDiagnostics(strict, userConfiguredWarningLevels)
         val checkersFactory: (FirSession) -> KueryClientFirCheckersExtension = { session ->
-            KueryClientFirCheckersExtension(session, autoTrimIndent, sqlSyntaxCheck)
+            KueryClientFirCheckersExtension(session, autoTrimIndent, sqlSyntaxCheck, diagnostics)
         }
         +checkersFactory
-        registerDiagnosticContainers(KueryClientDiagnostics)
+        registerDiagnosticContainers(diagnostics)
     }
 }
 
@@ -24,20 +29,21 @@ internal class KueryClientFirCheckersExtension(
     session: FirSession,
     autoTrimIndent: Boolean,
     sqlSyntaxCheck: SqlSyntaxCheck?,
+    diagnostics: KueryClientDiagnostics,
 ) : FirAdditionalCheckersExtension(session) {
     override val expressionCheckers: ExpressionCheckers = object : ExpressionCheckers() {
         override val functionCallCheckers: Set<FirFunctionCallChecker> = buildSet {
-            add(UnsafeSqlStringChecker)
-            add(BindCallInSqlTemplateChecker)
+            add(UnsafeSqlStringChecker(diagnostics))
+            add(BindCallInSqlTemplateChecker(diagnostics))
             // Only meaningful when the plugin actually auto-trims, so don't even register it
             // otherwise.
             if (autoTrimIndent) {
-                add(RedundantTrimIndentChecker)
+                add(RedundantTrimIndentChecker(diagnostics))
             }
             // Opt-in (null = disabled); the checker must know autoTrimIndent to reconstruct the
             // runtime SQL text.
             if (sqlSyntaxCheck != null) {
-                add(SqlSyntaxChecker(autoTrimIndent, sqlSyntaxCheck))
+                add(SqlSyntaxChecker(autoTrimIndent, sqlSyntaxCheck, diagnostics))
             }
         }
     }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/RedundantTrimIndentChecker.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/RedundantTrimIndentChecker.kt
@@ -24,7 +24,8 @@ import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
  * `trimMargin` is never flagged — auto-trim does not remove margins, so an explicit call is not
  * redundant.
  */
-internal object RedundantTrimIndentChecker : FirFunctionCallChecker(MppCheckerKind.Common) {
+internal class RedundantTrimIndentChecker(private val diagnostics: KueryClientDiagnostics) :
+    FirFunctionCallChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(expression: FirFunctionCall) {
         val sqlArgument = SqlBuilderCalls.sqlArgumentOrNull(expression) ?: return
@@ -36,7 +37,7 @@ internal object RedundantTrimIndentChecker : FirFunctionCallChecker(MppCheckerKi
         when (expression) {
             is FirFunctionCall -> {
                 if (expression.calleeReference.toResolvedCallableSymbol()?.callableId == CallableIds.TRIM_INDENT) {
-                    reporter.reportOn(expression.source, KueryClientDiagnostics.KUERY_REDUNDANT_TRIM_INDENT)
+                    reporter.reportOn(expression.source, diagnostics.KUERY_REDUNDANT_TRIM_INDENT)
                 }
             }
             // The automatic trim applies to whichever branch value is selected, so a trimIndent

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/SqlSyntaxChecker.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/SqlSyntaxChecker.kt
@@ -79,6 +79,7 @@ import java.util.concurrent.Executors
 internal class SqlSyntaxChecker(
     private val autoTrimIndent: Boolean,
     mode: SqlSyntaxCheck,
+    private val diagnostics: KueryClientDiagnostics,
 ) : FirFunctionCallChecker(MppCheckerKind.Common) {
     // null for GENERIC: parse only, no feature validation.
     private val dialect: DatabaseType? = mode.toDatabaseTypeOrNull()
@@ -214,7 +215,7 @@ internal class SqlSyntaxChecker(
         when (val outcome = parse(sql)) {
             is ParseOutcome.Failed -> reporter.reportOn(
                 anchorSource(parts, outcome.reason, leadingLineOffset) ?: expression.source,
-                KueryClientDiagnostics.KUERY_SQL_SYNTAX,
+                diagnostics.KUERY_SQL_SYNTAX,
                 outcome.reason,
             )
             // Only a statement that parses is feature-checked; a broken one already drew the
@@ -223,7 +224,7 @@ internal class SqlSyntaxChecker(
                 val reason = dialect?.let { dialectFailureOrNull(outcome.statements, it) } ?: return
                 reporter.reportOn(
                     expression.source,
-                    KueryClientDiagnostics.KUERY_SQL_DIALECT,
+                    diagnostics.KUERY_SQL_DIALECT,
                     "$reason (dialect: $dialectLabel)",
                 )
             }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/UnsafeSqlStringChecker.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/UnsafeSqlStringChecker.kt
@@ -7,13 +7,14 @@ import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 
-internal object UnsafeSqlStringChecker : FirFunctionCallChecker(MppCheckerKind.Common) {
+internal class UnsafeSqlStringChecker(private val diagnostics: KueryClientDiagnostics) :
+    FirFunctionCallChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(expression: FirFunctionCall) {
         val sqlArgument = SqlBuilderCalls.sqlArgumentOrNull(expression) ?: return
         if (CompileTimeSafeSqlStrings.isCompileTimeSafe(sqlArgument)) {
             return
         }
-        reporter.reportOn(sqlArgument.source ?: expression.source, KueryClientDiagnostics.KUERY_UNSAFE_SQL_STRING)
+        reporter.reportOn(sqlArgument.source ?: expression.source, diagnostics.KUERY_UNSAFE_SQL_STRING)
     }
 }

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/KueryClientDiagnosticsTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/KueryClientDiagnosticsTest.kt
@@ -1,0 +1,65 @@
+package dev.hsbrysk.kuery.compiler
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.hsbrysk.kuery.compiler.fir.KueryClientDiagnostics
+import org.jetbrains.kotlin.diagnostics.AbstractKtDiagnosticFactory
+import org.jetbrains.kotlin.diagnostics.Severity
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the registered severity of every diagnostic per mode, directly on the container. This is
+ * the guard for the name literals inside the container's severity decision: a literal that does
+ * not match its property name would silently leave that diagnostic a warning under strict mode,
+ * which these assertions catch without a full compilation.
+ */
+class KueryClientDiagnosticsTest {
+    @Test
+    fun `all diagnostics default to warnings except the unconditional bind-call error`() {
+        val diagnostics = KueryClientDiagnostics(strict = false, userConfiguredWarningLevels = emptySet())
+
+        assertThat(diagnostics.severitiesByName()).isEqualTo(
+            mapOf(
+                "KUERY_UNSAFE_SQL_STRING" to Severity.WARNING,
+                "KUERY_BIND_CALL_IN_SQL_TEMPLATE" to Severity.ERROR,
+                "KUERY_REDUNDANT_TRIM_INDENT" to Severity.WARNING,
+                "KUERY_SQL_SYNTAX" to Severity.WARNING,
+                "KUERY_SQL_DIALECT" to Severity.WARNING,
+            ),
+        )
+    }
+
+    @Test
+    fun `strict mode escalates exactly the strict diagnostic names`() {
+        val diagnostics = KueryClientDiagnostics(strict = true, userConfiguredWarningLevels = emptySet())
+
+        assertThat(diagnostics.severitiesByName()).isEqualTo(
+            mapOf(
+                "KUERY_UNSAFE_SQL_STRING" to Severity.ERROR,
+                "KUERY_BIND_CALL_IN_SQL_TEMPLATE" to Severity.ERROR,
+                "KUERY_REDUNDANT_TRIM_INDENT" to Severity.WARNING,
+                "KUERY_SQL_SYNTAX" to Severity.ERROR,
+                "KUERY_SQL_DIALECT" to Severity.ERROR,
+            ),
+        )
+    }
+
+    @Test
+    fun `a user-configured diagnostic keeps its warning registration under strict mode`() {
+        for (name in KueryClientDiagnostics.STRICT_DIAGNOSTIC_NAMES) {
+            val diagnostics = KueryClientDiagnostics(strict = true, userConfiguredWarningLevels = setOf(name))
+
+            assertThat(diagnostics.severitiesByName()[name]).isEqualTo(Severity.WARNING)
+        }
+    }
+
+    private fun KueryClientDiagnostics.severitiesByName(): Map<String, Severity> = listOf(
+        KUERY_UNSAFE_SQL_STRING,
+        KUERY_BIND_CALL_IN_SQL_TEMPLATE,
+        KUERY_REDUNDANT_TRIM_INDENT,
+        KUERY_SQL_SYNTAX,
+        KUERY_SQL_DIALECT,
+    ).associate { it.nameAndSeverity() }
+
+    private fun AbstractKtDiagnosticFactory.nameAndSeverity(): Pair<String, Severity> = name to severity
+}

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/KueryCompilation.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/KueryCompilation.kt
@@ -19,6 +19,12 @@ internal fun sqlSyntaxCheckOption(value: String = "generic"): PluginOption = Plu
     value,
 )
 
+internal fun strictOption(value: String = "true"): PluginOption = PluginOption(
+    KueryClientCompilerCommandLineProcessor.PLUGIN_ID,
+    KueryClientCompilerCommandLineProcessor.STRICT_OPTION_NAME,
+    value,
+)
+
 // Single kotlin-compile-testing harness with the kuery-client plugin applied, shared by every
 // test that compiles a snippet, so the registrar/processor wiring lives in one place.
 @OptIn(ExperimentalCompilerApi::class)

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/StrictModeTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/StrictModeTest.kt
@@ -144,6 +144,76 @@ class StrictModeTest {
         assertThat(result.messages).doesNotContain(UNSAFE_MESSAGE)
     }
 
+    @Test
+    fun `an explicit -Xwarning-level downgrade of the syntax diagnostic wins over strict mode`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun broken() = Sql { +"SELECT * FORM users" }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption(), sqlSyntaxCheckOption("generic")),
+            kotlincArguments = listOf("-Xwarning-level=KUERY_SQL_SYNTAX:warning"),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains("w: ")
+        assertThat(result.messages).contains(SYNTAX_MESSAGE)
+    }
+
+    @Test
+    fun `an explicit -Xwarning-level downgrade of the dialect diagnostic wins over strict mode`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun upsert(id: Int, name: String) = Sql {
+                +"INSERT INTO users (id, name) VALUES (${'$'}id, ${'$'}name) ON DUPLICATE KEY UPDATE name = ${'$'}name"
+            }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption(), sqlSyntaxCheckOption("postgresql")),
+            kotlincArguments = listOf("-Xwarning-level=KUERY_SQL_DIALECT:warning"),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains("w: ")
+        assertThat(result.messages).contains(DIALECT_MESSAGE)
+    }
+
+    // The diagnostics container is created per compilation, so a strict compilation must not
+    // change the severities of a later non-strict compilation in the same JVM.
+    @Test
+    fun `strict severities do not leak into a later non-strict compilation in the same JVM`() {
+        // given: a strict compilation in this JVM
+        val strictResult = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun unsafe(fragment: String) = Sql { add(fragment) }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption()),
+        )
+        assertThat(strictResult.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+
+        // when: the same source compiles again without strict
+        val defaultResult = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun unsafe(fragment: String) = Sql { add(fragment) }
+            """.trimIndent(),
+        )
+
+        // then: the diagnostic is a warning again
+        assertThat(defaultResult.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(defaultResult.messages).contains("w: ")
+        assertThat(defaultResult.messages).contains(UNSAFE_MESSAGE)
+    }
+
     // The downgraded diagnostic cannot be asserted on here: the CLI omits warnings from a
     // failing compilation entirely (general K2 behavior, unrelated to strict mode). The
     // downgrade itself is proven by the test above; this one proves the other escalations are

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/StrictModeTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/StrictModeTest.kt
@@ -1,0 +1,178 @@
+package dev.hsbrysk.kuery.compiler
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+
+/**
+ * The `strict` plugin option registers the SQL-safety diagnostics with error severity instead of
+ * warning severity. The diagnostic names are unchanged, so `@Suppress` behaves identically at
+ * both severities.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+class StrictModeTest {
+    @Test
+    fun `an unsafe SQL string is a compile error under strict mode`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun unsafe(fragment: String) = Sql { add(fragment) }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption()),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains("e: ")
+        assertThat(result.messages).contains(UNSAFE_MESSAGE)
+    }
+
+    @Test
+    fun `an unsafe SQL string under strict mode can be suppressed by diagnostic name`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            @Suppress("KUERY_UNSAFE_SQL_STRING")
+            fun unsafe(fragment: String) = Sql { add(fragment) }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption()),
+        )
+
+        // then
+        assertThat(result.messages).doesNotContain(UNSAFE_MESSAGE)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
+    fun `a SQL syntax failure is a compile error under strict mode`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun broken() = Sql { +"SELECT * FORM users" }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption(), sqlSyntaxCheckOption("generic")),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains(SYNTAX_MESSAGE)
+    }
+
+    @Test
+    fun `a dialect violation is a compile error under strict mode`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun upsert(id: Int, name: String) = Sql {
+                +"INSERT INTO users (id, name) VALUES (${'$'}id, ${'$'}name) ON DUPLICATE KEY UPDATE name = ${'$'}name"
+            }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption(), sqlSyntaxCheckOption("postgresql")),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains(DIALECT_MESSAGE)
+    }
+
+    @Test
+    fun `strict mode leaves the redundant trimIndent diagnostic a warning`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(id: Int) = Sql { +"SELECT * FROM users WHERE id = ${'$'}id".trimIndent() }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption(), autoTrimIndentOption()),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains("This trimIndent() is redundant")
+    }
+
+    // An explicit -Xwarning-level always wins over strict mode: the configured diagnostic keeps
+    // its warning-severity registration, so the user's chosen level applies. (Registering it as
+    // an error would instead make kotlinc reject the flag — errors cannot be re-leveled.)
+    @Test
+    fun `an explicit -Xwarning-level downgrade wins over strict mode`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun unsafe(fragment: String) = Sql { add(fragment) }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption()),
+            kotlincArguments = listOf("-Xwarning-level=KUERY_UNSAFE_SQL_STRING:warning"),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains("w: ")
+        assertThat(result.messages).contains(UNSAFE_MESSAGE)
+    }
+
+    @Test
+    fun `an explicit -Xwarning-level disabled wins over strict mode`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun unsafe(fragment: String) = Sql { add(fragment) }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption()),
+            kotlincArguments = listOf("-Xwarning-level=KUERY_UNSAFE_SQL_STRING:disabled"),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).doesNotContain(UNSAFE_MESSAGE)
+    }
+
+    // The downgraded diagnostic cannot be asserted on here: the CLI omits warnings from a
+    // failing compilation entirely (general K2 behavior, unrelated to strict mode). The
+    // downgrade itself is proven by the test above; this one proves the other escalations are
+    // untouched by it.
+    @Test
+    fun `a diagnostic downgraded by -Xwarning-level does not affect the other strict-mode errors`() {
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun unsafe(fragment: String) = Sql { add(fragment) }
+
+            fun broken() = Sql { +"SELECT * FORM users" }
+            """.trimIndent(),
+            pluginOptions = listOf(strictOption(), sqlSyntaxCheckOption("generic")),
+            kotlincArguments = listOf("-Xwarning-level=KUERY_UNSAFE_SQL_STRING:warning"),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains(SYNTAX_MESSAGE)
+    }
+
+    companion object {
+        // The CLI renders message text without diagnostic names, so assertions match on
+        // distinctive fragments of the rendered messages.
+        private const val UNSAFE_MESSAGE = "This expression is not a string literal/template"
+        private const val SYNTAX_MESSAGE = "The SQL assembled from this block failed to parse"
+        private const val DIALECT_MESSAGE = "uses a feature the configured dialect does not support"
+    }
+}

--- a/kuery-client-gradle-plugin/api/kuery-client-gradle-plugin.api
+++ b/kuery-client-gradle-plugin/api/kuery-client-gradle-plugin.api
@@ -1,6 +1,7 @@
 public abstract interface class dev/hsbrysk/kuery/gradle/KueryClientExtension {
 	public abstract fun getAutoTrimIndent ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSqlSyntaxCheck ()Lorg/gradle/api/provider/Property;
+	public abstract fun getStrict ()Lorg/gradle/api/provider/Property;
 }
 
 public final class dev/hsbrysk/kuery/gradle/KueryClientGradlePlugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {

--- a/kuery-client-gradle-plugin/functional-test/src/test/kotlin/dev/hsbrysk/kuery/gradle/PublishedPluginFunctionalTest.kt
+++ b/kuery-client-gradle-plugin/functional-test/src/test/kotlin/dev/hsbrysk/kuery/gradle/PublishedPluginFunctionalTest.kt
@@ -127,6 +127,109 @@ class PublishedPluginFunctionalTest {
     }
 
     @Test
+    fun `strict set via the kueryClient extension makes an unsafe SQL string a compile error`() {
+        writeSettings()
+        writeBuild(
+            """
+            plugins {
+                kotlin("jvm") version "$kotlinVersion"
+                id("dev.hsbrysk.kuery-client") version "$version"
+            }
+
+            kueryClient {
+                strict = true
+            }
+
+            dependencies {
+                implementation("dev.hsbrysk.kuery-client:kuery-client-core:$version")
+            }
+            """,
+        )
+        writeSource(
+            "src/main/kotlin/Main.kt",
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun unsafe(fragment: String) = Sql { add(fragment) }
+            """,
+        )
+
+        val output = runner("compileKotlin").buildAndFail().output
+
+        assertThat(output).contains("e: ")
+        assertThat(output).contains("This expression is not a string literal/template")
+    }
+
+    @Test
+    fun `an unsafe SQL string under strict can still be suppressed by diagnostic name`() {
+        writeSettings()
+        writeBuild(
+            """
+            plugins {
+                kotlin("jvm") version "$kotlinVersion"
+                id("dev.hsbrysk.kuery-client") version "$version"
+            }
+
+            kueryClient {
+                strict = true
+            }
+
+            dependencies {
+                implementation("dev.hsbrysk.kuery-client:kuery-client-core:$version")
+            }
+            """,
+        )
+        writeSource(
+            "src/main/kotlin/Main.kt",
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            @Suppress("KUERY_UNSAFE_SQL_STRING")
+            fun unsafe(fragment: String) = Sql { add(fragment) }
+            """,
+        )
+
+        val output = runner("compileKotlin").build().output
+
+        assertThat(output).doesNotContain("This expression is not a string literal/template")
+    }
+
+    @Test
+    fun `strict escalates sqlSyntaxCheck warnings to errors`() {
+        writeSettings()
+        writeBuild(
+            """
+            plugins {
+                kotlin("jvm") version "$kotlinVersion"
+                id("dev.hsbrysk.kuery-client") version "$version"
+            }
+
+            kueryClient {
+                strict = true
+                sqlSyntaxCheck = "mysql"
+            }
+
+            dependencies {
+                implementation("dev.hsbrysk.kuery-client:kuery-client-core:$version")
+            }
+            """,
+        )
+        writeSource(
+            "src/main/kotlin/Main.kt",
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun broken() = Sql { +"SELECT * FORM users" }
+            """,
+        )
+
+        val output = runner("compileKotlin").buildAndFail().output
+
+        assertThat(output).contains("e: ")
+        assertThat(output).contains("The SQL assembled from this block failed to parse")
+    }
+
+    @Test
     fun `in a multiplatform project the compiler plugin is applied to the JVM compilation only`() {
         writeSettings()
         writeBuild(

--- a/kuery-client-gradle-plugin/src/main/kotlin/dev/hsbrysk/kuery/gradle/KueryClientExtension.kt
+++ b/kuery-client-gradle-plugin/src/main/kotlin/dev/hsbrysk/kuery/gradle/KueryClientExtension.kt
@@ -31,4 +31,23 @@ interface KueryClientExtension {
      * `@Suppress("KUERY_SQL_SYNTAX")` / `@Suppress("KUERY_SQL_DIALECT")`.
      */
     val sqlSyntaxCheck: Property<String>
+
+    /**
+     * When true, the compiler plugin registers the SQL-safety diagnostics that are warnings by
+     * default as compile errors instead: `KUERY_UNSAFE_SQL_STRING`, and — when [sqlSyntaxCheck]
+     * is enabled — `KUERY_SQL_SYNTAX` / `KUERY_SQL_DIALECT`. Default: false.
+     *
+     * The escalated set may grow in minor releases as new safety diagnostics are added —
+     * enabling strict mode opts into those too.
+     *
+     * `@Suppress("KUERY_...")` on the enclosing declaration keeps working for individual call
+     * sites, and `addUnsafe()` + `bind()` remain the sanctioned way to build SQL dynamically.
+     * An explicit `-Xwarning-level` for a diagnostic always wins — strict only changes the
+     * default severity, so a single diagnostic can still be lowered back to a warning
+     * module-wide. `KUERY_REDUNDANT_TRIM_INDENT` stays a warning — a style issue, not a safety
+     * issue.
+     *
+     * See https://kuery-client.hsbrysk.dev/compiler-safety-check for details.
+     */
+    val strict: Property<Boolean>
 }

--- a/kuery-client-gradle-plugin/src/main/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePlugin.kt
+++ b/kuery-client-gradle-plugin/src/main/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePlugin.kt
@@ -13,12 +13,16 @@ class KueryClientGradlePlugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
         val extension = target.extensions.create(EXTENSION_NAME, KueryClientExtension::class.java)
         extension.autoTrimIndent.convention(false)
+        extension.strict.convention(false)
     }
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val extension = kotlinCompilation.target.project.extensions.getByType(KueryClientExtension::class.java)
         return extension.autoTrimIndent
             .zip(extension.sqlSyntaxCheck.orElse("")) { autoTrimIndent, sqlSyntaxCheck ->
+                autoTrimIndent to sqlSyntaxCheck
+            }
+            .zip(extension.strict) { (autoTrimIndent, sqlSyntaxCheck), strict ->
                 // Only emit an option when it deviates from the compiler plugin's default, so a
                 // build whose compiler-plugin artifact resolves to an older kuery-client-compiler
                 // (which would reject the unknown option) keeps working as long as the feature is
@@ -40,6 +44,7 @@ class KueryClientGradlePlugin : KotlinCompilerPluginSupportPlugin {
                         }
                         add(SubpluginOption("sqlSyntaxCheck", value))
                     }
+                    if (strict) add(SubpluginOption("strict", "true"))
                 }
             }
     }

--- a/kuery-client-gradle-plugin/src/test/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePluginTest.kt
+++ b/kuery-client-gradle-plugin/src/test/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePluginTest.kt
@@ -159,6 +159,20 @@ class KueryClientGradlePluginTest {
             .contains("must be one of generic, ansi, oracle, mysql, sqlserver, mariadb, postgresql, h2, but was 'db2'")
     }
 
+    @Test
+    fun `strict is passed through when enabled`() {
+        // given
+        val project = ProjectBuilder.builder().build()
+        plugin.apply(project)
+        project.extensions.getByType(KueryClientExtension::class.java).strict.set(true)
+
+        // when
+        val options = plugin.applyToCompilation(compilation(project)).get()
+
+        // then
+        assertThat(options.single().toEqualsString()).isEqualTo("strict=true")
+    }
+
     private fun compilation(platformType: KotlinPlatformType): KotlinCompilation<*> = mockk {
         every { target.platformType } returns platformType
     }


### PR DESCRIPTION
## Summary

Unless a user sets `allWarningsAsErrors`, the SQL-safety diagnostics only warn, so a build containing SQL the compiler plugin cannot prove safe still succeeds — at odds with the "safe by design" positioning. This adds an opt-in strict mode:

```kotlin
kueryClient {
    strict = true
}
```

When enabled, these diagnostics become compile errors:

- `KUERY_UNSAFE_SQL_STRING`
- `KUERY_SQL_SYNTAX` / `KUERY_SQL_DIALECT` (only fire when `sqlSyntaxCheck` is enabled)

The escalated set may grow in minor releases as new safety diagnostics are added — enabling strict opts into those too (documented in the KDoc and docs).

`KUERY_REDUNDANT_TRIM_INDENT` stays a warning (style, not safety). `KUERY_BIND_CALL_IN_SQL_TEMPLATE` is already an unconditional error (#418).

## Design

**The severity switch lives in the compiler plugin.** `strict` travels as a regular plugin option (like `autoTrimIndent` / `sqlSyntaxCheck`), and `KueryClientDiagnostics` becomes a per-compilation class whose factory delegates pick `error0`/`warning0` per diagnostic; the checkers take the container instance.

**An explicit `-Xwarning-level` always wins over strict.** The registrar reads the user's `-Xwarning-level` entries (`AnalysisFlags.warningLevels`) and keeps those diagnostics registered at warning severity, so the user's chosen level applies as usual — kotlinc would otherwise reject the flag (errors cannot be re-leveled). Strict therefore only changes the **default** severity, and a single diagnostic can still be lowered back to a warning (or disabled) module-wide:

```kotlin
kueryClient { strict = true }
kotlin {
    compilerOptions {
        // keep everything else strict, but let the dialect check stay advisory
        freeCompilerArgs.add("-Xwarning-level=KUERY_SQL_DIALECT:warning")
    }
}
```

Other properties:

- The diagnostic names are unchanged, so **`@Suppress("KUERY_...")` keeps working at either severity** (verified by tests); `addUnsafe()` + `bind()` remain the sanctioned escape hatch.
- No `-X` flag injection from the Gradle plugin (the first iteration did this and clashed with users' own `-Xwarning-level` flags via kotlinc's duplicate-flag hard error); works identically for direct compiler-plugin users.
- Named `strict`, not `strictSqlSafety`: the `kueryClient { }` block already provides the namespace, and the general name stays accurate as the escalated set grows.
- Default stays off; flipping the default is a future (major-version) discussion, same treatment as `autoTrimIndent`.

## Tests

- Compiler (`StrictModeTest`, 8 tests): unsafe SQL / syntax failure / dialect violation are compile errors under strict; `@Suppress` still works under strict; `KUERY_REDUNDANT_TRIM_INDENT` stays a warning; explicit `-Xwarning-level` downgrade and `:disabled` win over strict; a downgraded diagnostic does not affect the other escalations.
- CLI processor: `strict` accepts only `true`/`false` (shared `parseBoolean` path).
- Gradle plugin unit tests: `strict=true` emits the `strict` SubpluginOption; nothing is emitted at the default (older compiler artifacts keep working).
- TestKit functional tests (published-plugin path): unsafe SQL fails to compile under strict; `@Suppress` still compiles; `sqlSyntaxCheck` warnings become errors. 8 functional tests all passing.

## Docs

- `compiler-safety-check.md`: "Strict mode" section (mechanism, escape hatches, explicit `-Xwarning-level` wins with example); "Configuring the severity manually" covers both directions.
- `sql-syntax-check.md`: notes the escalation under strict mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)