### PR TITLE
Cover the untested branches of value class support

### DIFF
--- a/docs/row-mapping.md
+++ b/docs/row-mapping.md
@@ -114,11 +114,14 @@ val names: List<UserName> = kueryClient
 Boxing goes through the primary constructor, so `init` validation runs — an invalid database value fails with
 the same exception the constructor would throw. Value classes wrapping enums (or other value classes) convert
 recursively. A registered `@ReadingConverter` targeting the value class takes precedence over automatic
-boxing; see [Type Conversion](/type-conversion).
+boxing; see [Type Conversion](/type-conversion). Value classes also work as mutable (`var`) body properties,
+not just constructor parameters.
 
 Generic value classes (e.g. `value class Wrapped<T>(val value: T)`) cannot be boxed automatically — the
-underlying type is a type parameter — and are rejected with an error. Register a `@ReadingConverter` for them
-instead.
+underlying type is a type parameter — and are rejected with an error, whether used as the return type itself or
+as a data class property. Register a `@ReadingConverter` for them instead. As a scalar with such a converter, a
+SQL `NULL` is kept as a `null` element (the underlying type is unknown, so the `NULL` cannot be taken inside the
+value class).
 
 ### Nullable columns
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/conversion/ValueClassConversionTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/conversion/ValueClassConversionTest.kt
@@ -45,6 +45,11 @@ class ValueClassConversionTest {
     @JvmInline
     value class OptionalAge(val value: Int?)
 
+    data class CustomType(val raw: String)
+
+    @JvmInline
+    value class WrappedCustomType(val value: CustomType)
+
     private val kueryClient = h2.kueryClient()
 
     @BeforeEach
@@ -238,9 +243,34 @@ class ValueClassConversionTest {
         assertThat(map["text"]).isEqualTo("custom:hoge")
     }
 
+    @Test
+    fun `unwrapped underlying value goes through its own writing converter`() {
+        // No converter targets WrappedCustomType itself, so it is unwrapped to its CustomType
+        // underlying, which is then re-dispatched through the conversion pipeline and picked up by
+        // the CustomType -> String writing converter.
+        // given
+        val kueryClient = h2.kueryClient(listOf(CustomTypeToStringConverter()))
+
+        // when
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${WrappedCustomType(CustomType("hoge"))})"
+        }.rowsUpdated()
+
+        // then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("custom:hoge")
+    }
+
     @WritingConverter
     class UserNameToStringConverter : Converter<UserName, String> {
         override fun convert(source: UserName): String = "custom:${source.value}"
+    }
+
+    @WritingConverter
+    class CustomTypeToStringConverter : Converter<CustomType, String> {
+        override fun convert(source: CustomType): String = "custom:${source.raw}"
     }
 
     companion object {

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mapping/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mapping/ValueClassFetchTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.core.convert.converter.Converter
+import org.springframework.dao.TypeMismatchDataAccessException
 import org.springframework.data.convert.ReadingConverter
 import org.springframework.jdbc.BadSqlGrammarException
 import org.springframework.jdbc.IncorrectResultSetColumnCountException
@@ -84,6 +85,17 @@ class ValueClassFetchTest {
 
     @JvmInline
     value class OptionalUserName(val value: String?)
+
+    @JvmInline
+    value class Token(val value: String) {
+        init {
+            require(value.isNotEmpty()) { "must not be empty" }
+        }
+
+        // A secondary constructor means the class exposes more than one constructor-impl, so the
+        // fast box path is unavailable and boxing falls back to the kotlin-reflect constructor.
+        constructor(number: Int) : this(number.toString())
+    }
 
     private val kueryClient = h2.kueryClient()
 
@@ -199,6 +211,126 @@ class ValueClassFetchTest {
             +"SELECT text FROM converter"
         }.singleOrNull()
         assertThat(result).isEqualTo(UserName("user1"))
+    }
+
+    @Test
+    fun `singleOrNull returns null for a nullable-underlying value class scalar when no row matches`() {
+        // No row at all maps to the outer null, distinct from a SQL NULL row of a nullable-underlying
+        // value class, which maps to OptionalUserName(null).
+        // when & then
+        val result: OptionalUserName? = kueryClient.sql {
+            +"SELECT text FROM converter WHERE text = 'absent'"
+        }.singleOrNull()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `single rejects a SQL NULL value class scalar with a non-null underlying`() {
+        // The underlying type is non-null, so a SQL NULL cannot be held in the value class; single()
+        // must fail rather than hand back a null under a non-null return type. (singleOrNull()
+        // tolerates it and returns null; see the test above.)
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES (NULL)").update()
+
+        // when & then
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT text FROM converter"
+            }.single<UserName>()
+        }.isInstanceOf(TypeMismatchDataAccessException::class)
+    }
+
+    @Test
+    fun `non-nullable value class property rejects SQL NULL`() {
+        // The property and its underlying type are both non-null, so a SQL NULL cannot be taken into
+        // the value class; construction fails rather than yielding a null value class.
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES (NULL)").update()
+
+        // when & then
+        // Kotlin's non-null parameter intrinsic in the data class constructor rejects the null,
+        // the same failure the plain data class path produces for a non-null property.
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT text FROM converter"
+            }.single(NameRecord::class)
+        }.isInstanceOf(NullPointerException::class)
+    }
+
+    @Test
+    fun `value class with a secondary constructor is boxed through its primary constructor`() {
+        // A secondary constructor leaves no single constructor-impl/box-impl pair, so boxing falls
+        // back to the kotlin-reflect primary constructor rather than the fast path.
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1')").update()
+
+        // when & then
+        val result: Token = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single()
+        assertThat(result).isEqualTo(Token("user1"))
+    }
+
+    @Test
+    fun `init validation surfaces as the original exception for a value class with a secondary constructor`() {
+        // The kotlin-reflect constructor path wraps init failures in InvocationTargetException; it
+        // must be unwrapped so the require() IllegalArgumentException surfaces directly.
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('')").update()
+
+        // when & then
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT text FROM converter"
+            }.list<Token>()
+        }.isInstanceOf(IllegalArgumentException::class)
+            .hasMessage("must not be empty")
+    }
+
+    @Test
+    fun `generic value class is rejected as a scalar with a clear error`() {
+        // Same fail-fast as the data class property position, but with the generic value class as the
+        // fetch type itself: its underlying is a type parameter, so it cannot be boxed automatically.
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1')").update()
+
+        // when & then
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT text FROM converter"
+            }.list<Wrapped<String>>()
+        }.isInstanceOf(IllegalArgumentException::class)
+            .messageContains("generic value class")
+    }
+
+    @Test
+    fun `generic value class scalar is mapped through a registered reading converter`() {
+        // A generic value class cannot be boxed automatically, but a registered converter serves it
+        // as the fetch type itself (it wins before the boxing fail-fast).
+        // given
+        val kueryClient = h2.kueryClient(listOf(StringToWrappedConverter()))
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1')").update()
+
+        // when & then
+        val result: Wrapped<String> = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single()
+        assertThat(result).isEqualTo(Wrapped("user1"))
+    }
+
+    @Test
+    fun `generic value class scalar keeps SQL NULL as a null element`() {
+        // A generic value class has no known underlying type, so it cannot take a SQL NULL as an
+        // inner null; the SQL NULL row is kept as a null element, like a non-null-underlying scalar.
+        // given
+        val kueryClient = h2.kueryClient(listOf(StringToWrappedConverter()))
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1'), (NULL)").update()
+
+        // when & then
+        val result: List<Wrapped<String>?> = kueryClient.sql {
+            +"SELECT text FROM converter ORDER BY id"
+        }.list<Wrapped<String>>()
+        assertThat(result).isEqualTo(listOf(Wrapped("user1"), null))
     }
 
     @Test
