### PR TITLE
Accept Java constants in the unsafe SQL string check

### DIFF
--- a/docs/compiler-safety-check.md
+++ b/docs/compiler-safety-check.md
@@ -88,7 +88,7 @@ kueryClient.sql {
     """.trimMargin()
 }
 
-// const val
+// const val; a Java constant (static final String with a constant initializer) works the same
 const val SELECT_ALL_USERS = "SELECT * FROM users"
 kueryClient.sql {
     +SELECT_ALL_USERS

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/CompileTimeSafeSqlStrings.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/CompileTimeSafeSqlStrings.kt
@@ -2,6 +2,7 @@ package dev.hsbrysk.kuery.compiler.fir
 
 import dev.hsbrysk.kuery.compiler.misc.CallableIds
 import org.jetbrains.kotlin.fir.declarations.utils.isConst
+import org.jetbrains.kotlin.fir.declarations.utils.isStatic
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
@@ -11,8 +12,12 @@ import org.jetbrains.kotlin.fir.expressions.FirWhenBranch
 import org.jetbrains.kotlin.fir.expressions.FirWhenExpression
 import org.jetbrains.kotlin.fir.expressions.unwrapArgument
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirFieldSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.types.isNothing
 import org.jetbrains.kotlin.fir.types.resolvedType
+import org.jetbrains.kotlin.types.ConstantValueKind
 
 /**
  * The single definition of a "compile-time-safe" SQL string shape, shared by every FIR checker
@@ -28,8 +33,10 @@ internal object CompileTimeSafeSqlStrings {
         is FirLiteralExpression -> true
         // "SELECT ... $id" (converted into bind parameters by the IR transformation)
         is FirStringConcatenationCall -> true
-        // reference to a const val (a compile-time constant)
-        is FirPropertyAccessExpression -> expression.calleeReference.toResolvedCallableSymbol()?.isConst == true
+        // reference to a compile-time String/Char constant: a Kotlin const val, or a Java
+        // constant field — FIR2IR inlines both into the SQL text (mirrors
+        // SqlTextReconstruction.classifyValue)
+        is FirPropertyAccessExpression -> expression.isConstantRead()
         // "...".trimIndent() / "...".trimMargin(marginPrefix = <literal>)
         is FirFunctionCall ->
             expression.calleeReference.toResolvedCallableSymbol()?.callableId in ALLOWED_CHAIN_METHODS &&
@@ -43,6 +50,21 @@ internal object CompileTimeSafeSqlStrings {
                     ?.let { it.resolvedType.isNothing || isCompileTimeSafe(it) } == true
             }
         else -> false
+    }
+
+    // A Java static final field is a compile-time constant only when it carries a constant
+    // initializer (the ConstantValue attribute); fields computed at class initialization
+    // (e.g. java.io.File.separator) stay unsafe.
+    @OptIn(SymbolInternals::class)
+    private fun FirPropertyAccessExpression.isConstantRead(): Boolean {
+        val symbol = calleeReference.toResolvedCallableSymbol()
+        return when {
+            symbol is FirPropertySymbol && symbol.isConst -> true
+            symbol is FirFieldSymbol && symbol.isStatic && symbol.fir.isVal ->
+                (symbol.fir.initializer as? FirLiteralExpression)?.kind
+                    .let { it == ConstantValueKind.String || it == ConstantValueKind.Char }
+            else -> false
+        }
     }
 }
 

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
@@ -259,6 +259,49 @@ class UnsafeSqlStringCheckerTest {
     }
 
     @Test
+    fun `no warning when a Java constant is passed to add`() {
+        // FIR2IR inlines Java compile-time constants (static final String/Char fields with a
+        // constant initializer) into the SQL text just like Kotlin const vals, so the text is
+        // fully determined at compile time.
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query() {
+                Sql { add(javax.xml.XMLConstants.XML_NS_PREFIX) }
+                Sql { +javax.xml.XMLConstants.XML_NS_PREFIX }
+            }
+            """.trimIndent(),
+            allWarningsAsErrors = true,
+        )
+
+        // then
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
+    fun `warn when a non-constant Java static field is passed to add`() {
+        // java.io.File.separator is static final but computed at class initialization (no
+        // ConstantValue attribute), so its value is not known at compile time.
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query() {
+                Sql { add(java.io.File.separator) }
+            }
+            """.trimIndent(),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
     fun `no warning for extension function helpers writing common query parts`() {
         // Mirrors the documented helper style: common WHERE clauses etc. written as
         // SqlBuilder extension functions using add/unaryPlus with string templates.

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
@@ -58,8 +58,9 @@ public interface KueryClient {
     /**
      * Specifies how to execute the built SQL and retrieve the results.
      *
-     * Each terminal operation ([singleMap], [single], [list], [flow], [rowsUpdated],
-     * [generatedValues], ...) executes the statement when invoked.
+     * Each terminal operation ([singleMap], [single], [list], [rowsUpdated],
+     * [generatedValues], ...) executes the statement when invoked, except [flowMap] and
+     * [flow], which execute it when the returned [Flow] is collected.
      *
      * Rows are mapped to the specified type as follows: simple scalar types (numbers, strings,
      * date/time types, ...) are read from the first column of the row, while other types


### PR DESCRIPTION
## Summary

`CompileTimeSafeSqlStrings.isCompileTimeSafe` accepted only Kotlin `const val` references as compile-time constants, while `SqlTextReconstruction.classifyValue` (the SQL syntax check) already classifies Java constant fields — `static final` String/Char with a constant initializer — as statically known SQL text. This broke the invariant documented on `SqlTextReconstruction`: "the reconstructable shapes are a strict subset of `isCompileTimeSafe`".

The user-visible contradiction: `add(JavaConstants.SQL)` was checked by the opt-in SQL syntax check as static text, yet simultaneously reported `KUERY_UNSAFE_SQL_STRING`. The warning was a conservative false positive since v1.0, but the new `strict` option escalates it to a compile error, so the same call would be both "statically verified" and "rejected as not statically known".

## Fix

FIR2IR inlines Java constant fields into the SQL text exactly like Kotlin `const val`s, so `isCompileTimeSafe` now accepts a property access resolving to a Java `static final` field with a constant String/Char initializer — mirroring the conditions `SqlTextReconstruction.classifyValue` already uses. Java `static final` fields **without** a constant initializer (e.g. `java.io.File.separator`, computed at class initialization) remain unsafe.

The compliant-code example in the docs now mentions that Java constants behave like `const val`.

## Testing

Test-first: `no warning when a Java constant is passed to add` reproduced the false positive (red), and `warn when a non-constant Java static field is passed to add` pins the conservative behavior for non-constant fields. Both use JDK fields (`javax.xml.XMLConstants.XML_NS_PREFIX` / `java.io.File.separator`), the same technique as the existing reconstruction tests. Full `:kuery-client-compiler` unit + functional-test + functional-test-auto-trim suites and ktlint/detekt are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)