### PR TITLE
Add the docs link to the sqlSyntaxCheck KDoc

### DIFF
--- a/kuery-client-gradle-plugin/src/main/kotlin/dev/hsbrysk/kuery/gradle/KueryClientExtension.kt
+++ b/kuery-client-gradle-plugin/src/main/kotlin/dev/hsbrysk/kuery/gradle/KueryClientExtension.kt
@@ -29,6 +29,8 @@ interface KueryClientExtension {
      * is inlined); dynamically assembled blocks are skipped.
      * The checks are lenient and may occasionally produce a false positive — suppress with
      * `@Suppress("KUERY_SQL_SYNTAX")` / `@Suppress("KUERY_SQL_DIALECT")`.
+     *
+     * See https://kuery-client.hsbrysk.dev/sql-syntax-check for details.
      */
     val sqlSyntaxCheck: Property<String>
 


### PR DESCRIPTION
## Summary

The three `KueryClientExtension` properties document themselves consistently except for one detail: `autoTrimIndent` and `strict` both link to their docs page, while `sqlSyntaxCheck` had no link to https://kuery-client.hsbrysk.dev/sql-syntax-check. This adds the missing link in the same style.

KDoc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)