### PR TITLE
Rebalance the docs home feature grid into 3x2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,10 +20,13 @@ features:
     details: ORM libraries are convenient, but they each require learning their own DSL, which we believe is a steep cost. Kuery Client emphasizes writing SQL as it is.
   - icon: 🛡️
     title: Safe by design
-    details: String interpolation is converted into bind parameters by the compiler plugin — never concatenated into the SQL text. Built-in compile-time checks warn when a SQL string cannot be converted safely.
+    details: String interpolation is converted into bind parameters by the compiler plugin — never concatenated into the SQL text. SQL injection is prevented by construction.
+  - icon: ✅
+    title: Compile-time checks
+    details: The compiler plugin warns when a SQL string cannot be converted safely, and can optionally validate SQL syntax — mistakes surface at compile time, not in production.
     link: /compiler-safety-check
   - icon: 🍃
-    title: Based on spring-data-r2dbc and spring-data-jdbc
+    title: Built on Spring Data
     details: Kuery Client is implemented on top of spring-data-r2dbc and spring-data-jdbc. Use whichever you prefer. You can keep using Spring's ecosystem as is, such as @Transactional.
   - icon: 🔭
     title: Observability


### PR DESCRIPTION
## Summary

The docs home page listed 5 features, which the VitePress default theme renders as a 4-column grid — leaving the "Extensible" card orphaned alone on a second row. This PR rebalances the grid to a clean 3x2 layout by going to 6 cards:

- **New "Compile-time checks" card** — the compile-time checks story was previously squeezed into the "Safe by design" card's details. It now has its own card, which also takes over the link to the Compile-Time Checks hub (`/compiler-safety-check`) introduced in #420.
- **"Safe by design"** now focuses solely on the bind-parameter conversion (SQL injection prevented by construction).
- **Title shortened**: "Based on spring-data-r2dbc and spring-data-jdbc" → "Built on Spring Data" — the old title wrapped onto two lines and made the card heights uneven; the module names remain in the card details.

## Verification

- `npm run docs:build` passes.
- Verified in the dev-server preview that the six cards render as a balanced 3x2 grid on wide viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)