### PR TITLE
Document the shared Spring Data module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Integration tests (`kuery-client-spring-data-r2dbc`, `kuery-client-spring-data-j
 | `kuery-client-core` | Core interfaces and SQL builder. No Spring dependency. |
 | `kuery-client-compiler` | Kotlin compiler plugin (IR transformation). |
 | `kuery-client-gradle-plugin` | Gradle plugin that wires the compiler plugin into user projects. |
+| `kuery-client-spring-data-common` | Internal support shared by the two Spring Data implementations (value class reflection, read/write conversion). Published as their runtime dependency but exposes no public API. |
 | `kuery-client-spring-data-r2dbc` | `KueryClient` implementation using Spring Data R2DBC (coroutines). |
 | `kuery-client-spring-data-jdbc` | `KueryBlockingClient` implementation using Spring Data JDBC (blocking). |
 | `build-logic` | Convention Gradle plugins shared across modules. |
@@ -77,7 +78,7 @@ Row mapping uses `DataClassRowMapper` (Spring's data class mapper) for complex t
 
 All modules apply `conventions.preset.base` (= `conventions.kotlin` + `conventions.ktlint` + `conventions.detekt`). The Kotlin toolchain is Java 17 (Adoptium). `allWarningsAsErrors = true` is enforced. Versions are centralized in `gradle/libs.versions.toml`.
 
-`kuery-client-core`, `kuery-client-spring-data-jdbc`, and `kuery-client-spring-data-r2dbc` additionally apply `conventions.public-api`, which enables Kotlin explicit API mode and KGP built-in ABI validation. `checkKotlinAbi` runs as part of `check`; when the public API changes intentionally, run `./gradlew updateKotlinAbi` and commit the updated `api/*.api` files. Declarations annotated with `@KueryClientInternalApi` are excluded from the ABI dumps and carry no compatibility guarantee.
+`kuery-client-core`, `kuery-client-spring-data-common`, `kuery-client-spring-data-jdbc`, and `kuery-client-spring-data-r2dbc` additionally apply `conventions.public-api`, which enables Kotlin explicit API mode and KGP built-in ABI validation. `checkKotlinAbi` runs as part of `check`; when the public API changes intentionally, run `./gradlew updateKotlinAbi` and commit the updated `api/*.api` files. Declarations annotated with `@KueryClientInternalApi` are excluded from the ABI dumps and carry no compatibility guarantee. The `kuery-client-spring-data-common` dump is intentionally empty — every declaration there is `@KueryClientInternalApi`, public only so the jdbc/r2dbc modules can reach it.
 
 ### `@DelicateKueryClientApi`
 

--- a/kuery-client-spring-data-common/src/main/kotlin/dev/hsbrysk/kuery/spring/data/internal/SpringDataWriteConverter.kt
+++ b/kuery-client-spring-data-common/src/main/kotlin/dev/hsbrysk/kuery/spring/data/internal/SpringDataWriteConverter.kt
@@ -41,7 +41,10 @@ public class SpringDataWriteConverter(
             KotlinDetector.isInlineClass(componentType) -> {
                 val underlying = ValueClasses.underlyingType(componentType)
                 // A generic value class erases its underlying to Object, which is not a useful SQL
-                // array component type. Infer it from the converted elements when possible.
+                // array component type; return null so the caller infers the concrete type from the
+                // converted elements. An empty or all-null such array cannot be inferred — no
+                // driver-compatible component type can be produced and most drivers reject it
+                // (documented as unsupported).
                 if (underlying == Any::class.java) null else componentWriteTarget(underlying) ?: underlying
             }
             Enum::class.java.isAssignableFrom(componentType) -> String::class.java


### PR DESCRIPTION
## Summary

Follow up on #443, which extracted `kuery-client-spring-data-common` but left two documentation gaps:

- Add `kuery-client-spring-data-common` to the AGENTS.md module table and to the list of modules applying `conventions.public-api`, noting that its ABI dump is intentionally empty (every declaration is `@KueryClientInternalApi`) so the empty `api` file is not mistaken for a broken dump.
- Restore the `componentWriteTarget` comment stating that an empty or all-null generic value class array cannot be inferred and is documented as unsupported. This edge case's only in-code record was dropped during the extraction; the behavior itself is unchanged.

## Validation

- `./gradlew :kuery-client-spring-data-common:ktlintCheck :kuery-client-spring-data-common:compileKotlin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)