### PR TITLE
Reorganize the compiler-check docs into a Compile-Time Checks hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ SELECT * FROM users WHERE user_id = :p0  -- :p0 = userId, bound as a named param
       cost. Kuery Client emphasizes writing SQL as it is.
 - 🛡️ **Safe by design**
     - String interpolation is converted into bind parameters by the compiler plugin — never concatenated into
-      the SQL text. A built-in [compiler safety check](https://kuery-client.hsbrysk.dev/compiler-safety-check)
-      warns when it detects a SQL string that cannot be converted safely.
+      the SQL text. Built-in [compile-time checks](https://kuery-client.hsbrysk.dev/compiler-safety-check)
+      warn when they detect a SQL string that cannot be converted safely — and can be escalated to compile
+      errors with the [strict option](https://kuery-client.hsbrysk.dev/compiler-safety-check#strict-mode).
 - 🍃 **Based on spring-data-r2dbc and spring-data-jdbc**
     - Kuery Client is implemented on top of spring-data-r2dbc (coroutines) and spring-data-jdbc (blocking).
       Use whichever you prefer. You can keep using Spring's ecosystem as is, such as `@Transactional`.
@@ -164,7 +165,7 @@ val user: User? = kueryClient
 More details are on the [document site](https://kuery-client.hsbrysk.dev/):
 
 - [Basics](https://kuery-client.hsbrysk.dev/basics) — the SQL builder, dynamic SQL, fetch operations
-- [Compiler Safety Check](https://kuery-client.hsbrysk.dev/compiler-safety-check) — how unsafe SQL strings are caught at compile time
+- [Compile-Time Checks](https://kuery-client.hsbrysk.dev/compiler-safety-check) — the compiler diagnostics that catch unsafe SQL, and the strict option
 - [SQL Syntax Check](https://kuery-client.hsbrysk.dev/sql-syntax-check) — opt-in compile-time validation of your SQL syntax
 - [Transaction](https://kuery-client.hsbrysk.dev/transaction) / [Type Conversion](https://kuery-client.hsbrysk.dev/type-conversion) / [Row Mapping](https://kuery-client.hsbrysk.dev/row-mapping)
 - [Observation](https://kuery-client.hsbrysk.dev/observation) — Micrometer-based metrics, tracing, and logging

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -79,7 +79,7 @@ export default defineConfig({
                 items: [
                     {text: "Type Conversion", link: '/type-conversion'},
                     {text: "Observation", link: '/observation'},
-                    {text: "Compiler Safety Check", link: '/compiler-safety-check'},
+                    {text: "Compile-Time Checks", link: '/compiler-safety-check'},
                     {text: "SQL Syntax Check", link: '/sql-syntax-check'},
                     {text: "Helpers", link: '/helpers'},
                 ]

--- a/docs/compiler-safety-check.md
+++ b/docs/compiler-safety-check.md
@@ -1,14 +1,29 @@
 ---
-description: The KUERY_UNSAFE_SQL_STRING compiler warning that catches SQL strings the plugin cannot convert into bind parameters, and the strict option that turns the safety warnings into compile errors.
+description: All compile-time diagnostics reported by the kuery-client compiler plugin — unsafe SQL strings, bind() misuse, SQL syntax validation, redundant trimIndent — and the strict option that escalates the safety warnings into compile errors.
 ---
 
-# Compiler Safety Check
+# Compile-Time Checks
 
-The kuery-client compiler plugin converts string interpolation inside
-`SqlBuilder.add()` / `+"..."` into named bind parameters. This conversion
-only works when the SQL string is written **directly as a string
-literal/template at the call site**. If you pass anything else — for
-example a variable — the plugin cannot see the interpolation, and the
+The kuery-client compiler plugin does more than rewrite string interpolation into bind
+parameters — it also **checks your SQL code at compile time**. This page is the overview of
+every diagnostic the plugin can report:
+
+| Diagnostic | Fires when | Severity | Enabled |
+|---|---|---|---|
+| [`KUERY_UNSAFE_SQL_STRING`](#unsafe-sql-strings) | `add()` / `+` receives a string the plugin cannot analyze | warning ([`strict`](#strict-mode) → error) | always |
+| [`KUERY_BIND_CALL_IN_SQL_TEMPLATE`](#bind-in-a-string-template) | `bind()` is called inside a string template | always error | always |
+| [`KUERY_SQL_SYNTAX`](/sql-syntax-check) | Statically-known SQL fails to parse | warning ([`strict`](#strict-mode) → error) | [`sqlSyntaxCheck`](/sql-syntax-check) |
+| [`KUERY_SQL_DIALECT`](/sql-syntax-check#choosing-a-dialect) | SQL uses a feature the dialect lacks | warning ([`strict`](#strict-mode) → error) | [`sqlSyntaxCheck` with a dialect](/sql-syntax-check#choosing-a-dialect) |
+| [`KUERY_REDUNDANT_TRIM_INDENT`](#redundant-trimindent) | An explicit `trimIndent()` is redundant under auto-trim | warning (style — never escalated) | [`autoTrimIndent`](/basics#automatic-trimindent-opt-in) |
+
+Every diagnostic can be [suppressed per declaration or reconfigured project-wide](#configuring-the-severity-manually)
+with the standard Kotlin mechanisms (`@Suppress`, `-Xwarning-level`).
+
+## Unsafe SQL strings
+
+The plugin's conversion of string interpolation into named bind parameters only works when the
+SQL string is written **directly as a string literal/template at the call site**. If you pass
+anything else — for example a variable — the plugin cannot see the interpolation, and the
 string would be executed as raw SQL.
 
 To prevent this from happening silently, the compiler plugin reports a
@@ -43,7 +58,7 @@ time, so any interpolation in it is rewritten into bind parameters:
   recursively): `if (asc) "ORDER BY id" else "ORDER BY id DESC"`. A branch that only throws —
   e.g. `else -> error("unsupported sort")` — is also fine, since it never produces a SQL string.
 
-## Responding to the warning
+### Responding to the warning
 
 In order of preference:
 
@@ -52,6 +67,43 @@ In order of preference:
    safely. See [Basics](/basics#logic-such-as-if-and-for-etc).
 2. **Suppress the warning** with `@Suppress("KUERY_UNSAFE_SQL_STRING")` on the declaration, when
    you know the string is safe but the checker cannot see it.
+
+## `bind()` in a string template
+
+[`bind()`](/helpers#you-can-also-write-your-own-helper) only makes sense together with
+`addUnsafe()`. Calling it inside a string template passed to `add()` / `+` is reported as a
+`KUERY_BIND_CALL_IN_SQL_TEMPLATE` compile **error**:
+
+```kotlin
+kueryClient.sql {
+    +"SELECT * FROM users WHERE user_id = ${bind(userId)}" // KUERY_BIND_CALL_IN_SQL_TEMPLATE
+}
+```
+
+Interpolated values there are bound automatically, so the placeholder name returned by `bind()`
+(e.g. `:p0`) would itself be re-bound as a new parameter value — the query would compare
+`user_id` against the literal string `:p0` and silently match nothing. Since there is no valid
+program in which this may be left as-is, it is an **error regardless of strict mode**.
+Interpolate the value directly (`$userId` instead of `${bind(userId)}`), or use `addUnsafe()`
+when you need `bind()` — see [Helpers](/helpers#you-can-also-write-your-own-helper).
+
+## SQL syntax validation (opt-in)
+
+With the `sqlSyntaxCheck` option enabled, the plugin also validates the **SQL text itself** at
+compile time: blocks whose complete statement is statically known are assembled exactly like at
+runtime and run through a SQL parser. A parse failure is reported as `KUERY_SQL_SYNTAX`, and —
+when a dialect is configured — a feature the dialect does not support as `KUERY_SQL_DIALECT`.
+This check has its own page: see [SQL Syntax Check](/sql-syntax-check).
+
+## Redundant `trimIndent()`
+
+With the [`autoTrimIndent`](/basics#automatic-trimindent-opt-in) option enabled, every string
+passed to `add()` / `+` is trimmed automatically, so an explicit `.trimIndent()` left behind is
+redundant — it prevents the compile-time trimming and only adds an extra runtime trim. The
+plugin reports a `KUERY_REDUNDANT_TRIM_INDENT` **warning** for such calls; remove them when
+enabling the option. Details are in [Basics](/basics#automatic-trimindent-opt-in).
+
+This is a style issue, not a safety issue, so [strict mode](#strict-mode) does not escalate it.
 
 ## Strict mode
 
@@ -89,21 +141,22 @@ kotlin {
 
 ## Configuring the severity manually
 
-The checks are regular Kotlin compiler diagnostics, so `-Xwarning-level` works as usual —
-without strict mode to escalate a single diagnostic, with strict mode to lower one back (see
-above), or to disable one project-wide (not recommended):
+The checks are regular Kotlin compiler diagnostics, so the standard Kotlin mechanisms apply to
+every diagnostic in the table (except `KUERY_BIND_CALL_IN_SQL_TEMPLATE`, whose error severity
+cannot be lowered):
 
-```kotlin
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.add("-Xwarning-level=KUERY_UNSAFE_SQL_STRING:error")
-    }
-}
-```
+- **Suppress for specific code** with `@Suppress("<name>")` on the enclosing declaration, e.g.
+  `@Suppress("KUERY_SQL_SYNTAX")`. This also works for diagnostics escalated to errors.
+- **Escalate a single diagnostic** without strict mode:
 
-`allWarningsAsErrors` (`-Werror`) likewise turns all warnings into errors.
+  ```kotlin
+  kotlin {
+      compilerOptions {
+          freeCompilerArgs.add("-Xwarning-level=KUERY_UNSAFE_SQL_STRING:error")
+      }
+  }
+  ```
 
-## See also
-
-The compiler plugin can also validate the SQL text itself at compile time — see the opt-in
-[SQL Syntax Check](/sql-syntax-check).
+- **Lower one back to a warning** with strict mode enabled (see [above](#strict-mode)), or
+  **disable one project-wide** with `-Xwarning-level=<name>:disabled` (not recommended).
+- `allWarningsAsErrors` (`-Werror`) likewise turns all warnings into errors.

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -57,9 +57,8 @@ Some SQL fragments cannot be expressed with plain string interpolation — for e
 of placeholders. In such cases, use `addUnsafe` and `bind` (the `values` function above is a good example).
 
 `bind` only makes sense together with `addUnsafe`. Calling it inside a string template passed to `add()` / `+`
-is a compile error (`KUERY_BIND_CALL_IN_SQL_TEMPLATE`): interpolated values there are bound automatically, so
-the placeholder returned by `bind` would itself be re-bound as a value and the SQL would compare against the
-literal string `:pN`.
+is a compile error (`KUERY_BIND_CALL_IN_SQL_TEMPLATE`) — see
+[Compile-Time Checks](/compiler-safety-check#bind-in-a-string-template) for why.
 
 Note that `addUnsafe` and `bind` are annotated with `@DelicateKueryClientApi` and require an explicit opt-in, since
-misusing them can lead to SQL injection. See [Compiler Safety Check](/compiler-safety-check) for details.
+misusing them can lead to SQL injection. See [Compile-Time Checks](/compiler-safety-check) for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ features:
     details: ORM libraries are convenient, but they each require learning their own DSL, which we believe is a steep cost. Kuery Client emphasizes writing SQL as it is.
   - icon: 🛡️
     title: Safe by design
-    details: String interpolation is converted into bind parameters by the compiler plugin — never concatenated into the SQL text. A built-in compiler safety check warns when a SQL string cannot be converted safely.
+    details: String interpolation is converted into bind parameters by the compiler plugin — never concatenated into the SQL text. Built-in compile-time checks warn when a SQL string cannot be converted safely.
     link: /compiler-safety-check
   - icon: 🍃
     title: Based on spring-data-r2dbc and spring-data-jdbc

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -31,8 +31,9 @@ SELECT * FROM users WHERE user_id = :p0  -- :p0 = userId, bound as a named param
       cost. Kuery Client emphasizes writing SQL as it is.
 - 🛡️ **Safe by design**
     - String interpolation is converted into bind parameters by the compiler plugin — never concatenated into
-      the SQL text. A built-in [compiler safety check](/compiler-safety-check) warns when it detects a SQL
-      string that cannot be converted safely.
+      the SQL text. Built-in [compile-time checks](/compiler-safety-check) warn when they detect a SQL
+      string that cannot be converted safely — and can be escalated to compile errors with the
+      [strict option](/compiler-safety-check#strict-mode).
 - 🍃 **Based on spring-data-r2dbc and spring-data-jdbc**
     - Kuery Client is implemented on top of spring-data-r2dbc (coroutines) and spring-data-jdbc (blocking).
       Use whichever you prefer. You can keep using Spring's ecosystem as is, such as `@Transactional`.

--- a/docs/sql-syntax-check.md
+++ b/docs/sql-syntax-check.md
@@ -18,7 +18,7 @@ kueryClient {
 
 A block whose SQL fails to parse is then reported as a `KUERY_SQL_SYNTAX` **warning** (or a
 compile **error** when `strict` is enabled — see
-[Compiler Safety Check](/compiler-safety-check#strict-mode)), anchored to the offending line:
+[Compile-Time Checks](/compiler-safety-check#strict-mode)), anchored to the offending line:
 
 ```kotlin
 kueryClient.sql {
@@ -61,7 +61,7 @@ at compile time:
 - Helper functions that are dynamic inside, overridable, or compiled in another module
 - `addUnsafe()` (dynamic SQL is out of the check's scope by design)
 - Non-literal `add()` arguments such as variables (those already draw
-  [`KUERY_UNSAFE_SQL_STRING`](/compiler-safety-check))
+  [`KUERY_UNSAFE_SQL_STRING`](/compiler-safety-check#unsafe-sql-strings))
 
 This mirrors how compile-time-checked SQL works elsewhere (e.g. Rust's sqlx): statements that
 are fully known are verified, dynamically assembled ones are not — no false alarms on dynamic
@@ -119,13 +119,9 @@ fun listUsersWithVendorSyntax(): List<User> = ...
 
 ## Configuring the severity
 
-Like every diagnostic of the plugin, the standard Kotlin mechanisms apply — note there are two
-diagnostic names, `KUERY_SQL_SYNTAX` and `KUERY_SQL_DIALECT`, configured independently:
-
-- Treat them as errors: `-Xwarning-level=KUERY_SQL_SYNTAX:error` (and
-  `-Xwarning-level=KUERY_SQL_DIALECT:error`), or enable `allWarningsAsErrors` (`-Werror`)
-- Disable them for specific code with `@Suppress("KUERY_SQL_SYNTAX")` /
-  `@Suppress("KUERY_SQL_DIALECT")`, or project-wide with
-  `-Xwarning-level=<name>:disabled` (or simply leave `sqlSyntaxCheck` unset)
+Like every diagnostic of the plugin, the standard Kotlin mechanisms (`strict` mode, `@Suppress`,
+`-Xwarning-level`) apply — note there are two diagnostic names, `KUERY_SQL_SYNTAX` and
+`KUERY_SQL_DIALECT`, configured independently. See
+[Compile-Time Checks](/compiler-safety-check#configuring-the-severity-manually) for the details.
 
 The option is unset by default, so existing builds are unaffected.


### PR DESCRIPTION
## Summary

The compiler plugin now reports five diagnostics (`KUERY_UNSAFE_SQL_STRING`, `KUERY_BIND_CALL_IN_SQL_TEMPLATE`, `KUERY_SQL_SYNTAX`, `KUERY_SQL_DIALECT`, `KUERY_REDUNDANT_TRIM_INDENT`), but the docs described them in scattered places: the bind-call error existed only as a paragraph in Helpers, the redundant-trimIndent warning only in Basics, and severity configuration was duplicated between two pages. This PR reworks `compiler-safety-check.md` into a **"Compile-Time Checks"** hub page (follow-up to #418/#419, as planned).

## Changes

- **Overview table** at the top of the page listing all five diagnostics — trigger, default severity, `strict` escalation, and the option that enables each — with links to the detail section or page
- **New section for `KUERY_BIND_CALL_IN_SQL_TEMPLATE`** with an example and the reasoning for its unconditional error severity (previously only a paragraph in Helpers, which now links here)
- **Short sections** for the opt-in SQL syntax validation and for `KUERY_REDUNDANT_TRIM_INDENT`, pointing to their detail pages (`sql-syntax-check.md` stays the deep-dive page; Basics keeps the auto-trim details)
- **Severity configuration unified**: the hub's "Configuring the severity manually" section is now the single home for `@Suppress` / `-Xwarning-level` guidance; the duplicated section in `sql-syntax-check.md` was reduced to a link
- **URL kept**: the page stays at `/compiler-safety-check` — only the title and sidebar entry change to "Compile-Time Checks", so no existing links break
- Cross-references updated (`helpers.md`, `introduction.md`, `index.md`), and the README / introduction feature blurbs now mention the `strict` option

## Verification

- `npm run docs:build` (VitePress dead-link check) passes
- All referenced heading anchors verified in the built HTML (`#unsafe-sql-strings`, `#bind-in-a-string-template`, `#redundant-trimindent`, `#strict-mode`, `#configuring-the-severity-manually`, `/basics#automatic-trimindent-opt-in`, `/helpers#you-can-also-write-your-own-helper`)
- Rendered pages checked in the browser via `vitepress preview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)