### PR TITLE
Make MySqlSingleBasicTypeContract row order deterministic

### DIFF
--- a/kuery-client-spring-data-testing/src/main/kotlin/dev/hsbrysk/kuery/spring/testing/contract/mysql/MySqlSingleBasicTypeContract.kt
+++ b/kuery-client-spring-data-testing/src/main/kotlin/dev/hsbrysk/kuery/spring/testing/contract/mysql/MySqlSingleBasicTypeContract.kt
@@ -76,7 +76,15 @@ abstract class MySqlSingleBasicTypeContract {
     fun `list maps each row of a single-column result`() = runTest {
         // when
         val result = kueryClient.sql {
-            +"SELECT 1 UNION SELECT 0"
+            +"""
+            SELECT value
+            FROM (
+                SELECT 1 AS value
+                UNION ALL
+                SELECT 0 AS value
+            ) AS numbers
+            ORDER BY value DESC
+            """.trimIndent()
         }.list(Int::class)
 
         // then


### PR DESCRIPTION
## Summary

Follow-up to #449. `list maps each row of a single-column result` in `MySqlSingleBasicTypeContract` used `SELECT 1 UNION SELECT 0` with no `ORDER BY`, so row order is not guaranteed by MySQL and the test could flake.

## Changes

Wrap the query in a derived table with `UNION ALL` (making the two-row intent explicit, rather than relying on implicit `UNION` dedup semantics) and an explicit `ORDER BY value DESC`, so the result order is deterministic:

```sql
SELECT value
FROM (
    SELECT 1 AS value
    UNION ALL
    SELECT 0 AS value
) AS numbers
ORDER BY value DESC
```

The existing expected value `listOf(1, 0)` is unchanged on both jdbc and r2dbc.

## Testing

- `./gradlew :kuery-client-spring-data-jdbc:test :kuery-client-spring-data-r2dbc:test --tests '*MySqlSingleBasicTypeTest'` — green (jdbc 13, r2dbc 11, 0 failures)
- `./gradlew ktlintCheck detektMain detektTest` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)