### PR TITLE
Complete the NONE conditions in the sql(block) KDoc

### DIFF
--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryBlockingClient.kt
@@ -46,7 +46,8 @@ public interface KueryBlockingClient {
      *
      * The sqlId is derived from the enclosing declaration of the call site at compile time by
      * the compiler plugin and used when auto sqlId generation is enabled. `"NONE"` is used when
-     * auto sqlId generation is disabled or when the call site was not compiled with the
+     * auto sqlId generation is disabled, when the block is passed via a variable rather than
+     * written literally at the call site, or when the call site was not compiled with the
      * compiler plugin.
      *
      * @param block [SqlBuilder] block that constructs the SQL

--- a/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
+++ b/kuery-client-core/src/main/kotlin/dev/hsbrysk/kuery/core/KueryClient.kt
@@ -47,7 +47,8 @@ public interface KueryClient {
      *
      * The sqlId is derived from the enclosing declaration of the call site at compile time by
      * the compiler plugin and used when auto sqlId generation is enabled. `"NONE"` is used when
-     * auto sqlId generation is disabled or when the call site was not compiled with the
+     * auto sqlId generation is disabled, when the block is passed via a variable rather than
+     * written literally at the call site, or when the call site was not compiled with the
      * compiler plugin.
      *
      * @param block [SqlBuilder] block that constructs the SQL


### PR DESCRIPTION
## Summary

The KDoc on the sqlId-less `sql(block)` overload listed only two cases resolving to the `"NONE"` sqlId: auto sqlId generation being disabled, and the call site not being compiled with the compiler plugin. A third case was missing: a block passed via a variable also resolves to `"NONE"`, because the compiler plugin only rewrites literal lambdas and function references (pinned by the sqlId functional tests).

The builder KDoc on `enableAutoSqlIdGeneration` (`SpringJdbcKueryClientBuilder` / `SpringR2dbcKueryClientBuilder`) already documents this condition — this brings the client-side KDoc in `KueryClient` and `KueryBlockingClient` in line with it.

KDoc-only change; no behavior or ABI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)