### PR TITLE
Cover String const inlining in the SQL syntax check

### DIFF
--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/SqlSyntaxCheckerReconstructionTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/SqlSyntaxCheckerReconstructionTest.kt
@@ -214,6 +214,53 @@ class SqlSyntaxCheckerReconstructionTest {
     }
 
     @Test
+    fun `no warning when a string const in a template expands to valid SQL`() {
+        // A single-literal String const is folded into the SQL text (like a Java constant), so
+        // the runtime SQL is "SELECT * FROM users" — valid.
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            const val SELECT = "SELECT"
+
+            fun query() {
+                Sql { +"${'$'}SELECT * FROM users" }
+            }
+            """.trimIndent(),
+            allWarningsAsErrors = true,
+            pluginOptions = listOf(sqlSyntaxCheckOption()),
+        )
+
+        // then
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
+    fun `warn when a string const in a template expands to broken SQL`() {
+        // The const's own text is spliced into the reconstructed SQL, so its content participates
+        // in the parse: "SELCT * FROM users" fails to parse.
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            const val KEYWORD = "SELCT"
+
+            fun query() {
+                Sql { +"${'$'}KEYWORD * FROM users" }
+            }
+            """.trimIndent(),
+            pluginOptions = listOf(sqlSyntaxCheckOption()),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
     fun `no warning when a template value mutates the builder`() {
         // The value expression runs before the enclosing add at runtime and emits its own line,
         // so the block's SQL is not what the template alone suggests — it must be skipped.


### PR DESCRIPTION
## What

Adds two `SqlSyntaxCheckerReconstructionTest` cases for a Kotlin String `const val` interpolated into an `add`/`unaryPlus` template.

## Why

The existing const coverage in that file was one-sided for String consts:

- `warn when a template with a non-string const accompanies broken SQL` — the const is a non-String (`Int`, bound as `:pN`); the typo is in the literal part.
- `no warning when a Java constant appears in a template` — a **Java** constant folded into valid SQL.
- `no warning when a const val initializer is not a single literal` — skip path.

Nothing pinned a Kotlin single-literal String `const val` embedded in a template, where the const's text is folded into the reconstructed SQL and therefore participates in the parse — in either direction. This came up while verifying `+"$SELECT * FROM users"` (with `const val SELECT = "SELECT"`) end-to-end.

## Cases added

- `no warning when a string const in a template expands to valid SQL` — `const val SELECT = "SELECT"` → reconstructs to `SELECT * FROM users` → no `KUERY_SQL_SYNTAX`.
- `warn when a string const in a template expands to broken SQL` — `const val KEYWORD = "SELCT"` → reconstructs to `SELCT * FROM users` → `KUERY_SQL_SYNTAX` fires (proves the const's own text flows into the parse).

Both pass against the current implementation (behavior was already correct; this is a coverage gap fill). Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)