### PR TITLE
Bind Kotlin value classes transparently

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -62,20 +62,31 @@ internal class DefaultSpringJdbcKueryClient(
         }
     }
 
-    private fun StatementSpec.bind(parameter: NamedSqlParameter): StatementSpec {
-        val value = checkNotNull(parameter.value)
+    private fun StatementSpec.bind(parameter: NamedSqlParameter): StatementSpec =
+        bindValue(parameter.name, checkNotNull(parameter.value))
 
+    private fun StatementSpec.bindValue(
+        name: String,
+        value: Any,
+    ): StatementSpec {
         val targetType = customConversions.getCustomWriteTarget(value::class.java)
         if (targetType.isPresent) {
             // The Converter contract allows a null result; bind it as SQL NULL.
-            return param(parameter.name, conversionService.convert(value, targetType.get()))
+            return param(name, conversionService.convert(value, targetType.get()))
+        }
+
+        if (ValueClasses.isValueClass(value.javaClass)) {
+            // Unwrap and re-dispatch so the underlying value goes through the full conversion
+            // pipeline again (custom converters, enums, nested value classes, ...).
+            val unwrapped = ValueClasses.unbox(value) ?: return param(name, null)
+            return bindValue(name, unwrapped)
         }
 
         return when (value) {
-            is Collection<*> -> param(parameter.name, convertCollection(value))
-            is Array<*> -> param(parameter.name, convertArray(value))
-            is Enum<*> -> param(parameter.name, value.name)
-            else -> param(parameter.name, value)
+            is Collection<*> -> param(name, convertCollection(value))
+            is Array<*> -> param(name, convertArray(value))
+            is Enum<*> -> param(name, value.name)
+            else -> param(name, value)
         }
     }
 
@@ -105,6 +116,10 @@ internal class DefaultSpringJdbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(componentType)
         return when {
             targetType.isPresent -> targetType.get()
+            ValueClasses.isValueClass(componentType) -> {
+                val underlying = ValueClasses.underlyingType(componentType)
+                componentWriteTarget(underlying) ?: underlying
+            }
             Enum::class.java.isAssignableFrom(componentType) -> String::class.java
             else -> null
         }
@@ -117,6 +132,7 @@ internal class DefaultSpringJdbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(element::class.java)
         return when {
             targetType.isPresent -> conversionService.convert(element, targetType.get())
+            ValueClasses.isValueClass(element.javaClass) -> convertElement(ValueClasses.unbox(element))
             // composite IN `(a, b) IN ($pairs)` passes each row as an Object[] entry in a Collection
             element is Array<*> -> convertArray(element)
             element is Enum<*> -> element.name

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -121,8 +121,9 @@ internal class DefaultSpringJdbcKueryClient(
                 val underlying = ValueClasses.underlyingType(componentType)
                 // A generic value class erases its underlying to Object, which is no useful array
                 // component type (pgjdbc rejects Object[]); return null so the caller infers the
-                // concrete type from the unwrapped elements. Empty/all-null generic value class
-                // arrays cannot be inferred and are left as Object[] (documented as unsupported).
+                // concrete type from the unwrapped elements. An empty or all-null such array cannot
+                // be inferred — no driver-compatible component type can be produced and most drivers
+                // reject it (documented as unsupported).
                 if (underlying == Any::class.java) null else componentWriteTarget(underlying) ?: underlying
             }
             Enum::class.java.isAssignableFrom(componentType) -> String::class.java

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -14,6 +14,7 @@ import dev.hsbrysk.kuery.spring.jdbc.SqlIdInjector
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationRegistry
 import org.springframework.beans.BeanUtils
+import org.springframework.core.KotlinDetector
 import org.springframework.core.convert.ConversionService
 import org.springframework.dao.support.DataAccessUtils
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions
@@ -75,7 +76,7 @@ internal class DefaultSpringJdbcKueryClient(
             return param(name, conversionService.convert(value, targetType.get()))
         }
 
-        if (ValueClasses.isValueClass(value.javaClass)) {
+        if (KotlinDetector.isInlineClass(value.javaClass)) {
             // Unwrap and re-dispatch so the underlying value goes through the full conversion
             // pipeline again (custom converters, enums, nested value classes, ...).
             val unwrapped = ValueClasses.unbox(value) ?: return param(name, null)
@@ -116,7 +117,7 @@ internal class DefaultSpringJdbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(componentType)
         return when {
             targetType.isPresent -> targetType.get()
-            ValueClasses.isValueClass(componentType) -> {
+            KotlinDetector.isInlineClass(componentType) -> {
                 val underlying = ValueClasses.underlyingType(componentType)
                 componentWriteTarget(underlying) ?: underlying
             }
@@ -132,7 +133,7 @@ internal class DefaultSpringJdbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(element::class.java)
         return when {
             targetType.isPresent -> conversionService.convert(element, targetType.get())
-            ValueClasses.isValueClass(element.javaClass) -> convertElement(ValueClasses.unbox(element))
+            KotlinDetector.isInlineClass(element.javaClass) -> convertElement(ValueClasses.unbox(element))
             // composite IN `(a, b) IN ($pairs)` passes each row as an Object[] entry in a Collection
             element is Array<*> -> convertArray(element)
             element is Enum<*> -> element.name

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/DefaultSpringJdbcKueryClient.kt
@@ -119,7 +119,11 @@ internal class DefaultSpringJdbcKueryClient(
             targetType.isPresent -> targetType.get()
             KotlinDetector.isInlineClass(componentType) -> {
                 val underlying = ValueClasses.underlyingType(componentType)
-                componentWriteTarget(underlying) ?: underlying
+                // A generic value class erases its underlying to Object, which is no useful array
+                // component type (pgjdbc rejects Object[]); return null so the caller infers the
+                // concrete type from the unwrapped elements. Empty/all-null generic value class
+                // arrays cannot be inferred and are left as Object[] (documented as unsupported).
+                if (underlying == Any::class.java) null else componentWriteTarget(underlying) ?: underlying
             }
             Enum::class.java.isAssignableFrom(componentType) -> String::class.java
             else -> null

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/ValueClasses.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/ValueClasses.kt
@@ -1,0 +1,47 @@
+package dev.hsbrysk.kuery.spring.jdbc.internal
+
+import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+
+// NOTE: This object is intentionally duplicated in the r2dbc module
+// (dev.hsbrysk.kuery.spring.r2dbc.internal.ValueClasses); there is no shared Spring-dependent
+// module to host it. Keep both copies in sync.
+/**
+ * Reflection helpers for Kotlin value classes (`@JvmInline`), used to transparently bind a value
+ * class as its underlying value. Works without kotlin-reflect: `@JvmInline` is runtime-visible
+ * and the compiler-generated `unbox-impl` method exposes the underlying value.
+ */
+internal object ValueClasses {
+    private val unboxMethodCache = ConcurrentHashMap<Class<*>, Method>()
+
+    fun isValueClass(clazz: Class<*>): Boolean = clazz.isAnnotationPresent(JvmInline::class.java)
+
+    /**
+     * Returns the underlying value of a boxed value class instance. May be null when the
+     * underlying type is nullable (e.g. `value class Opt(val value: String?)`).
+     */
+    fun unbox(value: Any): Any? = unboxMethod(value.javaClass).invoke(value)
+
+    /**
+     * The JVM type of the underlying value, e.g. `UserName` -> `String`. Primitives are boxed
+     * (`Int` -> `java.lang.Integer`) because callers use this as an object array component type.
+     */
+    fun underlyingType(clazz: Class<*>): Class<*> = unboxMethod(clazz).returnType.boxed()
+
+    private fun unboxMethod(clazz: Class<*>): Method = unboxMethodCache.computeIfAbsent(clazz) {
+        it.getDeclaredMethod("unbox-impl")
+    }
+
+    private val primitiveToBoxed: Map<Class<*>, Class<*>> = listOf(
+        Boolean::class,
+        Byte::class,
+        Short::class,
+        Char::class,
+        Int::class,
+        Long::class,
+        Float::class,
+        Double::class,
+    ).associate { it.javaPrimitiveType!! to it.javaObjectType }
+
+    private fun Class<*>.boxed(): Class<*> = primitiveToBoxed[this] ?: this
+}

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/ValueClasses.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/ValueClasses.kt
@@ -23,8 +23,6 @@ internal object ValueClasses {
         }
     }
 
-    fun isValueClass(clazz: Class<*>): Boolean = clazz.isAnnotationPresent(JvmInline::class.java)
-
     /**
      * Returns the underlying value of a boxed value class instance. May be null when the
      * underlying type is nullable (e.g. `value class Opt(val value: String?)`).

--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/ValueClasses.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/ValueClasses.kt
@@ -1,18 +1,27 @@
 package dev.hsbrysk.kuery.spring.jdbc.internal
 
+import org.springframework.util.ClassUtils
 import java.lang.reflect.Method
-import java.util.concurrent.ConcurrentHashMap
 
 // NOTE: This object is intentionally duplicated in the r2dbc module
 // (dev.hsbrysk.kuery.spring.r2dbc.internal.ValueClasses); there is no shared Spring-dependent
 // module to host it. Keep both copies in sync.
 /**
  * Reflection helpers for Kotlin value classes (`@JvmInline`), used to transparently bind a value
- * class as its underlying value. Works without kotlin-reflect: `@JvmInline` is runtime-visible
- * and the compiler-generated `unbox-impl` method exposes the underlying value.
+ * class as its underlying value. Uses plain Java reflection (`@JvmInline` is runtime-visible and
+ * the compiler-generated `unbox-impl` method exposes the underlying value), which keeps the
+ * per-parameter bind hot path free of kotlin-reflect machinery.
  */
 internal object ValueClasses {
-    private val unboxMethodCache = ConcurrentHashMap<Class<*>, Method>()
+    // ClassValue (instead of a Class-keyed map) so cached entries are tied to the class itself
+    // and never pin user classloaders (e.g. across Spring DevTools restarts).
+    private val unboxMethods = object : ClassValue<Method>() {
+        override fun computeValue(type: Class<*>): Method = type.getDeclaredMethod("unbox-impl").apply {
+            // The method is public, but the declaring class may not be (e.g. a file-private
+            // value class compiles to a package-private JVM class).
+            isAccessible = true
+        }
+    }
 
     fun isValueClass(clazz: Class<*>): Boolean = clazz.isAnnotationPresent(JvmInline::class.java)
 
@@ -20,28 +29,12 @@ internal object ValueClasses {
      * Returns the underlying value of a boxed value class instance. May be null when the
      * underlying type is nullable (e.g. `value class Opt(val value: String?)`).
      */
-    fun unbox(value: Any): Any? = unboxMethod(value.javaClass).invoke(value)
+    fun unbox(value: Any): Any? = unboxMethods.get(value.javaClass).invoke(value)
 
     /**
      * The JVM type of the underlying value, e.g. `UserName` -> `String`. Primitives are boxed
      * (`Int` -> `java.lang.Integer`) because callers use this as an object array component type.
      */
-    fun underlyingType(clazz: Class<*>): Class<*> = unboxMethod(clazz).returnType.boxed()
-
-    private fun unboxMethod(clazz: Class<*>): Method = unboxMethodCache.computeIfAbsent(clazz) {
-        it.getDeclaredMethod("unbox-impl")
-    }
-
-    private val primitiveToBoxed: Map<Class<*>, Class<*>> = listOf(
-        Boolean::class,
-        Byte::class,
-        Short::class,
-        Char::class,
-        Int::class,
-        Long::class,
-        Float::class,
-        Double::class,
-    ).associate { it.javaPrimitiveType!! to it.javaObjectType }
-
-    private fun Class<*>.boxed(): Class<*> = primitiveToBoxed[this] ?: this
+    fun underlyingType(clazz: Class<*>): Class<*> =
+        ClassUtils.resolvePrimitiveIfNecessary(unboxMethods.get(clazz).returnType)
 }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/conversion/ValueClassConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/conversion/ValueClassConversionTest.kt
@@ -33,6 +33,12 @@ class ValueClassConversionTest {
     @JvmInline
     value class Outer(val inner: UserName)
 
+    @JvmInline
+    value class OptionalStatus(val value: SampleEnum?)
+
+    @JvmInline
+    value class OptionalName(val value: UserName?)
+
     private val kueryClient = h2.kueryClient()
 
     @BeforeEach
@@ -102,6 +108,62 @@ class ValueClassConversionTest {
     }
 
     @Test
+    fun `value class wrapping a null enum is bound as SQL NULL`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalStatus(null)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun `value class wrapping a nullable value class is unwrapped recursively`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalName(UserName("hoge"))})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    @Test
+    fun `value class wrapping a null value class is bound as SQL NULL`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalName(null)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun `file-private value class is bound as its underlying value`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${PrivateName("hoge")})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    @Test
     fun `value class in an IN clause matches the row stored by its underlying value`() {
         // given
         kueryClient.sql {
@@ -156,3 +218,8 @@ class ValueClassConversionTest {
         private val h2 = H2TestDatabase()
     }
 }
+
+// A top-level private value class compiles to a package-private JVM class, exercising the
+// accessibility handling of the unbox reflection.
+@JvmInline
+private value class PrivateName(val value: String)

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/conversion/ValueClassConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/conversion/ValueClassConversionTest.kt
@@ -39,6 +39,12 @@ class ValueClassConversionTest {
     @JvmInline
     value class OptionalName(val value: UserName?)
 
+    @JvmInline
+    value class Age(val value: Int)
+
+    @JvmInline
+    value class OptionalAge(val value: Int?)
+
     private val kueryClient = h2.kueryClient()
 
     @BeforeEach
@@ -140,6 +146,29 @@ class ValueClassConversionTest {
         // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${OptionalName(null)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun `value class wrapping a primitive is bound as its underlying value`() {
+        // when & then
+        val value: Int = kueryClient.sql {
+            +"SELECT ${Age(42)}"
+        }.single()
+        assertThat(value).isEqualTo(42)
+    }
+
+    @Test
+    fun `value class wrapping a null primitive is bound as SQL NULL`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalAge(null)})"
         }.rowsUpdated()
 
         // when & then

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/conversion/ValueClassConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/conversion/ValueClassConversionTest.kt
@@ -1,0 +1,158 @@
+package dev.hsbrysk.kuery.spring.jdbc.conversion
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import dev.hsbrysk.kuery.core.single
+import dev.hsbrysk.kuery.spring.jdbc.H2TestDatabase
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.WritingConverter
+
+/**
+ * Binding-side (write) support for Kotlin value classes: a value class is transparently
+ * unwrapped to its underlying value, like enums are bound by name. Fetch-side mapping is
+ * covered separately in `mapping.ValueClassFetchTest`.
+ */
+class ValueClassConversionTest {
+    @JvmInline
+    value class UserName(val value: String)
+
+    @JvmInline
+    value class OptionalText(val value: String?)
+
+    enum class SampleEnum {
+        HOGE,
+    }
+
+    @JvmInline
+    value class Status(val value: SampleEnum)
+
+    @JvmInline
+    value class Outer(val inner: UserName)
+
+    private val kueryClient = h2.kueryClient()
+
+    @BeforeEach
+    fun beforeEach() {
+        h2.setUpForConverterTest()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun `value class is bound as its underlying value`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${UserName("hoge")})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    @Test
+    fun `value class wrapping null is bound as SQL NULL`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalText(null)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun `value class wrapping an enum is bound as the enum name`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${Status(SampleEnum.HOGE)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("HOGE")
+    }
+
+    @Test
+    fun `nested value class is unwrapped recursively`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${Outer(UserName("hoge"))})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    @Test
+    fun `value class in an IN clause matches the row stored by its underlying value`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${UserName("hoge")})"
+        }.rowsUpdated()
+
+        // when & then
+        val count: Long = kueryClient.sql {
+            +"SELECT COUNT(*) FROM converter WHERE text IN (${listOf(UserName("hoge"))})"
+        }.single()
+        assertThat(count).isEqualTo(1L)
+    }
+
+    @Test
+    fun `value class in a composite IN tuple matches the row stored by its underlying value`() {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${UserName("hoge")})"
+        }.rowsUpdated()
+
+        // when & then
+        val count: Long = kueryClient.sql {
+            val pairs = listOf(arrayOf<Any>(1L, UserName("hoge")))
+            +"SELECT COUNT(*) FROM converter WHERE (id, text) IN ($pairs)"
+        }.single()
+        assertThat(count).isEqualTo(1L)
+    }
+
+    @Test
+    fun `registered writing converter takes precedence over automatic unwrapping`() {
+        // given
+        val kueryClient = h2.kueryClient(listOf(UserNameToStringConverter()))
+
+        // when
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${UserName("hoge")})"
+        }.rowsUpdated()
+
+        // then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("custom:hoge")
+    }
+
+    @WritingConverter
+    class UserNameToStringConverter : Converter<UserName, String> {
+        override fun convert(source: UserName): String = "custom:${source.value}"
+    }
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
@@ -22,6 +22,9 @@ class PostgresArrayBindingTest {
 
     data class StringWrapper(val value: String)
 
+    @JvmInline
+    value class UserName(val value: String)
+
     @WritingConverter
     class StringWrapperToStringConverter : Converter<StringWrapper, String> {
         override fun convert(source: StringWrapper): String = source.value
@@ -72,6 +75,40 @@ class PostgresArrayBindingTest {
 
         // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind value class array to ANY predicate`() {
+        // given
+        val usernames = arrayOf(UserName("HOGE"), UserName("FUGA"))
+
+        // when
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+
+        // then
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind all-null value class array to a native array column`() {
+        // given
+        val tags = arrayOf<UserName?>(null, null)
+
+        // when
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+
+        // then
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = (record["tags"] as SqlArray).array as Array<*>
+        assertThat(stored.toList()).isEqualTo(listOf(null, null))
     }
 
     @Test

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
@@ -112,6 +112,22 @@ class PostgresArrayBindingTest {
     }
 
     @Test
+    fun `bind generic value class array of a non-string type infers the element type`() {
+        // The inferred component type follows the actual unwrapped elements (Integer[] here),
+        // not a hardcoded String[].
+        // given
+        val ids = arrayOf(Wrapped(1), Wrapped(2))
+
+        // when
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE user_id = ANY($ids) ORDER BY user_id" }
+            .listMap()
+
+        // then
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
     fun `bind all-null value class array to a native array column`() {
         // given
         val tags = arrayOf<UserName?>(null, null)

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
@@ -25,6 +25,9 @@ class PostgresArrayBindingTest {
     @JvmInline
     value class UserName(val value: String)
 
+    @JvmInline
+    value class Wrapped<T>(val value: T)
+
     @WritingConverter
     class StringWrapperToStringConverter : Converter<StringWrapper, String> {
         override fun convert(source: StringWrapper): String = source.value
@@ -81,6 +84,23 @@ class PostgresArrayBindingTest {
     fun `bind value class array to ANY predicate`() {
         // given
         val usernames = arrayOf(UserName("HOGE"), UserName("FUGA"))
+
+        // when
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+
+        // then
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind generic value class array infers the element type`() {
+        // A generic value class's underlying erases to Object; the concrete component type
+        // (String[]) must be inferred from the unwrapped elements, not left as Object[] which
+        // pgjdbc rejects.
+        // given
+        val usernames = arrayOf(Wrapped("HOGE"), Wrapped("FUGA"))
 
         // when
         val list = kueryClient

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresNullBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresNullBindingTest.kt
@@ -12,6 +12,13 @@ import java.sql.Types
 class PostgresNullBindingTest {
     private val kueryClient = postgres.kueryClient()
 
+    enum class SampleEnum {
+        HOGE,
+    }
+
+    @JvmInline
+    value class OptionalStatus(val value: SampleEnum?)
+
     @BeforeEach
     fun setUp() {
         postgres.jdbcClient.sql(
@@ -79,6 +86,28 @@ class PostgresNullBindingTest {
 
         // then
         assertThat(count).isEqualTo(1L)
+    }
+
+    @Test
+    fun `bind value class wrapping a null enum`() {
+        // The jdbc client binds an untyped null, so no type resolution is involved; this mirrors
+        // the r2dbc test, where the bindNull type must be resolved through the write pipeline.
+        // given
+        val username = OptionalStatus(null)
+        val email = "user1@example.com"
+
+        // when
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
+            .rowsUpdated()
+
+        // then
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT * FROM users WHERE email = $email" }
+            .singleMap()
+        assertThat(record["username"]).isNull()
     }
 
     @Test

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -92,7 +92,13 @@ internal class DefaultSpringR2dbcKueryClient(
             // Unwrap and re-dispatch so the underlying value goes through the full conversion
             // pipeline again (custom converters, enums, nested value classes, ...).
             val unwrapped = ValueClasses.unbox(value)
-                ?: return bindNull(name, ValueClasses.underlyingType(value.javaClass))
+                ?: run {
+                    // The bindNull type must be what the driver would have received for a
+                    // non-null value (enum -> String, custom write target, nested value class),
+                    // not the raw underlying type, which may have no codec.
+                    val underlying = ValueClasses.underlyingType(value.javaClass)
+                    return bindNull(name, componentWriteTarget(underlying) ?: underlying)
+                }
             return bindValue(name, unwrapped)
         }
 

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -155,7 +155,11 @@ internal class DefaultSpringR2dbcKueryClient(
             targetType.isPresent -> targetType.get()
             KotlinDetector.isInlineClass(componentType) -> {
                 val underlying = ValueClasses.underlyingType(componentType)
-                componentWriteTarget(underlying) ?: underlying
+                // A generic value class erases its underlying to Object, which is no useful array
+                // component type (drivers reject Object[]); return null so the caller infers the
+                // concrete type from the unwrapped elements. Empty/all-null generic value class
+                // arrays cannot be inferred and are left as Object[] (documented as unsupported).
+                if (underlying == Any::class.java) null else componentWriteTarget(underlying) ?: underlying
             }
             Enum::class.java.isAssignableFrom(componentType) -> String::class.java
             else -> null

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -70,35 +70,51 @@ internal class DefaultSpringR2dbcKueryClient(
         }
     }
 
-    private fun GenericExecuteSpec.bind(parameter: NamedSqlParameter): GenericExecuteSpec {
-        val value = checkNotNull(parameter.value)
+    private fun GenericExecuteSpec.bind(parameter: NamedSqlParameter): GenericExecuteSpec =
+        bindValue(parameter.name, checkNotNull(parameter.value))
 
+    private fun GenericExecuteSpec.bindValue(
+        name: String,
+        value: Any,
+    ): GenericExecuteSpec {
         val targetType = customConversions.getCustomWriteTarget(value::class.java)
         if (targetType.isPresent) {
             // The Converter contract allows a null result; bind it as SQL NULL of the target type.
             val converted = conversionService.convert(value, targetType.get())
             return if (converted != null) {
-                bind(parameter.name, converted)
+                bind(name, converted)
             } else {
-                bindNull(parameter.name, targetType.get())
+                bindNull(name, targetType.get())
             }
         }
 
-        return when (value) {
-            is Collection<*> -> bind(parameter.name, convertCollection(value))
-            is Array<*> -> bind(parameter.name, convertArray(value))
-            // R2DBC drivers' array codecs accept only object arrays, so box primitive arrays.
-            // ByteArray is excluded: drivers encode byte[] as a single binary value, not an array.
-            is IntArray -> bind(parameter.name, value.toTypedArray())
-            is LongArray -> bind(parameter.name, value.toTypedArray())
-            is ShortArray -> bind(parameter.name, value.toTypedArray())
-            is DoubleArray -> bind(parameter.name, value.toTypedArray())
-            is FloatArray -> bind(parameter.name, value.toTypedArray())
-            is BooleanArray -> bind(parameter.name, value.toTypedArray())
-            is CharArray -> bind(parameter.name, value.toTypedArray())
-            is Enum<*> -> bind(parameter.name, value.name)
-            else -> bind(parameter.name, value)
+        if (ValueClasses.isValueClass(value.javaClass)) {
+            // Unwrap and re-dispatch so the underlying value goes through the full conversion
+            // pipeline again (custom converters, enums, nested value classes, ...).
+            val unwrapped = ValueClasses.unbox(value)
+                ?: return bindNull(name, ValueClasses.underlyingType(value.javaClass))
+            return bindValue(name, unwrapped)
         }
+
+        return when (value) {
+            is Collection<*> -> bind(name, convertCollection(value))
+            is Array<*> -> bind(name, convertArray(value))
+            is Enum<*> -> bind(name, value.name)
+            else -> bind(name, boxPrimitiveArray(value) ?: value)
+        }
+    }
+
+    // R2DBC drivers' array codecs accept only object arrays, so box primitive arrays.
+    // ByteArray is excluded: drivers encode byte[] as a single binary value, not an array.
+    private fun boxPrimitiveArray(value: Any): Array<*>? = when (value) {
+        is IntArray -> value.toTypedArray()
+        is LongArray -> value.toTypedArray()
+        is ShortArray -> value.toTypedArray()
+        is DoubleArray -> value.toTypedArray()
+        is FloatArray -> value.toTypedArray()
+        is BooleanArray -> value.toTypedArray()
+        is CharArray -> value.toTypedArray()
+        else -> null
     }
 
     // NOTE: The conversion helpers below (convertCollection / convertArray / componentWriteTarget /
@@ -127,6 +143,10 @@ internal class DefaultSpringR2dbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(componentType)
         return when {
             targetType.isPresent -> targetType.get()
+            ValueClasses.isValueClass(componentType) -> {
+                val underlying = ValueClasses.underlyingType(componentType)
+                componentWriteTarget(underlying) ?: underlying
+            }
             Enum::class.java.isAssignableFrom(componentType) -> String::class.java
             else -> null
         }
@@ -139,6 +159,7 @@ internal class DefaultSpringR2dbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(element::class.java)
         return when {
             targetType.isPresent -> conversionService.convert(element, targetType.get())
+            ValueClasses.isValueClass(element.javaClass) -> convertElement(ValueClasses.unbox(element))
             // composite IN `(a, b) IN ($pairs)` passes each row as an Object[] entry in a Collection
             element is Array<*> -> convertArray(element)
             element is Enum<*> -> element.name

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -157,8 +157,9 @@ internal class DefaultSpringR2dbcKueryClient(
                 val underlying = ValueClasses.underlyingType(componentType)
                 // A generic value class erases its underlying to Object, which is no useful array
                 // component type (drivers reject Object[]); return null so the caller infers the
-                // concrete type from the unwrapped elements. Empty/all-null generic value class
-                // arrays cannot be inferred and are left as Object[] (documented as unsupported).
+                // concrete type from the unwrapped elements. An empty or all-null such array cannot
+                // be inferred — no driver-compatible component type can be produced and most drivers
+                // reject it (documented as unsupported).
                 if (underlying == Any::class.java) null else componentWriteTarget(underlying) ?: underlying
             }
             Enum::class.java.isAssignableFrom(componentType) -> String::class.java

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/DefaultSpringR2dbcKueryClient.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.beans.BeanUtils
+import org.springframework.core.KotlinDetector
 import org.springframework.core.convert.ConversionService
 import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.dao.TypeMismatchDataAccessException
@@ -88,16 +89,19 @@ internal class DefaultSpringR2dbcKueryClient(
             }
         }
 
-        if (ValueClasses.isValueClass(value.javaClass)) {
+        if (KotlinDetector.isInlineClass(value.javaClass)) {
             // Unwrap and re-dispatch so the underlying value goes through the full conversion
             // pipeline again (custom converters, enums, nested value classes, ...).
             val unwrapped = ValueClasses.unbox(value)
                 ?: run {
                     // The bindNull type must be what the driver would have received for a
-                    // non-null value (enum -> String, custom write target, nested value class),
-                    // not the raw underlying type, which may have no codec.
+                    // non-null value (enum -> String, custom write target, nested value class,
+                    // boxed primitive array), not the raw underlying type, which may have no codec.
                     val underlying = ValueClasses.underlyingType(value.javaClass)
-                    return bindNull(name, componentWriteTarget(underlying) ?: underlying)
+                    val bindNullType = componentWriteTarget(underlying)
+                        ?: PRIMITIVE_ARRAY_TO_OBJECT_ARRAY[underlying]
+                        ?: underlying
+                    return bindNull(name, bindNullType)
                 }
             return bindValue(name, unwrapped)
         }
@@ -149,7 +153,7 @@ internal class DefaultSpringR2dbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(componentType)
         return when {
             targetType.isPresent -> targetType.get()
-            ValueClasses.isValueClass(componentType) -> {
+            KotlinDetector.isInlineClass(componentType) -> {
                 val underlying = ValueClasses.underlyingType(componentType)
                 componentWriteTarget(underlying) ?: underlying
             }
@@ -165,7 +169,7 @@ internal class DefaultSpringR2dbcKueryClient(
         val targetType = customConversions.getCustomWriteTarget(element::class.java)
         return when {
             targetType.isPresent -> conversionService.convert(element, targetType.get())
-            ValueClasses.isValueClass(element.javaClass) -> convertElement(ValueClasses.unbox(element))
+            KotlinDetector.isInlineClass(element.javaClass) -> convertElement(ValueClasses.unbox(element))
             // composite IN `(a, b) IN ($pairs)` passes each row as an Object[] entry in a Collection
             element is Array<*> -> convertArray(element)
             element is Enum<*> -> element.name
@@ -365,3 +369,17 @@ private object NullValue
 
 @Suppress("UNCHECKED_CAST")
 private fun <T : Any> Any.unwrapNullValue(): T? = if (this === NullValue) null else this as T
+
+// Maps a primitive array type to its boxed (object) array type, the type `boxPrimitiveArray`
+// would produce for a non-null value. Used to pick the `bindNull` type for a value class
+// wrapping a nullable primitive array. ByteArray is excluded: drivers encode byte[] as a single
+// binary value, not an array.
+private val PRIMITIVE_ARRAY_TO_OBJECT_ARRAY: Map<Class<*>, Class<*>> = mapOf(
+    IntArray::class.java to Array<Int>::class.java,
+    LongArray::class.java to Array<Long>::class.java,
+    ShortArray::class.java to Array<Short>::class.java,
+    DoubleArray::class.java to Array<Double>::class.java,
+    FloatArray::class.java to Array<Float>::class.java,
+    BooleanArray::class.java to Array<Boolean>::class.java,
+    CharArray::class.java to Array<Char>::class.java,
+)

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/ValueClasses.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/ValueClasses.kt
@@ -1,18 +1,27 @@
 package dev.hsbrysk.kuery.spring.r2dbc.internal
 
+import org.springframework.util.ClassUtils
 import java.lang.reflect.Method
-import java.util.concurrent.ConcurrentHashMap
 
 // NOTE: This object is intentionally duplicated in the jdbc module
 // (dev.hsbrysk.kuery.spring.jdbc.internal.ValueClasses); there is no shared Spring-dependent
 // module to host it. Keep both copies in sync.
 /**
  * Reflection helpers for Kotlin value classes (`@JvmInline`), used to transparently bind a value
- * class as its underlying value. Works without kotlin-reflect: `@JvmInline` is runtime-visible
- * and the compiler-generated `unbox-impl` method exposes the underlying value.
+ * class as its underlying value. Uses plain Java reflection (`@JvmInline` is runtime-visible and
+ * the compiler-generated `unbox-impl` method exposes the underlying value), which keeps the
+ * per-parameter bind hot path free of kotlin-reflect machinery.
  */
 internal object ValueClasses {
-    private val unboxMethodCache = ConcurrentHashMap<Class<*>, Method>()
+    // ClassValue (instead of a Class-keyed map) so cached entries are tied to the class itself
+    // and never pin user classloaders (e.g. across Spring DevTools restarts).
+    private val unboxMethods = object : ClassValue<Method>() {
+        override fun computeValue(type: Class<*>): Method = type.getDeclaredMethod("unbox-impl").apply {
+            // The method is public, but the declaring class may not be (e.g. a file-private
+            // value class compiles to a package-private JVM class).
+            isAccessible = true
+        }
+    }
 
     fun isValueClass(clazz: Class<*>): Boolean = clazz.isAnnotationPresent(JvmInline::class.java)
 
@@ -20,28 +29,12 @@ internal object ValueClasses {
      * Returns the underlying value of a boxed value class instance. May be null when the
      * underlying type is nullable (e.g. `value class Opt(val value: String?)`).
      */
-    fun unbox(value: Any): Any? = unboxMethod(value.javaClass).invoke(value)
+    fun unbox(value: Any): Any? = unboxMethods.get(value.javaClass).invoke(value)
 
     /**
      * The JVM type of the underlying value, e.g. `UserName` -> `String`. Primitives are boxed
      * (`Int` -> `java.lang.Integer`) because callers use this as an object array component type.
      */
-    fun underlyingType(clazz: Class<*>): Class<*> = unboxMethod(clazz).returnType.boxed()
-
-    private fun unboxMethod(clazz: Class<*>): Method = unboxMethodCache.computeIfAbsent(clazz) {
-        it.getDeclaredMethod("unbox-impl")
-    }
-
-    private val primitiveToBoxed: Map<Class<*>, Class<*>> = listOf(
-        Boolean::class,
-        Byte::class,
-        Short::class,
-        Char::class,
-        Int::class,
-        Long::class,
-        Float::class,
-        Double::class,
-    ).associate { it.javaPrimitiveType!! to it.javaObjectType }
-
-    private fun Class<*>.boxed(): Class<*> = primitiveToBoxed[this] ?: this
+    fun underlyingType(clazz: Class<*>): Class<*> =
+        ClassUtils.resolvePrimitiveIfNecessary(unboxMethods.get(clazz).returnType)
 }

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/ValueClasses.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/ValueClasses.kt
@@ -23,8 +23,6 @@ internal object ValueClasses {
         }
     }
 
-    fun isValueClass(clazz: Class<*>): Boolean = clazz.isAnnotationPresent(JvmInline::class.java)
-
     /**
      * Returns the underlying value of a boxed value class instance. May be null when the
      * underlying type is nullable (e.g. `value class Opt(val value: String?)`).

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/ValueClasses.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/ValueClasses.kt
@@ -1,0 +1,47 @@
+package dev.hsbrysk.kuery.spring.r2dbc.internal
+
+import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+
+// NOTE: This object is intentionally duplicated in the jdbc module
+// (dev.hsbrysk.kuery.spring.jdbc.internal.ValueClasses); there is no shared Spring-dependent
+// module to host it. Keep both copies in sync.
+/**
+ * Reflection helpers for Kotlin value classes (`@JvmInline`), used to transparently bind a value
+ * class as its underlying value. Works without kotlin-reflect: `@JvmInline` is runtime-visible
+ * and the compiler-generated `unbox-impl` method exposes the underlying value.
+ */
+internal object ValueClasses {
+    private val unboxMethodCache = ConcurrentHashMap<Class<*>, Method>()
+
+    fun isValueClass(clazz: Class<*>): Boolean = clazz.isAnnotationPresent(JvmInline::class.java)
+
+    /**
+     * Returns the underlying value of a boxed value class instance. May be null when the
+     * underlying type is nullable (e.g. `value class Opt(val value: String?)`).
+     */
+    fun unbox(value: Any): Any? = unboxMethod(value.javaClass).invoke(value)
+
+    /**
+     * The JVM type of the underlying value, e.g. `UserName` -> `String`. Primitives are boxed
+     * (`Int` -> `java.lang.Integer`) because callers use this as an object array component type.
+     */
+    fun underlyingType(clazz: Class<*>): Class<*> = unboxMethod(clazz).returnType.boxed()
+
+    private fun unboxMethod(clazz: Class<*>): Method = unboxMethodCache.computeIfAbsent(clazz) {
+        it.getDeclaredMethod("unbox-impl")
+    }
+
+    private val primitiveToBoxed: Map<Class<*>, Class<*>> = listOf(
+        Boolean::class,
+        Byte::class,
+        Short::class,
+        Char::class,
+        Int::class,
+        Long::class,
+        Float::class,
+        Double::class,
+    ).associate { it.javaPrimitiveType!! to it.javaObjectType }
+
+    private fun Class<*>.boxed(): Class<*> = primitiveToBoxed[this] ?: this
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/conversion/ValueClassConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/conversion/ValueClassConversionTest.kt
@@ -1,0 +1,159 @@
+package dev.hsbrysk.kuery.spring.r2dbc.conversion
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import dev.hsbrysk.kuery.core.single
+import dev.hsbrysk.kuery.spring.r2dbc.H2TestDatabase
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.WritingConverter
+
+/**
+ * Binding-side (write) support for Kotlin value classes: a value class is transparently
+ * unwrapped to its underlying value, like enums are bound by name. Fetch-side mapping is
+ * covered separately in `mapping.ValueClassFetchTest`.
+ */
+class ValueClassConversionTest {
+    @JvmInline
+    value class UserName(val value: String)
+
+    @JvmInline
+    value class OptionalText(val value: String?)
+
+    enum class SampleEnum {
+        HOGE,
+    }
+
+    @JvmInline
+    value class Status(val value: SampleEnum)
+
+    @JvmInline
+    value class Outer(val inner: UserName)
+
+    private val kueryClient = h2.kueryClient()
+
+    @BeforeEach
+    fun beforeEach() = runTest {
+        h2.setUpForConverterTest()
+    }
+
+    @AfterEach
+    fun afterEach() = runTest {
+        h2.tearDownForConverterTest()
+    }
+
+    @Test
+    fun `value class is bound as its underlying value`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${UserName("hoge")})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    @Test
+    fun `value class wrapping null is bound as SQL NULL`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalText(null)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun `value class wrapping an enum is bound as the enum name`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${Status(SampleEnum.HOGE)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("HOGE")
+    }
+
+    @Test
+    fun `nested value class is unwrapped recursively`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${Outer(UserName("hoge"))})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    @Test
+    fun `value class in an IN clause matches the row stored by its underlying value`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${UserName("hoge")})"
+        }.rowsUpdated()
+
+        // when & then
+        val count: Long = kueryClient.sql {
+            +"SELECT COUNT(*) FROM converter WHERE text IN (${listOf(UserName("hoge"))})"
+        }.single()
+        assertThat(count).isEqualTo(1L)
+    }
+
+    @Test
+    fun `value class in a composite IN tuple matches the row stored by its underlying value`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${UserName("hoge")})"
+        }.rowsUpdated()
+
+        // when & then
+        val count: Long = kueryClient.sql {
+            val pairs = listOf(arrayOf<Any>(1L, UserName("hoge")))
+            +"SELECT COUNT(*) FROM converter WHERE (id, text) IN ($pairs)"
+        }.single()
+        assertThat(count).isEqualTo(1L)
+    }
+
+    @Test
+    fun `registered writing converter takes precedence over automatic unwrapping`() = runTest {
+        // given
+        val kueryClient = h2.kueryClient(listOf(UserNameToStringConverter()))
+
+        // when
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${UserName("hoge")})"
+        }.rowsUpdated()
+
+        // then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("custom:hoge")
+    }
+
+    @WritingConverter
+    class UserNameToStringConverter : Converter<UserName, String> {
+        override fun convert(source: UserName): String = "custom:${source.value}"
+    }
+
+    companion object {
+        private val h2 = H2TestDatabase()
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/conversion/ValueClassConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/conversion/ValueClassConversionTest.kt
@@ -34,6 +34,12 @@ class ValueClassConversionTest {
     @JvmInline
     value class Outer(val inner: UserName)
 
+    @JvmInline
+    value class OptionalStatus(val value: SampleEnum?)
+
+    @JvmInline
+    value class OptionalName(val value: UserName?)
+
     private val kueryClient = h2.kueryClient()
 
     @BeforeEach
@@ -103,6 +109,62 @@ class ValueClassConversionTest {
     }
 
     @Test
+    fun `value class wrapping a null enum is bound as SQL NULL`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalStatus(null)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun `value class wrapping a nullable value class is unwrapped recursively`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalName(UserName("hoge"))})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    @Test
+    fun `value class wrapping a null value class is bound as SQL NULL`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalName(null)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun `file-private value class is bound as its underlying value`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${PrivateName("hoge")})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("hoge")
+    }
+
+    @Test
     fun `value class in an IN clause matches the row stored by its underlying value`() = runTest {
         // given
         kueryClient.sql {
@@ -157,3 +219,8 @@ class ValueClassConversionTest {
         private val h2 = H2TestDatabase()
     }
 }
+
+// A top-level private value class compiles to a package-private JVM class, exercising the
+// accessibility handling of the unbox reflection.
+@JvmInline
+private value class PrivateName(val value: String)

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/conversion/ValueClassConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/conversion/ValueClassConversionTest.kt
@@ -40,6 +40,12 @@ class ValueClassConversionTest {
     @JvmInline
     value class OptionalName(val value: UserName?)
 
+    @JvmInline
+    value class Age(val value: Int)
+
+    @JvmInline
+    value class OptionalAge(val value: Int?)
+
     private val kueryClient = h2.kueryClient()
 
     @BeforeEach
@@ -141,6 +147,29 @@ class ValueClassConversionTest {
         // given
         kueryClient.sql {
             +"INSERT INTO converter (text) VALUES (${OptionalName(null)})"
+        }.rowsUpdated()
+
+        // when & then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isNull()
+    }
+
+    @Test
+    fun `value class wrapping a primitive is bound as its underlying value`() = runTest {
+        // when & then
+        val value: Int = kueryClient.sql {
+            +"SELECT ${Age(42)}"
+        }.single()
+        assertThat(value).isEqualTo(42)
+    }
+
+    @Test
+    fun `value class wrapping a null primitive is bound as SQL NULL`() = runTest {
+        // given
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${OptionalAge(null)})"
         }.rowsUpdated()
 
         // when & then

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
@@ -23,6 +23,9 @@ class PostgresArrayBindingTest {
     @JvmInline
     value class UserName(val value: String)
 
+    @JvmInline
+    value class Scores(val value: IntArray?)
+
     @WritingConverter
     class StringWrapperToStringConverter : Converter<StringWrapper, String> {
         override fun convert(source: StringWrapper): String = source.value
@@ -35,7 +38,8 @@ class PostgresArrayBindingTest {
             CREATE TABLE users (
                 user_id SERIAL PRIMARY KEY,
                 username VARCHAR(50) NOT NULL,
-                tags TEXT[]
+                tags TEXT[],
+                scores INT[]
             )
             """.trimIndent(),
         ).fetch().awaitRowsUpdated()
@@ -283,6 +287,42 @@ class PostgresArrayBindingTest {
 
         // then
         assertThat((record["chars"] as Array<*>).toList()).isEqualTo(listOf("a", "b"))
+    }
+
+    @Test
+    fun `value class wrapping a primitive array binds the boxed array`() = runTest {
+        // given
+        val scores = Scores(intArrayOf(1, 2))
+
+        // when
+        kueryClient
+            .sql { +"INSERT INTO users (username, scores) VALUES ('scored', $scores)" }
+            .rowsUpdated()
+
+        // then
+        val record = kueryClient
+            .sql { +"SELECT scores FROM users WHERE username = 'scored'" }
+            .singleMap()
+        assertThat((record["scores"] as Array<*>).toList()).isEqualTo(listOf(1, 2))
+    }
+
+    @Test
+    fun `value class wrapping a null primitive array binds SQL NULL`() = runTest {
+        // The bindNull type must be the boxed array type the driver would have received for a
+        // non-null value, not the raw primitive array type, which r2dbc has no codec for.
+        // given
+        val scores = Scores(null)
+
+        // when
+        kueryClient
+            .sql { +"INSERT INTO users (username, scores) VALUES ('scored', $scores)" }
+            .rowsUpdated()
+
+        // then
+        val record = kueryClient
+            .sql { +"SELECT scores FROM users WHERE username = 'scored'" }
+            .singleMap()
+        assertThat(record["scores"]).isEqualTo(null)
     }
 
     companion object {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
@@ -20,6 +20,9 @@ class PostgresArrayBindingTest {
 
     data class StringWrapper(val value: String)
 
+    @JvmInline
+    value class UserName(val value: String)
+
     @WritingConverter
     class StringWrapperToStringConverter : Converter<StringWrapper, String> {
         override fun convert(source: StringWrapper): String = source.value
@@ -71,6 +74,40 @@ class PostgresArrayBindingTest {
 
         // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind value class array to ANY predicate`() = runTest {
+        // given
+        val usernames = arrayOf(UserName("HOGE"), UserName("FUGA"))
+
+        // when
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+
+        // then
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind all-null value class array to a native array column`() = runTest {
+        // given
+        val tags = arrayOf<UserName?>(null, null)
+
+        // when
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+
+        // then
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = record["tags"] as Array<*>
+        assertThat(stored.toList()).isEqualTo(listOf(null, null))
     }
 
     @Test

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
@@ -289,6 +289,8 @@ class PostgresArrayBindingTest {
         assertThat((record["chars"] as Array<*>).toList()).isEqualTo(listOf("a", "b"))
     }
 
+    // R2DBC-only: only the r2dbc client boxes primitive arrays (the jdbc client passes them to the
+    // driver as-is and binds an untyped null), so there is no jdbc counterpart to these two tests.
     @Test
     fun `value class wrapping a primitive array binds the boxed array`() = runTest {
         // given

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
@@ -115,6 +115,22 @@ class PostgresArrayBindingTest {
     }
 
     @Test
+    fun `bind generic value class array of a non-string type infers the element type`() = runTest {
+        // The inferred component type follows the actual unwrapped elements (Integer[] here),
+        // not a hardcoded String[].
+        // given
+        val ids = arrayOf(Wrapped(1), Wrapped(2))
+
+        // when
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE user_id = ANY($ids) ORDER BY user_id" }
+            .listMap()
+
+        // then
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
     fun `bind all-null value class array to a native array column`() = runTest {
         // given
         val tags = arrayOf<UserName?>(null, null)

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
@@ -26,6 +26,9 @@ class PostgresArrayBindingTest {
     @JvmInline
     value class Scores(val value: IntArray?)
 
+    @JvmInline
+    value class Wrapped<T>(val value: T)
+
     @WritingConverter
     class StringWrapperToStringConverter : Converter<StringWrapper, String> {
         override fun convert(source: StringWrapper): String = source.value
@@ -84,6 +87,23 @@ class PostgresArrayBindingTest {
     fun `bind value class array to ANY predicate`() = runTest {
         // given
         val usernames = arrayOf(UserName("HOGE"), UserName("FUGA"))
+
+        // when
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($usernames) ORDER BY user_id" }
+            .listMap()
+
+        // then
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind generic value class array infers the element type`() = runTest {
+        // A generic value class's underlying erases to Object; the concrete component type
+        // (String[]) must be inferred from the unwrapped elements, not left as Object[] which
+        // the driver rejects.
+        // given
+        val usernames = arrayOf(Wrapped("HOGE"), Wrapped("FUGA"))
 
         // when
         val list = kueryClient

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresNullBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresNullBindingTest.kt
@@ -14,6 +14,13 @@ import org.springframework.r2dbc.core.awaitRowsUpdated
 class PostgresNullBindingTest {
     private val kueryClient = postgres.kueryClient()
 
+    enum class SampleEnum {
+        HOGE,
+    }
+
+    @JvmInline
+    value class OptionalStatus(val value: SampleEnum?)
+
     @BeforeEach
     fun setUp() = runTest {
         postgres.databaseClient.sql(
@@ -81,6 +88,28 @@ class PostgresNullBindingTest {
 
         // then
         assertThat(count).isEqualTo(1L)
+    }
+
+    @Test
+    fun `bind value class wrapping a null enum`() = runTest {
+        // The bindNull type must be resolved through the write pipeline (enum -> String here),
+        // not the raw underlying type, which the driver has no codec for.
+        // given
+        val username = OptionalStatus(null)
+        val email = "user1@example.com"
+
+        // when
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, email) VALUES ($username, $email)" }
+            .rowsUpdated()
+
+        // then
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT * FROM users WHERE email = $email" }
+            .singleMap()
+        assertThat(record["username"]).isNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Write-side (binding) support for Kotlin value classes. This is the first of a planned series (write side → read side → docs).

A value class passed to string interpolation (or `bind()`) is now transparently unwrapped to its underlying value at bind time, the same way enums are bound by name — no `WritingConverter` registration required:

```kotlin
@JvmInline
value class UserName(val value: String)

client.sql { +"SELECT * FROM users WHERE name = ${UserName("hoge")}" } // binds "hoge"
```

## Behavior

- The unwrapped value is re-dispatched through the full conversion pipeline, so value classes wrapping enums, nested value classes, and value classes inside collections / arrays / composite IN tuples all work.
- A value class wrapping a nullable underlying type (`value class Opt(val v: String?)`) binds SQL NULL when the wrapped value is null.
- `Array<ValueClass>` resolves its SQL array component type from the underlying type (e.g. `UserName[]` → `String[]`), including all-null arrays where the component type alone carries the intent.
- A **generic** value class array (`value class Wrapped<T>(val value: T)`) has an erased underlying type, so the component type is inferred from the unwrapped elements — a non-empty array binds correctly. An empty or all-`null` generic value class array cannot be inferred and is left as-is, which most drivers reject; use a concrete value class or the underlying array type in that case (documented in #435).
- Backward compatible: a registered `WritingConverter` on the value class still takes precedence over automatic unwrapping.

## Implementation

Detection and unboxing use plain Java reflection — `@JvmInline` is runtime-visible and the compiler-generated `unbox-impl` method exposes the underlying value (cached per class) — so **no kotlin-reflect dependency is needed**. The helper is duplicated in both Spring modules following the existing keep-in-sync convention.

Fetch-side (read) mapping is intentionally out of scope and will follow in a separate PR.

## Testing

- New mirrored `conversion.ValueClassConversionTest` (jdbc / r2dbc, H2): unwrap, null underlying, enum wrapping, nesting, IN clause, composite IN tuple, converter precedence. Written test-first and confirmed failing before the fix.
- New mirrored cases in `PostgresArrayBindingTest` (Testcontainers): `ANY(array)` predicate, generic value class array element-type inference, all-null array component-type resolution, and (r2dbc) a value class wrapping a primitive array.
- Full jdbc/r2dbc suites, ktlint, detekt, and ABI checks pass (no public API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)