### PR TITLE
Harden the value class fetch path and cover its terminal operators

### DIFF
--- a/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/KotlinRowMappers.kt
+++ b/kuery-client-spring-data-jdbc/src/main/kotlin/dev/hsbrysk/kuery/spring/jdbc/internal/KotlinRowMappers.kt
@@ -191,7 +191,7 @@ internal class ValueClassPropertyRowMapper(
  * can still be served by a registered reading converter, which wins before boxing is attempted.
  */
 internal class ValueClassColumnConverter(
-    target: KClass<*>,
+    private val target: KClass<*>,
     private val conversionService: ConversionService,
 ) {
     private val targetJavaType = target.javaObjectType
@@ -207,10 +207,14 @@ internal class ValueClassColumnConverter(
     private val canConvertCache = ConcurrentHashMap<Class<*>, Boolean>()
 
     // Whether SQL NULL should be taken into the value class as an inner null (X(null)). True only
-    // when the underlying type is nullable; false when it is non-null or cannot be determined
-    // (a generic value class, whose boxer resolution fail-fasts — never let that fire here).
+    // when the single underlying constructor parameter is a concrete, nullable type. A generic value
+    // class (its underlying is a type parameter, not a KClass) is excluded — its underlying type,
+    // and hence nullability, is unknowable. Determined directly from the primary constructor so a
+    // genuine reflection/ABI fault surfaces instead of being silently treated as non-nullable, and
+    // without resolving `boxer` (which fail-fasts for generic value classes).
     private val nullableUnderlying: Boolean by lazy {
-        runCatching { boxer.underlyingNullable }.getOrDefault(false)
+        val underlyingType = target.primaryConstructor?.parameters?.singleOrNull()?.type
+        underlyingType != null && underlyingType.classifier is KClass<*> && underlyingType.isMarkedNullable
     }
 
     /**
@@ -303,10 +307,6 @@ private class ValueClassBoxer(target: KClass<*>) {
             "Register a reading converter targeting $target instead."
     }
 
-    // Whether the underlying type is declared nullable (e.g. `value class X(val v: String?)`), so
-    // SQL NULL can be taken into the value class as X(null) instead of a null value class.
-    val underlyingNullable: Boolean = constructor.parameters.single().type.isMarkedNullable
-
     // Fast path: the compiler-generated static `constructor-impl` (which contains the `init`
     // validation) + `box-impl` pair, invoked through plain Java reflection — measurably faster
     // than KFunction.call. They are part of a value class's stable JVM ABI (compiled callers in
@@ -327,9 +327,10 @@ private class ValueClassBoxer(target: KClass<*>) {
     }
 
     /**
-     * Boxes a null underlying value into X(null), running `init` validation. Only valid when
-     * [underlyingNullable]. Goes through the Kotlin constructor (not the fast path, whose `accepts`
-     * is non-null); this runs only on SQL NULL rows, so it is off the hot path.
+     * Boxes a null underlying value into X(null), running `init` validation. Only called when the
+     * underlying type is nullable (see [ValueClassColumnConverter]). Goes through the Kotlin
+     * constructor (not the fast path, whose `accepts` is non-null); this runs only on SQL NULL rows,
+     * so it is off the hot path.
      */
     fun boxNull(): Any = callConstructor { constructor.call(null) }
 }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mapping/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mapping/ValueClassFetchTest.kt
@@ -8,7 +8,9 @@ import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
 import assertk.assertions.messageContains
 import dev.hsbrysk.kuery.core.list
+import dev.hsbrysk.kuery.core.sequence
 import dev.hsbrysk.kuery.core.single
+import dev.hsbrysk.kuery.core.singleOrNull
 import dev.hsbrysk.kuery.spring.jdbc.H2TestDatabase
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -133,6 +135,70 @@ class ValueClassFetchTest {
             +"SELECT text FROM converter ORDER BY id"
         }.list()
         assertThat(result).isEqualTo(listOf(OptionalUserName("user1"), OptionalUserName(null)))
+    }
+
+    @Test
+    fun `sequence keeps a SQL NULL value class scalar as a null element`() {
+        // The scalar mapper maps a SQL NULL row to a null element; sequence() must preserve it
+        // (non-null underlying type), like list().
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1'), (NULL)").update()
+
+        // when & then
+        val result: List<UserName?> = kueryClient.sql {
+            +"SELECT text FROM converter ORDER BY id"
+        }.sequence<UserName>().toList()
+        assertThat(result).isEqualTo(listOf(UserName("user1"), null))
+    }
+
+    @Test
+    fun `sequence maps a nullable-underlying value class scalar SQL NULL to an inner null`() {
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1'), (NULL)").update()
+
+        // when & then
+        val result: List<OptionalUserName> = kueryClient.sql {
+            +"SELECT text FROM converter ORDER BY id"
+        }.sequence<OptionalUserName>().toList()
+        assertThat(result).isEqualTo(listOf(OptionalUserName("user1"), OptionalUserName(null)))
+    }
+
+    @Test
+    fun `singleOrNull maps a SQL NULL value class scalar to null`() {
+        // The scalar mapper maps the SQL NULL row to a null element; singleOrNull() must return it
+        // as null (non-null underlying type).
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES (NULL)").update()
+
+        // when & then
+        val result: UserName? = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.singleOrNull()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `singleOrNull maps a nullable-underlying value class scalar SQL NULL to an inner null`() {
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES (NULL)").update()
+
+        // when & then
+        val result: OptionalUserName? = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.singleOrNull()
+        assertThat(result).isEqualTo(OptionalUserName(null))
+    }
+
+    @Test
+    fun `singleOrNull returns a value class scalar when a row matches`() {
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1')").update()
+
+        // when & then
+        val result: UserName? = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.singleOrNull()
+        assertThat(result).isEqualTo(UserName("user1"))
     }
 
     @Test

--- a/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/KotlinRowMappers.kt
+++ b/kuery-client-spring-data-r2dbc/src/main/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/KotlinRowMappers.kt
@@ -65,7 +65,11 @@ private fun retrieveTyped(
     raw: Any?,
 ): Any? = try {
     readable.get(index, type)
-} catch (@Suppress("SwallowedException", "TooGenericExceptionCaught") ex: RuntimeException) {
+} catch (@Suppress("SwallowedException") ex: IllegalArgumentException) {
+    // The R2DBC SPI signals "the column cannot be decoded to the requested type" as
+    // IllegalArgumentException — the same signal SingleColumnRowMapper falls back on. This is the
+    // only failure that should degrade to the raw value; anything else (a driver/connection error,
+    // an IndexOutOfBoundsException) is an unexpected fault that must propagate, not be masked here.
     raw
 }
 
@@ -194,7 +198,7 @@ internal class ValueClassPropertyRowMapper(
  * can still be served by a registered reading converter, which wins before boxing is attempted.
  */
 internal class ValueClassColumnConverter(
-    target: KClass<*>,
+    private val target: KClass<*>,
     private val conversionService: ConversionService,
 ) {
     private val targetJavaType = target.javaObjectType
@@ -210,10 +214,14 @@ internal class ValueClassColumnConverter(
     private val canConvertCache = ConcurrentHashMap<Class<*>, Boolean>()
 
     // Whether SQL NULL should be taken into the value class as an inner null (X(null)). True only
-    // when the underlying type is nullable; false when it is non-null or cannot be determined
-    // (a generic value class, whose boxer resolution fail-fasts — never let that fire here).
+    // when the single underlying constructor parameter is a concrete, nullable type. A generic value
+    // class (its underlying is a type parameter, not a KClass) is excluded — its underlying type,
+    // and hence nullability, is unknowable. Determined directly from the primary constructor so a
+    // genuine reflection/ABI fault surfaces instead of being silently treated as non-nullable, and
+    // without resolving `boxer` (which fail-fasts for generic value classes).
     private val nullableUnderlying: Boolean by lazy {
-        runCatching { boxer.underlyingNullable }.getOrDefault(false)
+        val underlyingType = target.primaryConstructor?.parameters?.singleOrNull()?.type
+        underlyingType != null && underlyingType.classifier is KClass<*> && underlyingType.isMarkedNullable
     }
 
     /**
@@ -306,10 +314,6 @@ private class ValueClassBoxer(target: KClass<*>) {
             "Register a reading converter targeting $target instead."
     }
 
-    // Whether the underlying type is declared nullable (e.g. `value class X(val v: String?)`), so
-    // SQL NULL can be taken into the value class as X(null) instead of a null value class.
-    val underlyingNullable: Boolean = constructor.parameters.single().type.isMarkedNullable
-
     // Fast path: the compiler-generated static `constructor-impl` (which contains the `init`
     // validation) + `box-impl` pair, invoked through plain Java reflection — measurably faster
     // than KFunction.call. They are part of a value class's stable JVM ABI (compiled callers in
@@ -330,9 +334,10 @@ private class ValueClassBoxer(target: KClass<*>) {
     }
 
     /**
-     * Boxes a null underlying value into X(null), running `init` validation. Only valid when
-     * [underlyingNullable]. Goes through the Kotlin constructor (not the fast path, whose `accepts`
-     * is non-null); this runs only on SQL NULL rows, so it is off the hot path.
+     * Boxes a null underlying value into X(null), running `init` validation. Only called when the
+     * underlying type is nullable (see [ValueClassColumnConverter]). Goes through the Kotlin
+     * constructor (not the fast path, whose `accepts` is non-null); this runs only on SQL NULL rows,
+     * so it is off the hot path.
      */
     fun boxNull(): Any = callConstructor { constructor.call(null) }
 }

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mapping/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mapping/ValueClassFetchTest.kt
@@ -7,9 +7,12 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
 import assertk.assertions.messageContains
+import dev.hsbrysk.kuery.core.flow
 import dev.hsbrysk.kuery.core.list
 import dev.hsbrysk.kuery.core.single
+import dev.hsbrysk.kuery.core.singleOrNull
 import dev.hsbrysk.kuery.spring.r2dbc.H2TestDatabase
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -135,6 +138,70 @@ class ValueClassFetchTest {
             +"SELECT text FROM converter ORDER BY id"
         }.list()
         assertThat(result).isEqualTo(listOf(OptionalUserName("user1"), OptionalUserName(null)))
+    }
+
+    @Test
+    fun `flow keeps a SQL NULL value class scalar as a null element`() = runTest {
+        // The scalar mapper emits the NullValue sentinel for a SQL NULL row; flow() must unwrap it
+        // back to a null element (non-null underlying type), like list().
+        // given
+        insert("INSERT INTO converter (text) VALUES ('user1'), (NULL)")
+
+        // when & then
+        val result: List<UserName?> = kueryClient.sql {
+            +"SELECT text FROM converter ORDER BY id"
+        }.flow<UserName>().toList()
+        assertThat(result).isEqualTo(listOf(UserName("user1"), null))
+    }
+
+    @Test
+    fun `flow maps a nullable-underlying value class scalar SQL NULL to an inner null`() = runTest {
+        // given
+        insert("INSERT INTO converter (text) VALUES ('user1'), (NULL)")
+
+        // when & then
+        val result: List<OptionalUserName> = kueryClient.sql {
+            +"SELECT text FROM converter ORDER BY id"
+        }.flow<OptionalUserName>().toList()
+        assertThat(result).isEqualTo(listOf(OptionalUserName("user1"), OptionalUserName(null)))
+    }
+
+    @Test
+    fun `singleOrNull maps a SQL NULL value class scalar to null`() = runTest {
+        // The scalar mapper emits the NullValue sentinel for the SQL NULL row; singleOrNull() must
+        // unwrap it back to null (non-null underlying type).
+        // given
+        insert("INSERT INTO converter (text) VALUES (NULL)")
+
+        // when & then
+        val result: UserName? = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.singleOrNull()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `singleOrNull maps a nullable-underlying value class scalar SQL NULL to an inner null`() = runTest {
+        // given
+        insert("INSERT INTO converter (text) VALUES (NULL)")
+
+        // when & then
+        val result: OptionalUserName? = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.singleOrNull()
+        assertThat(result).isEqualTo(OptionalUserName(null))
+    }
+
+    @Test
+    fun `singleOrNull returns a value class scalar when a row matches`() = runTest {
+        // given
+        insert("INSERT INTO converter (text) VALUES ('user1')")
+
+        // when & then
+        val result: UserName? = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.singleOrNull()
+        assertThat(result).isEqualTo(UserName("user1"))
     }
 
     @Test


### PR DESCRIPTION
Follow-up hardening for the value class read-side support (#434). Three related changes to the fetch path, kept in sync across the jdbc and r2dbc modules.

## 1. Narrow the R2DBC typed-retrieval fallback
`retrieveTyped()` re-reads a column asking the driver for a specific type and falls back to the raw value when the driver cannot produce it. It caught **every** `RuntimeException`, which could mask driver/connection faults as a silent fall-back.

It now catches only **`IllegalArgumentException`** — the R2DBC SPI's signal for "the column cannot be decoded to the requested type" (r2dbc-h2 / r2dbc-postgresql / r2dbc-mysql). This is exactly the signal the module's existing `SingleColumnRowMapper` already falls back on. Anything else (a driver/connection error, an `IndexOutOfBoundsException`) now propagates.

The JDBC counterpart is intentionally left unchanged: it already catches only `SQLException`, the equivalent driver-level "cannot produce this type" signal there.

## 2. Explicit generic detection for the nullable-underlying flag
`nullableUnderlying` used `runCatching { boxer.underlyingNullable }.getOrDefault(false)`, which swallowed **every** `Throwable` (relying on the boxer's fail-fast for generic value classes) and would hide unexpected reflection/ABI faults.

It is now computed directly from the primary constructor, excluding a generic value class explicitly (its underlying is a type parameter, not a `KClass`):

```kotlin
val underlyingType = target.primaryConstructor?.parameters?.singleOrNull()?.type
underlyingType != null && underlyingType.classifier is KClass<*> && underlyingType.isMarkedNullable
```

This keeps the generic-value-class intent, avoids resolving `boxer` (whose fail-fast is meant for the boxing path), and lets a genuine reflection fault surface. The now-unused `ValueClassBoxer.underlyingNullable` is removed.

## 3. Terminal-operator tests for value class scalars over SQL NULL
Existing coverage exercised only `list()` / `single()`. Added tests for the terminal operators whose NullValue handling was untested:

| Behavior | R2DBC (`flow`) | JDBC (`sequence`) | Both (`singleOrNull`) |
|---|---|---|---|
| SQL NULL → null element (sentinel unwrapped, non-null underlying) | ✓ | ✓ | ✓ (→ null) |
| SQL NULL → inner null `X(null)` (nullable underlying) | ✓ | ✓ | ✓ |
| present value | (multi-row) | (multi-row) | ✓ |

The `singleOrNull` tests use identical method names across both modules; `flow` (r2dbc) and `sequence` (jdbc) are the genuinely one-sided terminal operators, so only their names differ.

## Notes
Changes 1 and 2 are behavior-preserving hardening (narrowing exception handling); a reproducing test would require forcing an unexpected driver/reflection exception, which is not practical, so regression safety rests on the existing value-class suite (including the generic-value-class cases) plus the new terminal-operator tests.

## Verification
- `./gradlew build` (full suite incl. Testcontainers) — green
- `ktlintCheck`, `detektMain` / `detektTest` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)