### PR TITLE
Clarify observation scope

### DIFF
--- a/docs/observation.md
+++ b/docs/observation.md
@@ -30,7 +30,8 @@ val kueryClient = SpringR2dbcKueryClient.builder()
 
 ## Recorded data
 
-Each fetch is recorded as an observation named `kuery.client.fetches` with the following tags:
+Each non-streaming terminal operation is recorded as an observation named `kuery.client.fetches` with the following
+tags. Streaming operations are not observed; see [Streaming operations are not observed](#streaming-operations-are-not-observed).
 
 | Tag | Cardinality | Description |
 |---|---|---|


### PR DESCRIPTION
## What changed

- clarify that only non-streaming terminal operations create Kuery Client observations
- link the recorded-data section directly to the existing streaming limitation

## Why

The recorded-data section previously said that each fetch was observed, while the same page later explains that `flow()` / `flowMap()` and `sequence()` / `sequenceMap()` are not observed. The new wording makes the scope accurate at the first mention.

## Impact

Documentation only. Runtime behavior is unchanged.

## Validation

- VitePress documentation build
- `git diff --check`
