### PR TITLE
Add tests for previously untested behavior found while auditing coverage

### DIFF
--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/SqlSyntaxCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/SqlSyntaxCheckerTest.kt
@@ -658,6 +658,52 @@ class SqlSyntaxCheckerTest {
     }
 
     @Test
+    fun `warn for sql calls through an intersection-typed receiver`() {
+        // A smart cast on an unbounded type parameter produces an intersection type
+        // (T & KueryBlockingClient); the call must still be recognized as a client sql call.
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.KueryBlockingClient
+
+            fun <T> query(client: T) {
+                if (client is KueryBlockingClient) {
+                    client.sql { +"SELCT * FROM users" }
+                }
+            }
+            """.trimIndent(),
+            pluginOptions = listOf(sqlSyntaxCheckOption()),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
+    fun `no warning when an add argument is a non-trim method chain`() {
+        // Only trimIndent/trimMargin chains are reconstructable; any other chain makes the text
+        // statically unknown, so the block is skipped instead of guessing (the chains already
+        // draw KUERY_UNSAFE_SQL_STRING).
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query() {
+                Sql { add("SELCT * FROM users".lowercase()) }
+                Sql { add("SELCT *".plus(" FROM users")) }
+            }
+            """.trimIndent(),
+            pluginOptions = listOf(sqlSyntaxCheckOption()),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).doesNotContain(DIAGNOSTIC_NAME)
+    }
+
+    @Test
     fun `the warning message contains the parser reason without exception class names`() {
         // when
         val result = compile(

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/SqlSyntaxCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/SqlSyntaxCheckerTest.kt
@@ -658,7 +658,7 @@ class SqlSyntaxCheckerTest {
     }
 
     @Test
-    fun `warn for sql calls through an intersection-typed receiver`() {
+    fun `a sql call through an intersection-typed receiver triggers a SQL syntax warning`() {
         // A smart cast on an unbounded type parameter produces an intersection type
         // (T & KueryBlockingClient); the call must still be recognized as a client sql call.
         // when
@@ -681,7 +681,7 @@ class SqlSyntaxCheckerTest {
     }
 
     @Test
-    fun `no warning when an add argument is a non-trim method chain`() {
+    fun `a non-trim method chain add argument does not trigger a SQL syntax warning`() {
         // Only trimIndent/trimMargin chains are reconstructable; any other chain makes the text
         // statically unknown, so the block is skipped instead of guessing (the chains already
         // draw KUERY_UNSAFE_SQL_STRING).

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
@@ -225,6 +225,66 @@ class UnsafeSqlStringCheckerTest {
     }
 
     @Test
+    fun `warn when trimMargin is called with a non-literal prefix`() {
+        // The margin prefix changes the resulting SQL text, so a non-literal prefix means the
+        // text is not fully determined at compile time even though the receiver is a literal.
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(prefix: String) {
+                Sql { add("|SELECT 1".trimMargin(prefix)) }
+            }
+            """.trimIndent(),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
+    fun `warn when trimIndent is chained on a non-literal receiver`() {
+        // The chain whitelist only makes the trim call transparent; it must not make an unsafe
+        // receiver safe.
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(sql: String) {
+                Sql { add(sql.trimIndent()) }
+            }
+            """.trimIndent(),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
+    fun `warn when a non-null asserted string is passed to add`() {
+        // An expression shape the checker does not model (here FirCheckNotNullCall) must default
+        // to unsafe, not silently pass.
+        // when
+        val result = compile(
+            """
+            import dev.hsbrysk.kuery.core.Sql
+
+            fun query(sql: String?) {
+                Sql { add(sql!!) }
+            }
+            """.trimIndent(),
+        )
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.messages).contains(DIAGNOSTIC_NAME)
+    }
+
+    @Test
     fun `no warning for safe argument forms`() {
         // allWarningsAsErrors = true, so any unexpected warning fails the compilation as well
         // when

--- a/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
+++ b/kuery-client-compiler/src/test/kotlin/dev/hsbrysk/kuery/compiler/UnsafeSqlStringCheckerTest.kt
@@ -225,7 +225,7 @@ class UnsafeSqlStringCheckerTest {
     }
 
     @Test
-    fun `warn when trimMargin is called with a non-literal prefix`() {
+    fun `a non-literal trimMargin prefix triggers an unsafe SQL string warning`() {
         // The margin prefix changes the resulting SQL text, so a non-literal prefix means the
         // text is not fully determined at compile time even though the receiver is a literal.
         // when
@@ -245,7 +245,7 @@ class UnsafeSqlStringCheckerTest {
     }
 
     @Test
-    fun `warn when trimIndent is chained on a non-literal receiver`() {
+    fun `trimIndent chained on a non-literal receiver triggers an unsafe SQL string warning`() {
         // The chain whitelist only makes the trim call transparent; it must not make an unsafe
         // receiver safe.
         // when
@@ -265,7 +265,7 @@ class UnsafeSqlStringCheckerTest {
     }
 
     @Test
-    fun `warn when a non-null asserted string is passed to add`() {
+    fun `a non-null asserted string passed to add triggers an unsafe SQL string warning`() {
         // An expression shape the checker does not model (here FirCheckNotNullCall) must default
         // to unsafe, not silently pass.
         // when

--- a/kuery-client-gradle-plugin/src/test/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePluginTest.kt
+++ b/kuery-client-gradle-plugin/src/test/kotlin/dev/hsbrysk/kuery/gradle/KueryClientGradlePluginTest.kt
@@ -160,6 +160,17 @@ class KueryClientGradlePluginTest {
     }
 
     @Test
+    fun `the compiler plugin coordinates point at the published kuery-client-compiler artifact`() {
+        // Kotlin resolves the compiler plugin through these values at build time, so a drift
+        // (e.g. a module or group rename) would break every consumer build.
+        assertThat(plugin.getCompilerPluginId()).isEqualTo("dev.hsbrysk.kuery-client")
+        val artifact = plugin.getPluginArtifact()
+        assertThat(artifact.groupId).isEqualTo("dev.hsbrysk.kuery-client")
+        assertThat(artifact.artifactId).isEqualTo("kuery-client-compiler")
+        assertThat(artifact.version).isEqualTo(BuildConfig.VERSION)
+    }
+
+    @Test
     fun `strict is passed through when enabled`() {
         // given
         val project = ProjectBuilder.builder().build()

--- a/kuery-client-spring-data-common/src/test/kotlin/dev/hsbrysk/kuery/spring/data/internal/ValueClassColumnConverterTest.kt
+++ b/kuery-client-spring-data-common/src/test/kotlin/dev/hsbrysk/kuery/spring/data/internal/ValueClassColumnConverterTest.kt
@@ -4,6 +4,7 @@ package dev.hsbrysk.kuery.spring.data.internal
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isNull
 import dev.hsbrysk.kuery.core.KueryClientInternalApi
 import org.junit.jupiter.api.Test
@@ -34,6 +35,9 @@ class ValueClassColumnConverterTest {
 
     @JvmInline
     value class Money(val value: BigDecimal)
+
+    @JvmInline
+    value class MoneyBox(val value: Money)
 
     class LongToStringIdConverter : Converter<Long, StringId> {
         override fun convert(source: Long): StringId = StringId("raw:$source")
@@ -119,5 +123,25 @@ class ValueClassColumnConverterTest {
         // when & then
         val result = converter.convert("") { "" }
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun `a nested value class maps to null when the inner conversion yields null`() {
+        // The recursive converter for the nested level may resolve to null (here through a
+        // converter legitimately returning null); the outer level must map to null as well
+        // instead of boxing null.
+        // given
+        val converter = ValueClassColumnConverter(MoneyBox::class, conversionService(BlankToNullBigDecimalConverter()))
+
+        // when & then
+        val result = converter.convert("") { null }
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `hasValueClassConstructorParameters is false for a class without a primary constructor`() {
+        // A Java class has no Kotlin primary constructor; it must stay on Spring's own mappers
+        // instead of being routed to the value class mapper.
+        assertThat(hasValueClassConstructorParameters(StringBuilder::class)).isFalse()
     }
 }

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/JdbcH2ContractDatabase.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/JdbcH2ContractDatabase.kt
@@ -2,6 +2,7 @@ package dev.hsbrysk.kuery.spring.jdbc
 
 import dev.hsbrysk.kuery.core.KueryBlockingClient
 import dev.hsbrysk.kuery.core.KueryClient
+import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import dev.hsbrysk.kuery.spring.testing.BlockingKueryClientAdapter
 import dev.hsbrysk.kuery.spring.testing.ContractDatabase
 import io.micrometer.observation.ObservationRegistry
@@ -31,11 +32,13 @@ class JdbcH2ContractDatabase : ContractDatabase {
     fun blockingClient(
         converters: List<Any> = emptyList(),
         observationRegistry: ObservationRegistry? = null,
+        observationConvention: KueryClientFetchObservationConvention? = null,
     ): KueryBlockingClient = SpringJdbcKueryClient.builder()
         .dataSource(dataSource)
         .converters(converters)
         .apply {
             observationRegistry?.let { observationRegistry(it) }
+            observationConvention?.let { observationConvention(it) }
         }
         .build()
 

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/observation/ObservationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/observation/ObservationTest.kt
@@ -3,17 +3,27 @@ package dev.hsbrysk.kuery.spring.jdbc.observation
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.example.spring.jdbc.UserRepository
+import dev.hsbrysk.kuery.core.KueryClient
 import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import dev.hsbrysk.kuery.spring.jdbc.JdbcH2ContractDatabase
+import dev.hsbrysk.kuery.spring.testing.BlockingKueryClientAdapter
 import dev.hsbrysk.kuery.spring.testing.contract.observation.ObservationContract
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationHandler
+import io.micrometer.observation.ObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
 import org.junit.jupiter.api.Test
 
 class ObservationTest : ObservationContract() {
     override val database get() = h2
+
+    override fun conventionKueryClient(
+        observationRegistry: ObservationRegistry,
+        observationConvention: KueryClientFetchObservationConvention,
+    ): KueryClient = BlockingKueryClientAdapter(
+        h2.blockingClient(observationRegistry = observationRegistry, observationConvention = observationConvention),
+    )
 
     // Streaming via Sequence and the Micrometer scope lifecycle are jdbc-specific, so they are
     // tested here against the real blocking API rather than through the contract.
@@ -30,26 +40,6 @@ class ObservationTest : ObservationContract() {
         val blockingClient = h2.blockingClient(observationRegistry = registry)
         UserRepository(blockingClient).sequence().toList()
         TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation()
-    }
-
-    @Test
-    fun `a custom observationConvention replaces the default convention`() {
-        // given
-        val customRegistry = TestObservationRegistry.create()
-        val convention = object : KueryClientFetchObservationConvention {
-            override fun getName(): String = "custom.fetches"
-        }
-        val client = h2.blockingClient(observationRegistry = customRegistry, observationConvention = convention)
-
-        // when
-        client.sql { +"SELECT * FROM users" }.listMap()
-
-        // then
-        TestObservationRegistryAssert.assertThat(customRegistry)
-            .hasObservationWithNameEqualTo("custom.fetches")
-            .that()
-            .hasBeenStarted()
-            .hasBeenStopped()
     }
 
     @Test

--- a/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/observation/ObservationTest.kt
+++ b/kuery-client-spring-data-jdbc/src/test/kotlin/dev/hsbrysk/kuery/spring/jdbc/observation/ObservationTest.kt
@@ -3,6 +3,7 @@ package dev.hsbrysk.kuery.spring.jdbc.observation
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.example.spring.jdbc.UserRepository
+import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import dev.hsbrysk.kuery.spring.jdbc.JdbcH2ContractDatabase
 import dev.hsbrysk.kuery.spring.testing.contract.observation.ObservationContract
 import io.micrometer.observation.Observation
@@ -29,6 +30,26 @@ class ObservationTest : ObservationContract() {
         val blockingClient = h2.blockingClient(observationRegistry = registry)
         UserRepository(blockingClient).sequence().toList()
         TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation()
+    }
+
+    @Test
+    fun `a custom observationConvention replaces the default convention`() {
+        // given
+        val customRegistry = TestObservationRegistry.create()
+        val convention = object : KueryClientFetchObservationConvention {
+            override fun getName(): String = "custom.fetches"
+        }
+        val client = h2.blockingClient(observationRegistry = customRegistry, observationConvention = convention)
+
+        // when
+        client.sql { +"SELECT * FROM users" }.listMap()
+
+        // then
+        TestObservationRegistryAssert.assertThat(customRegistry)
+            .hasObservationWithNameEqualTo("custom.fetches")
+            .that()
+            .hasBeenStarted()
+            .hasBeenStopped()
     }
 
     @Test

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/observation/ObservationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/observation/ObservationTest.kt
@@ -1,9 +1,11 @@
 package dev.hsbrysk.kuery.spring.r2dbc.observation
 
 import com.example.spring.r2dbc.UserRepository
+import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import dev.hsbrysk.kuery.spring.r2dbc.R2dbcH2ContractDatabase
 import dev.hsbrysk.kuery.spring.r2dbc.SpringR2dbcKueryClient
 import dev.hsbrysk.kuery.spring.testing.contract.observation.ObservationContract
+import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionFactory
@@ -34,6 +36,30 @@ class ObservationTest : ObservationContract() {
     fun `flow does not record an observation`() = runTest {
         UserRepository(kueryClient).flow().collect()
         TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation()
+    }
+
+    @Test
+    fun `a custom observationConvention replaces the default convention`() = runTest {
+        // given
+        val customRegistry = TestObservationRegistry.create()
+        val convention = object : KueryClientFetchObservationConvention {
+            override fun getName(): String = "custom.fetches"
+        }
+        val client = SpringR2dbcKueryClient.builder()
+            .connectionFactory(h2.connectionFactory)
+            .observationRegistry(customRegistry)
+            .observationConvention(convention)
+            .build()
+
+        // when
+        client.sql { +"SELECT * FROM users" }.listMap()
+
+        // then
+        TestObservationRegistryAssert.assertThat(customRegistry)
+            .hasObservationWithNameEqualTo("custom.fetches")
+            .that()
+            .hasBeenStarted()
+            .hasBeenStopped()
     }
 
     @Test

--- a/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/observation/ObservationTest.kt
+++ b/kuery-client-spring-data-r2dbc/src/test/kotlin/dev/hsbrysk/kuery/spring/r2dbc/observation/ObservationTest.kt
@@ -1,11 +1,12 @@
 package dev.hsbrysk.kuery.spring.r2dbc.observation
 
 import com.example.spring.r2dbc.UserRepository
+import dev.hsbrysk.kuery.core.KueryClient
 import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import dev.hsbrysk.kuery.spring.r2dbc.R2dbcH2ContractDatabase
 import dev.hsbrysk.kuery.spring.r2dbc.SpringR2dbcKueryClient
 import dev.hsbrysk.kuery.spring.testing.contract.observation.ObservationContract
-import io.micrometer.observation.tck.TestObservationRegistry
+import io.micrometer.observation.ObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionFactory
@@ -23,6 +24,15 @@ import reactor.core.publisher.Flux
 class ObservationTest : ObservationContract() {
     override val database get() = h2
 
+    override fun conventionKueryClient(
+        observationRegistry: ObservationRegistry,
+        observationConvention: KueryClientFetchObservationConvention,
+    ): KueryClient = SpringR2dbcKueryClient.builder()
+        .connectionFactory(h2.connectionFactory)
+        .observationRegistry(observationRegistry)
+        .observationConvention(observationConvention)
+        .build()
+
     // Streaming via Flow and cancellation are r2dbc-specific, so they are tested here against
     // the real API rather than through the contract.
 
@@ -36,30 +46,6 @@ class ObservationTest : ObservationContract() {
     fun `flow does not record an observation`() = runTest {
         UserRepository(kueryClient).flow().collect()
         TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation()
-    }
-
-    @Test
-    fun `a custom observationConvention replaces the default convention`() = runTest {
-        // given
-        val customRegistry = TestObservationRegistry.create()
-        val convention = object : KueryClientFetchObservationConvention {
-            override fun getName(): String = "custom.fetches"
-        }
-        val client = SpringR2dbcKueryClient.builder()
-            .connectionFactory(h2.connectionFactory)
-            .observationRegistry(customRegistry)
-            .observationConvention(convention)
-            .build()
-
-        // when
-        client.sql { +"SELECT * FROM users" }.listMap()
-
-        // then
-        TestObservationRegistryAssert.assertThat(customRegistry)
-            .hasObservationWithNameEqualTo("custom.fetches")
-            .that()
-            .hasBeenStarted()
-            .hasBeenStopped()
     }
 
     @Test

--- a/kuery-client-spring-data-testing/src/main/kotlin/dev/hsbrysk/kuery/spring/testing/contract/mapping/ValueClassFetchContract.kt
+++ b/kuery-client-spring-data-testing/src/main/kotlin/dev/hsbrysk/kuery/spring/testing/contract/mapping/ValueClassFetchContract.kt
@@ -393,6 +393,21 @@ abstract class ValueClassFetchContract : ConverterContractBase() {
     }
 
     @Test
+    fun `a type-parameter property receives the column value unconverted`() = runTest {
+        // The declared type of the property is a type parameter of the data class, so there is no
+        // conversion target; the raw column value is passed to the constructor as-is.
+        // given
+        database.execute("INSERT INTO converter (text) VALUES ('user1')")
+
+        // when & then
+        val record: TypeParamRecord<String> = kueryClient.sql {
+            +"SELECT text, text AS payload FROM converter"
+        }.single()
+        assertThat(record.text).isEqualTo(UserName("user1"))
+        assertThat(record.payload).isEqualTo("user1")
+    }
+
+    @Test
     fun `default value applies when the column for a defaulted value class parameter is SQL NULL`() = runTest {
         // A value class parameter with a Kotlin default: a SQL NULL yields a null converted value,
         // which is omitted for the optional parameter so the default value class applies (mirrors
@@ -679,6 +694,11 @@ abstract class ValueClassFetchContract : ConverterContractBase() {
     data class MultiValueClassRecord(
         val name: UserName,
         val amount: Amount,
+    )
+
+    data class TypeParamRecord<T>(
+        val text: UserName,
+        val payload: T,
     )
 
     data class DefaultedValueClassRecord(val text: UserName = UserName("default"))

--- a/kuery-client-spring-data-testing/src/main/kotlin/dev/hsbrysk/kuery/spring/testing/contract/observation/ObservationContract.kt
+++ b/kuery-client-spring-data-testing/src/main/kotlin/dev/hsbrysk/kuery/spring/testing/contract/observation/ObservationContract.kt
@@ -4,7 +4,9 @@ import assertk.assertFailure
 import assertk.assertions.isInstanceOf
 import com.example.spring.testing.UserRepository
 import dev.hsbrysk.kuery.core.KueryClient
+import dev.hsbrysk.kuery.core.observation.KueryClientFetchObservationConvention
 import dev.hsbrysk.kuery.spring.testing.ContractDatabase
+import io.micrometer.observation.ObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistry
 import io.micrometer.observation.tck.TestObservationRegistryAssert
 import kotlinx.coroutines.test.runTest
@@ -32,6 +34,17 @@ abstract class ObservationContract {
     protected val kueryClient: KueryClient by lazy { database.kueryClient(observationRegistry = registry) }
 
     private val userRepository by lazy { UserRepository(kueryClient) }
+
+    /**
+     * A client built with the given [observationRegistry] and [observationConvention]. Not
+     * expressible through [ContractDatabase] (whose `kueryClient` has no convention parameter),
+     * so each concrete subclass builds it directly with its own module's builder — mirrors
+     * `SqlIdGenerationDefaultContract.capturingKueryClient`.
+     */
+    protected abstract fun conventionKueryClient(
+        observationRegistry: ObservationRegistry,
+        observationConvention: KueryClientFetchObservationConvention,
+    ): KueryClient
 
     @BeforeEach
     fun setUpUsersTable() {
@@ -163,6 +176,26 @@ abstract class ObservationContract {
             .hasBeenStarted()
             .hasBeenStopped()
             .hasError()
+    }
+
+    @Test
+    fun `a custom observationConvention replaces the default convention`() = runTest {
+        // given
+        val customRegistry = TestObservationRegistry.create()
+        val convention = object : KueryClientFetchObservationConvention {
+            override fun getName(): String = "custom.fetches"
+        }
+        val client = conventionKueryClient(customRegistry, convention)
+
+        // when
+        client.sql { +"SELECT * FROM users" }.listMap()
+
+        // then
+        TestObservationRegistryAssert.assertThat(customRegistry)
+            .hasObservationWithNameEqualTo("custom.fetches")
+            .that()
+            .hasBeenStarted()
+            .hasBeenStopped()
     }
 
     protected fun assertObservation(


### PR DESCRIPTION
## Summary

While investigating why Codecov reports 87.52% on `main` (vs Kover's own ~97.9% — a measurement-definition gap, not a regression), I audited every uncovered line and picked out the handful that represent genuinely untested behavior, skipping the rest (functional-test-only coverage Kover can't see, and defensive/unreachable branches).

- `observationConvention()` builder setter had **no test at all** on either `kuery-client-spring-data-jdbc` or `kuery-client-spring-data-r2dbc` — a regression here (custom convention silently ignored) would have gone undetected.
- FIR checker safety contracts in `kuery-client-compiler`: non-literal `trimMargin`/`trimIndent` chains, a `!!`-asserted string, an intersection-typed (smart-cast) receiver, and a non-reconstructable method chain (`.lowercase()`) — all pin the "unknown shape defaults to unsafe / non-reconstructable defaults to skip, not guess" contracts.
- `kuery-client-gradle-plugin`'s published compiler-plugin coordinates (`getCompilerPluginId()` / `getPluginArtifact()`), mirroring the existing `SUPPORTED_SQL_SYNTAX_CHECKS` drift-guard.
- `ValueClassColumnConverter`: a nested value class whose inner conversion yields null now asserted to map to null instead of boxing null; `hasValueClassConstructorParameters` asserted false for a Java class.
- Shared `ValueClassFetchContract`: a generic data class property (unconverted type-parameter column) is fetched correctly on both jdbc and r2dbc.

Deliberately **not** chasing the Codecov percentage itself — most of the remaining gap is either covered by `functional-test` (which runs the compiler plugin in a separate Gradle-managed process Kover can't instrument) or defensive/unreachable code paths not worth testing directly.

## Test plan
- [x] `:kuery-client-compiler:test` (`UnsafeSqlStringCheckerTest`, `SqlSyntaxCheckerTest`)
- [x] `:kuery-client-gradle-plugin:test`
- [x] `:kuery-client-spring-data-common:test`
- [x] `:kuery-client-spring-data-jdbc:test` (`mapping.ValueClassFetchTest`, `observation.ObservationTest`)
- [x] `:kuery-client-spring-data-r2dbc:test` (`mapping.ValueClassFetchTest`, `observation.ObservationTest`)
- [x] `ktlintCheck` + `detektTest` on touched modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)