### PR TITLE
Introduce Codecov with Kover coverage aggregation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,15 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Check
         run: |
-          ./gradlew check detektMain detektTest
+          ./gradlew check detektMain detektTest :koverXmlReport
           ./gradlew -p examples check detektMain detektTest
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/reports/kover/report.xml
+          disable_search: true
+          fail_ci_if_error: false
 
   build-docs:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Kotlin SQL client built on Spring Data — interpolated runtime values become 
 
 <a href="https://central.sonatype.com/search?q=kuery-client"><img alt="Maven Central Version" src="https://img.shields.io/maven-central/v/dev.hsbrysk.kuery-client/kuery-client-core"></a>
 <a href="https://github.com/be-hase/kuery-client/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/be-hase/kuery-client/actions/workflows/ci.yml/badge.svg"></a>
+<a href="https://codecov.io/gh/be-hase/kuery-client"><img alt="Codecov" src="https://codecov.io/gh/be-hase/kuery-client/branch/main/graph/badge.svg"></a>
 <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/be-hase/kuery-client"></a>
 
 <a href="https://kuery-client.hsbrysk.dev/"><b>Document Site</b></a> ·

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation(libs.gradle.plugin.dokka)
     implementation(libs.gradle.plugin.jmh)
     implementation(libs.gradle.plugin.kotlin)
+    implementation(libs.gradle.plugin.kover)
     implementation(libs.gradle.plugin.ktlint)
     implementation(libs.gradle.plugin.maven.publish)
 

--- a/build-logic/src/main/kotlin/conventions/kover.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/kover.gradle.kts
@@ -3,3 +3,13 @@ package conventions
 plugins {
     id("org.jetbrains.kotlinx.kover")
 }
+
+// Modules with conventions.jmh have a "jmh" source set alongside "main"; without this, its
+// benchmark classes are instrumented as always-uncovered production code.
+kover {
+    currentProject {
+        sources {
+            excludedSourceSets.addAll("jmh")
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/conventions/kover.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/kover.gradle.kts
@@ -1,0 +1,5 @@
+package conventions
+
+plugins {
+    id("org.jetbrains.kotlinx.kover")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,14 @@
 plugins {
     // Load the Kotlin plugin once so all subprojects share the same plugin classloader.
     alias(libs.plugins.kotlin.jvm) apply false
+    id("conventions.kover")
+}
+
+dependencies {
+    kover(projects.kueryClientCore)
+    kover(projects.kueryClientCompiler)
+    kover(projects.kueryClientSpringDataCommon)
+    kover(projects.kueryClientSpringDataJdbc)
+    kover(projects.kueryClientSpringDataR2dbc)
+    kover(projects.kueryClientSpringDataTesting)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 dependencies {
     kover(projects.kueryClientCore)
     kover(projects.kueryClientCompiler)
+    kover(projects.kueryClientGradlePlugin)
     kover(projects.kueryClientSpringDataCommon)
     kover(projects.kueryClientSpringDataJdbc)
     kover(projects.kueryClientSpringDataR2dbc)
-    kover(projects.kueryClientSpringDataTesting)
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        informational: true
+
+comment:
+  layout: "header, diff, files"
+  behavior: default
+  require_changes: true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 detekt = "1.23.8"
 kotlin-core = "2.4.10"
 kotlin-coroutines = "1.11.0"
+kover = "0.9.9"
 ktlint = "1.8.0"
 micrometer = "1.17.0"
 spring-boot = "4.1.0"
@@ -33,6 +34,7 @@ gradle-plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plu
 gradle-plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }
 gradle-plugin-jmh = { module = "me.champeau.jmh:jmh-gradle-plugin", version = "0.7.3" }
 gradle-plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-core" }
+gradle-plugin-kover = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 gradle-plugin-ktlint = { module = "org.jlleitschuh.gradle:ktlint-gradle", version = "14.2.0" }
 gradle-plugin-maven-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.37.0" }
 

--- a/kuery-client-compiler/build.gradle.kts
+++ b/kuery-client-compiler/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("conventions.preset.base")
     id("conventions.maven-publish")
     id("conventions.functional-test-publish")
+    id("conventions.kover")
 }
 
 description = "Compiler plugin for the Kuery client."

--- a/kuery-client-core/build.gradle.kts
+++ b/kuery-client-core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("conventions.maven-publish")
     id("conventions.functional-test-publish")
     id("conventions.jmh")
+    id("conventions.kover")
 }
 
 description = "Kuery client's core module."

--- a/kuery-client-gradle-plugin/build.gradle.kts
+++ b/kuery-client-gradle-plugin/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     // build scripts, but Gradle plugin code doesn't follow library explicit-API conventions.
     id("conventions.abi-validation")
     id("conventions.functional-test-publish")
+    id("conventions.kover")
     `java-gradle-plugin`
     signing
     alias(libs.plugins.plugin.publish)

--- a/kuery-client-spring-data-common/build.gradle.kts
+++ b/kuery-client-spring-data-common/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("conventions.preset.base")
     id("conventions.public-api")
     id("conventions.maven-publish")
+    id("conventions.kover")
 }
 
 description = "Shared Spring Data support for Kuery Client implementations."

--- a/kuery-client-spring-data-jdbc/build.gradle.kts
+++ b/kuery-client-spring-data-jdbc/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("conventions.public-api")
     id("conventions.maven-publish")
     id("conventions.jmh")
+    id("conventions.kover")
 }
 
 description = "Kuery client implementation using spring-data-jdbc."

--- a/kuery-client-spring-data-r2dbc/build.gradle.kts
+++ b/kuery-client-spring-data-r2dbc/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("conventions.public-api")
     id("conventions.maven-publish")
     id("conventions.jmh")
+    id("conventions.kover")
 }
 
 description = "Kuery client implementation using spring-data-r2dbc."

