### PR TITLE
Clean up build warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    // Load the Kotlin plugin once so all subprojects share the same plugin classloader.
+    alias(libs.plugins.kotlin.jvm) apply false
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ gradle-plugin-maven-publish = { module = "com.vanniktech:gradle-maven-publish-pl
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "6.0.10" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-core" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin-core" }
 plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.1" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/BindCallInSqlTemplateChecker.kt
+++ b/kuery-client-compiler/src/main/kotlin/dev/hsbrysk/kuery/compiler/fir/BindCallInSqlTemplateChecker.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.visitors.FirVisitorVoid
 
 /**
- * Reports [diagnostics.KUERY_BIND_CALL_IN_SQL_TEMPLATE] when `SqlBuilder.bind()` is called
+ * Reports `KUERY_BIND_CALL_IN_SQL_TEMPLATE` when `SqlBuilder.bind()` is called
  * anywhere inside the SQL string argument of `add()` / `unaryPlus`. The IR transformation converts every
  * interpolated value into a bind parameter, so the placeholder name returned by `bind()` would itself be
  * re-bound as a new parameter value and the SQL would compare against the literal string ":pN".


### PR DESCRIPTION
## What changed

- declare the Kotlin JVM plugin once at the root so subprojects share the same plugin classloader
- add the corresponding version-catalog plugin alias
- replace an unresolved KDoc property link with code formatting

## Why

Gradle warned that the Kotlin Gradle Plugin was loaded multiple times across subprojects, which is unsupported. Dokka also warned that it could not resolve the diagnostic property link.

## Impact

This only changes build configuration and generated documentation input. Runtime behavior and public APIs are unchanged.

The existing Gradle deprecation emitted by Detekt 1.x is upstream and remains outside this change.

## Validation

- `./gradlew check detektMain detektTest --no-daemon`
- `./gradlew -p examples check detektMain detektTest --no-daemon`
- confirmed that the duplicate Kotlin plugin and unresolved KDoc link warnings are gone
