### PR TITLE
Mention the Gradle 8.4 minimum requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ spring-data code, so you can start small.
 
 ## Getting Started
 
-Kuery Client requires Java 17 or later.
+Kuery Client requires Java 17 or later and Gradle 8.4 or later.
 
 ### Install
 


### PR DESCRIPTION
## Summary

The README's Getting Started section stated only "Java 17 or later", while the docs ([Getting Started](https://kuery-client.hsbrysk.dev/getting-started), [Compatibility](https://kuery-client.hsbrysk.dev/compatibility)) declare Gradle 8.4 as the minimum supported version for the Gradle plugin. Since the README is intentionally self-contained, it should state both requirements.

This adds "and Gradle 8.4 or later" to the existing requirement sentence, matching the docs' wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)