--- a/kuery-client-spring-data-testing/build.gradle.kts
+++ b/kuery-client-spring-data-testing/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("conventions.preset.base")
+    id("conventions.kover")
     // Deliberately no conventions.public-api / conventions.maven-publish: this module is not
     // published, and its contract classes are excluded from explicit API mode and ABI checks.
 }

--- a/kuery-client-spring-data-testing/build.gradle.kts
+++ b/kuery-client-spring-data-testing/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("conventions.preset.base")
-    id("conventions.kover")
     // Deliberately no conventions.public-api / conventions.maven-publish: this module is not
     // published, and its contract classes are excluded from explicit API mode and ABI checks.
 }


### PR DESCRIPTION
## Summary

Introduces test coverage reporting with [Kover](https://github.com/Kotlin/kotlinx-kover) (0.9.9) and uploads the merged report to Codecov from CI.

### Coverage setup

- New thin `conventions.kover` convention plugin, applied to the six published product modules: `kuery-client-core`, `kuery-client-compiler`, `kuery-client-gradle-plugin`, `kuery-client-spring-data-common/jdbc/r2dbc`. It is deliberately **not** part of `conventions.preset.base`, to avoid instrumenting modules where it is pointless.
- The root project aggregates them into a single merged XML report (`:koverXmlReport` → `build/reports/kover/report.xml`). Aggregation (rather than per-module uploads) matters here because coverage crosses module boundaries: the spring-data-jdbc/r2dbc test runs also exercise `kuery-client-core`.
- Excluded from aggregation:
  - `kuery-client-spring-data-testing` — unpublished shared contract-test/test-utility module, not product code, even though it lives under `src/main`.
  - JMH benchmark modules and the compiler `functional-test` modules — the compiler plugin runs at compile time in Gradle workers, so nothing is recorded at test runtime.
  - `examples` — separate build.
- Within the jdbc/r2dbc modules, the `jmh` source set (which shares its package with production code) is also excluded via `excludedSourceSets`, since it was otherwise instrumented as always-uncovered production code.
- `kuery-client-gradle-plugin` is included even though its functional tests run in a separate Gradle TestKit process and stay uncovered — only its ordinary unit tests are measurable by Kover. That gap is accepted as an honest reflection of the current state rather than hidden by excluding the whole module.

### CI / Codecov

- `ci.yml` runs `:koverXmlReport` in the same invocation as `check` (tests run once) and uploads via `codecov/codecov-action@v7`. Fork PRs fall back to tokenless uploads automatically when the `CODECOV_TOKEN` secret is unavailable.
- `codecov.yml` starts both project and patch status checks as `informational`, so coverage never blocks a PR until the numbers settle; the PR comment is suppressed when coverage does not change.
- README gains a Codecov badge.

Local merged report currently sits at **97.5% line coverage** across the six product modules (after excluding the `jmh` source set from instrumentation).

### Follow-up (manual, before/after merge)

1. Enable the repo on https://app.codecov.io and install the Codecov GitHub App.
2. Register the upload token as the `CODECOV_TOKEN` Actions secret.
3. After the first upload on `main`, the badge goes live.

## Test plan

- [x] `./gradlew :koverXmlReport` — merged report contains exactly the six target modules (`spring-data-testing`/benchmark/functional-test packages absent, `kuery-client-gradle-plugin` present), cross-module coverage credited
- [x] `./gradlew check detektMain detektTest` — green (ktlint, detekt, ABI check, all tests incl. Testcontainers)
- [ ] CI on this PR: codecov-action upload succeeds (tokenless until the secret is registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
