### PR TITLE
Verify releases before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,35 @@ permissions:
   contents: read
 
 jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Set up gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - name: Check
+        run: |
+          ./gradlew check detektMain detektTest
+          ./gradlew -p examples check detektMain detektTest
+      - name: Build docs
+        run: |
+          npm ci
+          npm run docs:build
+
   publish-maven-central:
+    needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -34,6 +62,7 @@ jobs:
           ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -PpublishVersion="$PUBLISH_VERSION"
 
   publish-gradle-plugin:
+    needs: publish-maven-central
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## What changed

- add a `verify` job to the tag-triggered publish workflow
- run the full Gradle checks, example-project checks, and VitePress build against the tagged commit
- make Maven Central publishing depend on verification
- make Gradle Plugin Portal publishing depend on Maven Central publishing

## Why

The publish workflow previously started both registries in parallel without validating the exact tagged commit. A bad tag could therefore begin publishing immediately, and the Gradle plugin could be published before its compiler artifact had been published to Maven Central.

The new dependency chain is:

`verify` → `publish-maven-central` → `publish-gradle-plugin`

This prevents publishing when preflight checks fail and establishes the required artifact order.

## Validation

- YAML parsed successfully
- `./gradlew check detektMain detektTest --no-daemon`
- `./gradlew -p examples check detektMain detektTest --no-daemon`
- VitePress documentation build