@@ -533,6 +665,46 @@ class ValueClassFetchTest {
         val id: Long,
         val text: UserName?,
     )
+
+    @Test
+    fun `value class mutable body property is populated when no constructor parameter is a value class`() {
+        // The constructor takes no value class parameter, so mapping stays on Spring's
+        // DataClassRowMapper; a value class mutable body property is still populated through the
+        // inherited setter + ConversionService path.
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1')").update()
+
+        // when & then
+        val record: BodyValueClassRecord = kueryClient.sql {
+            +"SELECT id, text AS name FROM converter"
+        }.single()
+        assertThat(record.name).isEqualTo(UserName("user1"))
+    }
+
+    @Test
+    fun `value class mutable body property is populated alongside a value class constructor parameter`() {
+        // A value class constructor parameter routes to ValueClassPropertyRowMapper; a value class
+        // mutable body property is still populated through the inherited setter path.
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1')").update()
+
+        // when & then
+        val record: ConstructorAndBodyValueClassRecord = kueryClient.sql {
+            +"SELECT text, text AS name FROM converter"
+        }.single()
+        assertThat(record.text).isEqualTo(UserName("user1"))
+        assertThat(record.name).isEqualTo(UserName("user1"))
+    }
+
+    data class BodyValueClassRecord(val id: Long) {
+        var name: UserName? = null
+    }
+
+    data class ConstructorAndBodyValueClassRecord(val text: UserName) {
+        var name: UserName? = null
+    }
+
+    data class NameRecord(val text: UserName)
 
     data class EnumRecord(val text: Status)
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/postgres/PostgresArrayBindingTest.kt
@@ -28,6 +28,12 @@ class PostgresArrayBindingTest {
     @JvmInline
     value class Wrapped<T>(val value: T)
 
+    @JvmInline
+    value class Status(val value: SampleEnum)
+
+    @JvmInline
+    value class OptionalStatus(val value: SampleEnum?)
+
     @WritingConverter
     class StringWrapperToStringConverter : Converter<StringWrapper, String> {
         override fun convert(source: StringWrapper): String = source.value
@@ -92,6 +98,66 @@ class PostgresArrayBindingTest {
 
         // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind value class wrapping enum array to ANY predicate`() {
+        // The value class recurses value class -> enum -> String, so the array binds as String[]
+        // with the enum names.
+        // given
+        val statuses = arrayOf(Status(SampleEnum.HOGE), Status(SampleEnum.FUGA))
+
+        // when
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($statuses) ORDER BY user_id" }
+            .listMap()
+
+        // then
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind empty value class wrapping enum array to a native array column`() {
+        // The component type carries the value class -> enum -> String intent even with no elements,
+        // so an empty array still binds as String[].
+        // given
+        val tags = arrayOf<Status>()
+
+        // when
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+
+        // then
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = (record["tags"] as SqlArray).array as Array<*>
+        assertThat(stored.toList()).isEqualTo(emptyList<String>())
+    }
+
+    @Test
+    fun `bind all-inner-null value class wrapping enum array to a native array column`() {
+        // Every element is an inner null (nullable underlying enum); the component type is still
+        // resolved to String[] from the value class, so the array binds with null elements.
+        // given
+        val tags = arrayOf(OptionalStatus(null), OptionalStatus(null))
+
+        // when
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+
+        // then
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = (record["tags"] as SqlArray).array as Array<*>
+        assertThat(stored.toList()).isEqualTo(listOf(null, null))
     }
 
     @Test

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/conversion/ValueClassConversionTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/conversion/ValueClassConversionTest.kt
@@ -46,6 +46,11 @@ class ValueClassConversionTest {
     @JvmInline
     value class OptionalAge(val value: Int?)
 
+    data class CustomType(val raw: String)
+
+    @JvmInline
+    value class WrappedCustomType(val value: CustomType)
+
     private val kueryClient = h2.kueryClient()
 
     @BeforeEach
@@ -239,9 +244,34 @@ class ValueClassConversionTest {
         assertThat(map["text"]).isEqualTo("custom:hoge")
     }
 
+    @Test
+    fun `unwrapped underlying value goes through its own writing converter`() = runTest {
+        // No converter targets WrappedCustomType itself, so it is unwrapped to its CustomType
+        // underlying, which is then re-dispatched through the conversion pipeline and picked up by
+        // the CustomType -> String writing converter.
+        // given
+        val kueryClient = h2.kueryClient(listOf(CustomTypeToStringConverter()))
+
+        // when
+        kueryClient.sql {
+            +"INSERT INTO converter (text) VALUES (${WrappedCustomType(CustomType("hoge"))})"
+        }.rowsUpdated()
+
+        // then
+        val map = kueryClient.sql {
+            +"SELECT * FROM converter"
+        }.singleMap()
+        assertThat(map["text"]).isEqualTo("custom:hoge")
+    }
+
     @WritingConverter
     class UserNameToStringConverter : Converter<UserName, String> {
         override fun convert(source: UserName): String = "custom:${source.value}"
+    }
+
+    @WritingConverter
+    class CustomTypeToStringConverter : Converter<CustomType, String> {
+        override fun convert(source: CustomType): String = "custom:${source.raw}"
     }
 
     companion object {

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/ValueClassScalarRowMapperTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/internal/ValueClassScalarRowMapperTest.kt
@@ -1,0 +1,70 @@
+package dev.hsbrysk.kuery.spring.r2dbc.internal
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import io.r2dbc.spi.Readable
+import org.junit.jupiter.api.Test
+import org.springframework.core.convert.support.DefaultConversionService
+
+/**
+ * Direct unit tests for [ValueClassScalarRowMapper]'s driver typed-retrieval fallback, driving a
+ * fake [Readable] instead of a real database. The R2DBC SPI signals "the column cannot be decoded
+ * to the requested type" as an `IllegalArgumentException`; only that must degrade to the raw value,
+ * while any other driver/connection fault must propagate.
+ *
+ * R2DBC-only (no jdbc mirror): the jdbc counterpart falls back on `SQLException`, a checked
+ * exception with different semantics, and faking a full `ResultSet` would add little.
+ */
+class ValueClassScalarRowMapperTest {
+    @JvmInline
+    value class Amount(val value: Int)
+
+    // A Readable whose single column reads back as [raw] with no type hint, and whose typed
+    // retrieval is driven by [typed] so the fallback behaviour can be exercised deterministically.
+    private class FakeReadable(
+        private val raw: Any?,
+        private val typed: (Class<*>) -> Any?,
+    ) : Readable {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : Any?> get(
+            index: Int,
+            type: Class<T>,
+        ): T? = typed(type) as T?
+
+        override fun get(index: Int): Any? = raw
+
+        override fun <T : Any?> get(
+            name: String,
+            type: Class<T>,
+        ): T? = throw UnsupportedOperationException()
+
+        override fun get(name: String): Any? = throw UnsupportedOperationException()
+    }
+
+    private fun mapper() = ValueClassScalarRowMapper(Amount::class, DefaultConversionService())
+
+    @Test
+    fun `driver typed retrieval falls back to the raw value on IllegalArgumentException`() {
+        // The raw Long is coercible to the Int underlying by the ConversionService, but the driver
+        // cannot decode the column to Int and signals it as IllegalArgumentException; retrieval must
+        // degrade to the raw value rather than fail.
+        // given
+        val readable = FakeReadable(raw = 1L) { throw IllegalArgumentException("cannot decode to Integer") }
+
+        // when & then
+        assertThat(mapper().apply(readable)).isEqualTo(Amount(1))
+    }
+
+    @Test
+    fun `an unexpected driver exception propagates from typed retrieval`() {
+        // A driver/connection fault (here an IllegalStateException) is not the "cannot decode" signal
+        // and must not be masked as a fall-back to the raw value.
+        // given
+        val readable = FakeReadable(raw = 1L) { throw IllegalStateException("connection reset") }
+
+        // when & then
+        assertFailure { mapper().apply(readable) }.isInstanceOf(IllegalStateException::class)
+    }
+}

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mapping/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mapping/ValueClassFetchTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.core.convert.converter.Converter
 import org.springframework.dao.DataRetrievalFailureException
+import org.springframework.dao.TypeMismatchDataAccessException
 import org.springframework.data.convert.ReadingConverter
 import org.springframework.r2dbc.core.awaitRowsUpdated
 import java.math.BigDecimal
@@ -83,6 +84,17 @@ class ValueClassFetchTest {
 
     @JvmInline
     value class OptionalUserName(val value: String?)
+
+    @JvmInline
+    value class Token(val value: String) {
+        init {
+            require(value.isNotEmpty()) { "must not be empty" }
+        }
+
+        // A secondary constructor means the class exposes more than one constructor-impl, so the
+        // fast box path is unavailable and boxing falls back to the kotlin-reflect constructor.
+        constructor(number: Int) : this(number.toString())
+    }
 
     private val kueryClient = h2.kueryClient()
 
@@ -202,6 +214,157 @@ class ValueClassFetchTest {
             +"SELECT text FROM converter"
         }.singleOrNull()
         assertThat(result).isEqualTo(UserName("user1"))
+    }
+
+    @Test
+    fun `singleOrNull returns null for a nullable-underlying value class scalar when no row matches`() = runTest {
+        // No row at all maps to the outer null, distinct from a SQL NULL row of a nullable-underlying
+        // value class, which maps to OptionalUserName(null).
+        // when & then
+        val result: OptionalUserName? = kueryClient.sql {
+            +"SELECT text FROM converter WHERE text = 'absent'"
+        }.singleOrNull()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `single rejects a SQL NULL value class scalar with a non-null underlying`() = runTest {
+        // The underlying type is non-null, so a SQL NULL cannot be held in the value class; single()
+        // must fail rather than hand back a null under a non-null return type. (singleOrNull()
+        // tolerates it and returns null; see the test above.)
+        // given
+        insert("INSERT INTO converter (text) VALUES (NULL)")
+
+        // when & then
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT text FROM converter"
+            }.single<UserName>()
+        }.isInstanceOf(TypeMismatchDataAccessException::class)
+    }
+
+    @Test
+    fun `non-nullable value class property rejects SQL NULL`() = runTest {
+        // The property and its underlying type are both non-null, so a SQL NULL cannot be taken into
+        // the value class; construction fails rather than yielding a null value class.
+        // given
+        insert("INSERT INTO converter (text) VALUES (NULL)")
+
+        // when & then
+        // Kotlin's non-null parameter intrinsic in the data class constructor rejects the null,
+        // the same failure the plain data class path produces for a non-null property.
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT text FROM converter"
+            }.single(NameRecord::class)
+        }.isInstanceOf(NullPointerException::class)
+    }
+
+    @Test
+    fun `value class with a secondary constructor is boxed through its primary constructor`() = runTest {
+        // A secondary constructor leaves no single constructor-impl/box-impl pair, so boxing falls
+        // back to the kotlin-reflect primary constructor rather than the fast path.
+        // given
+        insert("INSERT INTO converter (text) VALUES ('user1')")
+
+        // when & then
+        val result: Token = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single()
+        assertThat(result).isEqualTo(Token("user1"))
+    }
+
+    @Test
+    fun `init validation surfaces as the original exception for a value class with a secondary constructor`() =
+        runTest {
+            // The kotlin-reflect constructor path wraps init failures in InvocationTargetException; it
+            // must be unwrapped so the require() IllegalArgumentException surfaces directly.
+            // given
+            insert("INSERT INTO converter (text) VALUES ('')")
+
+            // when & then
+            assertFailure {
+                kueryClient.sql {
+                    +"SELECT text FROM converter"
+                }.list<Token>()
+            }.isInstanceOf(IllegalArgumentException::class)
+                .hasMessage("must not be empty")
+        }
+
+    @Test
+    fun `generic value class is rejected as a scalar with a clear error`() = runTest {
+        // Same fail-fast as the data class property position, but with the generic value class as the
+        // fetch type itself: its underlying is a type parameter, so it cannot be boxed automatically.
+        // given
+        insert("INSERT INTO converter (text) VALUES ('user1')")
+
+        // when & then
+        assertFailure {
+            kueryClient.sql {
+                +"SELECT text FROM converter"
+            }.list<Wrapped<String>>()
+        }.isInstanceOf(IllegalArgumentException::class)
+            .messageContains("generic value class")
+    }
+
+    @Test
+    fun `generic value class scalar is mapped through a registered reading converter`() = runTest {
+        // A generic value class cannot be boxed automatically, but a registered converter serves it
+        // as the fetch type itself (it wins before the boxing fail-fast).
+        // given
+        val kueryClient = h2.kueryClient(listOf(StringToWrappedConverter()))
+        insert("INSERT INTO converter (text) VALUES ('user1')")
+
+        // when & then
+        val result: Wrapped<String> = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single()
+        assertThat(result).isEqualTo(Wrapped("user1"))
+    }
+
+    @Test
+    fun `generic value class scalar keeps SQL NULL as a null element`() = runTest {
+        // A generic value class has no known underlying type, so it cannot take a SQL NULL as an
+        // inner null; the SQL NULL row is kept as a null element, like a non-null-underlying scalar.
+        // given
+        val kueryClient = h2.kueryClient(listOf(StringToWrappedConverter()))
+        insert("INSERT INTO converter (text) VALUES ('user1'), (NULL)")
+
+        // when & then
+        val result: List<Wrapped<String>?> = kueryClient.sql {
+            +"SELECT text FROM converter ORDER BY id"
+        }.list<Wrapped<String>>()
+        assertThat(result).isEqualTo(listOf(Wrapped("user1"), null))
+    }
+
+    @Test
+    fun `value class mutable body property is populated when no constructor parameter is a value class`() = runTest {
+        // The constructor takes no value class parameter, so mapping stays on Spring's
+        // DataClassRowMapper; a value class mutable body property is still populated through the
+        // inherited setter + ConversionService path.
+        // given
+        insert("INSERT INTO converter (text) VALUES ('user1')")
+
+        // when & then
+        val record: BodyValueClassRecord = kueryClient.sql {
+            +"SELECT id, text AS name FROM converter"
+        }.single()
+        assertThat(record.name).isEqualTo(UserName("user1"))
+    }
+
+    @Test
+    fun `value class mutable body property is populated alongside a value class constructor parameter`() = runTest {
+        // A value class constructor parameter routes to ValueClassPropertyRowMapper; a value class
+        // mutable body property is still populated through the inherited setter path.
+        // given
+        insert("INSERT INTO converter (text) VALUES ('user1')")
+
+        // when & then
+        val record: ConstructorAndBodyValueClassRecord = kueryClient.sql {
+            +"SELECT text, text AS name FROM converter"
+        }.single()
+        assertThat(record.text).isEqualTo(UserName("user1"))
+        assertThat(record.name).isEqualTo(UserName("user1"))
     }
 
     @Test
@@ -500,6 +663,16 @@ class ValueClassFetchTest {
         val id: Long,
         val text: UserName?,
     )
+
+    data class BodyValueClassRecord(val id: Long) {
+        var name: UserName? = null
+    }
+
+    data class ConstructorAndBodyValueClassRecord(val text: UserName) {
+        var name: UserName? = null
+    }
+
+    data class NameRecord(val text: UserName)
 
     data class EnumRecord(val text: Status)
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/postgres/PostgresArrayBindingTest.kt
@@ -29,6 +29,12 @@ class PostgresArrayBindingTest {
     @JvmInline
     value class Wrapped<T>(val value: T)
 
+    @JvmInline
+    value class Status(val value: SampleEnum)
+
+    @JvmInline
+    value class OptionalStatus(val value: SampleEnum?)
+
     @WritingConverter
     class StringWrapperToStringConverter : Converter<StringWrapper, String> {
         override fun convert(source: StringWrapper): String = source.value
@@ -95,6 +101,66 @@ class PostgresArrayBindingTest {
 
         // then
         assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind value class wrapping enum array to ANY predicate`() = runTest {
+        // The value class recurses value class -> enum -> String, so the array binds as String[]
+        // with the enum names.
+        // given
+        val statuses = arrayOf(Status(SampleEnum.HOGE), Status(SampleEnum.FUGA))
+
+        // when
+        val list = kueryClient
+            .sql { +"SELECT username FROM users WHERE username = ANY($statuses) ORDER BY user_id" }
+            .listMap()
+
+        // then
+        assertThat(list.map { it["username"] }).isEqualTo(listOf("HOGE", "FUGA"))
+    }
+
+    @Test
+    fun `bind empty value class wrapping enum array to a native array column`() = runTest {
+        // The component type carries the value class -> enum -> String intent even with no elements,
+        // so an empty array still binds as String[].
+        // given
+        val tags = arrayOf<Status>()
+
+        // when
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+
+        // then
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = record["tags"] as Array<*>
+        assertThat(stored.toList()).isEqualTo(emptyList<String>())
+    }
+
+    @Test
+    fun `bind all-inner-null value class wrapping enum array to a native array column`() = runTest {
+        // Every element is an inner null (nullable underlying enum); the component type is still
+        // resolved to String[] from the value class, so the array binds with null elements.
+        // given
+        val tags = arrayOf(OptionalStatus(null), OptionalStatus(null))
+
+        // when
+        val count = kueryClient
+            .sql { +"INSERT INTO users (username, tags) VALUES ('tagged', $tags)" }
+            .rowsUpdated()
+
+        // then
+        assertThat(count).isEqualTo(1L)
+
+        val record = kueryClient
+            .sql { +"SELECT tags FROM users WHERE username = 'tagged'" }
+            .singleMap()
+        val stored = record["tags"] as Array<*>
+        assertThat(stored.toList()).isEqualTo(listOf(null, null))
     }
 
     @Test


### PR DESCRIPTION
Follow-up test coverage for the value class read/write support (after #434 / #439), pinning previously unverified branches — one spec per test. The jdbc and r2dbc suites mirror each other with identical class/method names unless a behaviour is genuinely one-sided. DB-independent behaviour runs on H2; only driver-dependent array codecs run on PostgreSQL Testcontainers. No production code changes — tests and docs only.

## What is covered

- **Non-nullable value class + SQL NULL**: a non-nullable value class property rejects SQL NULL with a `NullPointerException` (Kotlin's non-null intrinsic in the data class constructor, matching the plain data class path), and a non-null-underlying scalar fails through `single()`.
- **`singleOrNull()` NULL boundary**: on a nullable-underlying scalar, no matching row maps to the outer `null`, distinct from a SQL NULL row mapping to `X(null)`.
- **Writing converter after unwrapping**: a value class with no converter of its own is unwrapped to its underlying type, and the underlying type's `@WritingConverter` is then applied (re-dispatch), distinct from the existing "converter on the value class itself wins" test.
- **Secondary constructor**: a value class with a secondary constructor boxes through the kotlin-reflect primary constructor (no single `constructor-impl`/`box-impl` fast path), and its `init` failure surfaces as the original exception rather than `InvocationTargetException`.
- **Value class mutable body property**: populated both when no constructor parameter is a value class (Spring's `DataClassRowMapper`) and alongside a value class constructor parameter (`ValueClassPropertyRowMapper`). This turned out to be already supported, so it is pinned rather than documented as a limitation.
- **Generic value class as a top-level scalar**: rejected with a clear error without a converter, served by a registered reading converter, and a scalar SQL NULL is kept as a `null` element.
- **PostgreSQL value-class-wrapping-enum arrays**: bind as `String[]` (recursing value class → enum → String), including empty and all-inner-null arrays — directly covering the `componentWriteTarget` recursion.
- **R2DBC typed-retrieval fallback (r2dbc-only)**: `ValueClassScalarRowMapper` is driven with a fake `Readable` to pin the narrowed catch from #439 — only `IllegalArgumentException` degrades to the raw value; any other driver fault propagates. jdbc falls back on `SQLException` with different semantics, so this is genuinely one-sided.

Documents value class mutable body property support and the generic value class scalar SQL NULL behaviour in `row-mapping.md`.

## Verification

`./gradlew build` passes — all tests (including the MySQL/PostgreSQL Testcontainers suites), ktlint, detekt, and the Kotlin ABI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)