### PR TITLE
Cover value class parameter combinations in fetch mapping

### DIFF
--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mapping/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/mapping/ValueClassFetchTest.kt
@@ -413,6 +413,50 @@ class ValueClassFetchTest {
     }
 
     @Test
+    fun `value class wrapping an enum is mapped as a scalar`() {
+        // The scalar path (value class as the fetch type itself) recurses value class -> enum: the
+        // column String is coerced to the enum underlying through the ConversionService, then boxed.
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('HOGE')").update()
+
+        // when & then
+        val result: List<Status> = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.list()
+        assertThat(result).isEqualTo(listOf(Status(SampleEnum.HOGE)))
+    }
+
+    @Test
+    fun `each value class constructor parameter is mapped from its own column`() {
+        // A data class with more than one value class parameter: each parameter must be resolved
+        // from its own matched column independently, with no cross-talk between converters.
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('user1')").update()
+
+        // when & then
+        val record: MultiValueClassRecord = kueryClient.sql {
+            +"SELECT text AS name, id AS amount FROM converter"
+        }.single()
+        assertThat(record.name).isEqualTo(UserName("user1"))
+        assertThat(record.amount).isEqualTo(Amount(1))
+    }
+
+    @Test
+    fun `default value applies when the column for a defaulted value class parameter is SQL NULL`() {
+        // A value class parameter with a Kotlin default: a SQL NULL yields a null converted value,
+        // which is omitted for the optional parameter so the default value class applies (mirrors
+        // the non-value-class defaulted parameter path).
+        // given
+        h2.jdbcClient.sql("INSERT INTO converter (text) VALUES (NULL)").update()
+
+        // when & then
+        val record: DefaultedValueClassRecord = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single()
+        assertThat(record.text).isEqualTo(UserName("default"))
+    }
+
+    @Test
     fun `init validation runs when mapping a value class`() {
         // given
         h2.jdbcClient.sql("INSERT INTO converter (text) VALUES ('')").update()
@@ -705,6 +749,13 @@ class ValueClassFetchTest {
     }
 
     data class NameRecord(val text: UserName)
+
+    data class MultiValueClassRecord(
+        val name: UserName,
+        val amount: Amount,
+    )
+
+    data class DefaultedValueClassRecord(val text: UserName = UserName("default"))
 
     data class EnumRecord(val text: Status)
 

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mapping/ValueClassFetchTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/mapping/ValueClassFetchTest.kt
@@ -432,6 +432,50 @@ class ValueClassFetchTest {
     }
 
     @Test
+    fun `value class wrapping an enum is mapped as a scalar`() = runTest {
+        // The scalar path (value class as the fetch type itself) recurses value class -> enum: the
+        // column String is coerced to the enum underlying through the ConversionService, then boxed.
+        // given
+        insert("INSERT INTO converter (text) VALUES ('HOGE')")
+
+        // when & then
+        val result: List<Status> = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.list()
+        assertThat(result).isEqualTo(listOf(Status(SampleEnum.HOGE)))
+    }
+
+    @Test
+    fun `each value class constructor parameter is mapped from its own column`() = runTest {
+        // A data class with more than one value class parameter: each parameter must be resolved
+        // from its own matched column independently, with no cross-talk between converters.
+        // given
+        insert("INSERT INTO converter (text) VALUES ('user1')")
+
+        // when & then
+        val record: MultiValueClassRecord = kueryClient.sql {
+            +"SELECT text AS name, id AS amount FROM converter"
+        }.single()
+        assertThat(record.name).isEqualTo(UserName("user1"))
+        assertThat(record.amount).isEqualTo(Amount(1))
+    }
+
+    @Test
+    fun `default value applies when the column for a defaulted value class parameter is SQL NULL`() = runTest {
+        // A value class parameter with a Kotlin default: a SQL NULL yields a null converted value,
+        // which is omitted for the optional parameter so the default value class applies (mirrors
+        // the non-value-class defaulted parameter path).
+        // given
+        insert("INSERT INTO converter (text) VALUES (NULL)")
+
+        // when & then
+        val record: DefaultedValueClassRecord = kueryClient.sql {
+            +"SELECT text FROM converter"
+        }.single()
+        assertThat(record.text).isEqualTo(UserName("default"))
+    }
+
+    @Test
     fun `init validation runs when mapping a value class`() = runTest {
         // given
         insert("INSERT INTO converter (text) VALUES ('')")
@@ -673,6 +717,13 @@ class ValueClassFetchTest {
     }
 
     data class NameRecord(val text: UserName)
+
+    data class MultiValueClassRecord(
+        val name: UserName,
+        val amount: Amount,
+    )
+
+    data class DefaultedValueClassRecord(val text: UserName = UserName("default"))
 
     data class EnumRecord(val text: Status)
 


### PR DESCRIPTION
Additional fetch-side test coverage for value class combinations not exercised by the existing tests (a follow-up to #440). One spec per test, mirrored across the jdbc and r2dbc suites with identical names, all on H2. Tests only — no production code changes.

## What is covered

- **Value class wrapping an enum as the scalar fetch type** (`list<Status>()`): previously only covered as a data class property (`EnumRecord`). This exercises `ValueClassScalarRowMapper`'s `value class -> enum` coercion (column `String` → enum underlying via the `ConversionService`, then boxed) end to end.
- **A data class with more than one value class constructor parameter**: every existing record has at most one value class parameter, so the parameter loop resolving several value class converters — each from its own matched column, with no cross-talk — was untested.
- **A defaulted value class constructor parameter over a SQL NULL column**: the null converted value is omitted for the optional parameter so the Kotlin default value class applies. The existing defaulted-parameter test uses a non-value-class (`String`) default, so the value class variant of that interaction was untested.

All three passed on the first run — no behaviour surprises; they pin combinations whose underlying logic was only covered in isolation (unit tests) or in a different position.

## Verification

`./gradlew build` passes — all tests (including the MySQL/PostgreSQL Testcontainers suites), ktlint, detekt, and the Kotlin ABI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)