### PR TITLE
Fix FetchSpec class KDoc contradicting flow execution timing

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
@@ -58,8 +58,9 @@ public interface KueryClient {
     /**
      * Specifies how to execute the built SQL and retrieve the results.
      *
-     * Each terminal operation ([singleMap], [single], [list], [flow], [rowsUpdated],
-     * [generatedValues], ...) executes the statement when invoked.
+     * Each terminal operation ([singleMap], [single], [list], [rowsUpdated],
+     * [generatedValues], ...) executes the statement when invoked, except [flowMap] and
+     * [flow], which execute it when the returned [Flow] is collected.
      *
      * Rows are mapped to the specified type as follows: simple scalar types (numbers, strings,
      * date/time types, ...) are read from the first column of the row, while other types


### PR DESCRIPTION
## Summary

The class-level KDoc on `KueryClient.FetchSpec` stated:

> Each terminal operation ([singleMap], [single], [list], [flow], [rowsUpdated], [generatedValues], ...) executes the statement when invoked.

However, `flowMap` / `flow` return a cold `Flow` and execute the query only when the returned `Flow` is collected — as their own method-level KDoc correctly states, and as `FlowExecutionTimingTest` pins (`flow defers query execution until collected`).

This rewords the class-level sentence to exclude the two flow operations and state their actual timing.

`KueryBlockingClient.FetchSpec` is intentionally untouched: `sequence()` really does execute the query eagerly (pinned by `SequenceExecutionTimingTest`), so its class KDoc is accurate.

KDoc-only change; no behavior or ABI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)