### PR TITLE
Publish Dokka API docs under /api/ on the docs site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Check
         run: |
-          ./gradlew check detektMain detektTest :koverXmlReport
+          ./gradlew check detektMain detektTest :koverXmlReport :dokkaGeneratePublicationHtml
           ./gradlew -p examples check detektMain detektTest
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,10 +31,19 @@ jobs:
         with:
           node-version: 24
           cache: npm
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Set up gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Install dependencies
         run: npm ci
+      - name: Build API docs with Dokka
+        run: npm run docs:api
       - name: Build with VitePress
         run: npm run docs:build
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ out/
 /node_modules
 docs/.vitepress/cache
 docs/.vitepress/dist
+# Dokka HTML copied in by `npm run docs:api`; generated, never committed
+docs/public/api

--- a/build-logic/src/main/kotlin/conventions/dokka.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/dokka.gradle.kts
@@ -1,0 +1,21 @@
+package conventions
+
+plugins {
+    id("org.jetbrains.dokka")
+}
+
+dokka {
+    dokkaSourceSets.configureEach {
+        // Implementation details live in `internal` packages (annotated with
+        // @KueryClientInternalApi); they are public only for cross-module access.
+        perPackageOption {
+            matchingRegex.set(""".*\.internal(\..*)?""")
+            suppress.set(true)
+        }
+        sourceLink {
+            localDirectory.set(project.projectDir)
+            remoteUrl("https://github.com/be-hase/kuery-client/tree/main/${project.name}")
+            remoteLineSuffix.set("#L")
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/conventions/dokka.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/dokka.gradle.kts
@@ -1,8 +1,18 @@
 package conventions
 
+import java.net.URI
+
 plugins {
     id("org.jetbrains.dokka")
 }
+
+// Both release-time Dokka builds (the Pages deploy and the Maven Central javadoc jar) run on a
+// version-tag push, so pin source links to that tag; otherwise `main` moves on after the release
+// and published links drift to different lines. Everywhere else (local builds, PR/branch CI,
+// workflow_dispatch) GITHUB_REF_NAME is absent or not a version tag, and `main` is the best ref.
+val sourceLinkRef: Provider<String> = providers.environmentVariable("GITHUB_REF_NAME")
+    .map { if (it.matches(Regex("""v\d+\.\d+\.\d+"""))) it else "main" }
+    .orElse("main")
 
 dokka {
     dokkaSourceSets.configureEach {
@@ -14,7 +24,11 @@ dokka {
         }
         sourceLink {
             localDirectory.set(project.projectDir)
-            remoteUrl("https://github.com/be-hase/kuery-client/tree/main/${project.name}")
+            remoteUrl.set(
+                sourceLinkRef.map { ref ->
+                    URI("https://github.com/be-hase/kuery-client/tree/$ref/${project.name}")
+                },
+            )
             remoteLineSuffix.set("#L")
         }
     }

--- a/build-logic/src/main/kotlin/conventions/maven-publish.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/maven-publish.gradle.kts
@@ -6,7 +6,7 @@ import com.vanniktech.maven.publish.SourcesJar
 
 plugins {
     id("com.vanniktech.maven.publish")
-    id("org.jetbrains.dokka")
+    id("conventions.dokka")
 }
 
 mavenPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     // Load the Kotlin plugin once so all subprojects share the same plugin classloader.
     alias(libs.plugins.kotlin.jvm) apply false
     id("conventions.kover")
+    id("conventions.dokka")
 }
 
 dependencies {
@@ -11,4 +12,15 @@ dependencies {
     kover(projects.kueryClientSpringDataCommon)
     kover(projects.kueryClientSpringDataJdbc)
     kover(projects.kueryClientSpringDataR2dbc)
+
+    // Modules aggregated into the Dokka HTML published at https://kuery-client.hsbrysk.dev/api/.
+    // Matches the modules that expose a public API (see conventions.public-api usage); the
+    // other published modules are internal-only or build tooling.
+    dokka(projects.kueryClientCore)
+    dokka(projects.kueryClientSpringDataJdbc)
+    dokka(projects.kueryClientSpringDataR2dbc)
+}
+
+dokka {
+    moduleName = "Kuery Client"
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -61,6 +61,9 @@ export default defineConfig({
         nav: [
             {text: "Home", link: "/"},
             {text: "Docs", link: "/getting-started"},
+            // Dokka HTML copied into docs/public/api at build time (see `docs:api` script);
+            // target keeps VitePress' SPA router from intercepting the navigation.
+            {text: "API", link: "/api/", target: "_blank"},
         ],
 
         sidebar: [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,6 +45,29 @@ export default defineConfig({
     vite: {
         plugins: [
             {
+                // The Vite dev server only serves public/ files on exact paths; directory URLs
+                // like /api/ fall through to the SPA fallback and render VitePress' 404 page.
+                // The built site (GitHub Pages, `docs:preview`) resolves directory indexes itself,
+                // so mimic that in dev for the Dokka site copied in by `docs:api`.
+                name: 'serve-dokka-api-in-dev',
+                configureServer(server) {
+                    server.middlewares.use((req, res, next) => {
+                        const [path, query = ''] = (req.url ?? '').split('?')
+                        const suffix = query ? `?${query}` : ''
+                        if (path === '/api') {
+                            res.statusCode = 302
+                            res.setHeader('Location', `/api/${suffix}`)
+                            res.end()
+                            return
+                        }
+                        if (path.startsWith('/api/') && path.endsWith('/')) {
+                            req.url = `${path}index.html${suffix}`
+                        }
+                        next()
+                    })
+                },
+            },
+            {
                 name: 'replace-kuery-client-version',
                 enforce: 'pre',
                 transform(code, id) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "docs:api": "./gradlew :dokkaGeneratePublicationHtml && rm -rf docs/public/api && cp -R build/dokka/html docs/public/api",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"


### PR DESCRIPTION
## Summary

Generates aggregated Dokka HTML and serves it from the existing VitePress site at `https://kuery-client.hsbrysk.dev/api/`.

- **New `conventions.dokka` plugin** (build-logic): suppresses `*.internal` packages (the `@KueryClientInternalApi` implementation details) and adds GitHub source links. `conventions.maven-publish` now applies it instead of the raw Dokka plugin, so the javadoc-jar path picks up the same config.
- **Root aggregation**: the three public-API modules (`kuery-client-core`, `kuery-client-spring-data-jdbc`, `kuery-client-spring-data-r2dbc`) are aggregated as "Kuery Client". The other published modules are internal-only (`spring-data-common`) or build tooling (compiler, gradle-plugin), so they are excluded.
- **`npm run docs:api`**: runs `:dokkaGeneratePublicationHtml` and copies `build/dokka/html` into `docs/public/api` (gitignored), which VitePress ships verbatim under `/api/`.
- **Site nav**: adds an "API" link (`target="_blank"` so the SPA router doesn't intercept it).
- **Workflows**: the Pages deploy workflow now sets up JDK/Gradle and runs `docs:api` before the VitePress build; the CI check job also runs `:dokkaGeneratePublicationHtml` so Dokka breakage surfaces on PRs instead of at release-tag time.

Notes:
- Output size is ~2.8 MB. Dokka HTML uses relative links, so it works under the `/api/` subpath as-is.
- Dokka Gradle Plugin v2 does not render module versions in the HTML by default, so no `publishVersion` injection is needed in the docs workflow.

## Test plan

- [x] `./gradlew :dokkaGeneratePublicationHtml` generates the aggregated site; `internal` packages absent, source links present
- [x] `npm run docs:api && npm run docs:build` puts the Dokka site into `docs/.vitepress/dist/api`
- [x] `vitepress preview`: `/`, `/api/`, and a deep module page all return 200
- [x] `./gradlew :kuery-client-core:dokkaJavadocJar` still builds the javadoc jar via the new convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)