### PR TITLE
Add a functional test for multi-dollar string interpolation

### DIFF
--- a/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
+++ b/kuery-client-compiler/functional-test/src/test/kotlin/dev/hsbrysk/kuery/core/StringInterpolationTest.kt
@@ -494,6 +494,28 @@ class StringInterpolationTest {
     }
 
     @Test
+    fun `a multi-dollar template keeps single dollars as raw text and binds double-dollar values`() {
+        // Multi-dollar interpolation is resolved by the parser, so by the time the IR rewrite
+        // runs, the template is indistinguishable from a regular one: `$` is a plain character
+        // and only `$$`-prefixed entries are interpolation values.
+        // given
+        val id = 5
+
+        // when
+        val sql = Sql {
+            +$$"SELECT data->>'$name' FROM t WHERE id = $$id AND tag = $${"x".uppercase()}"
+        }
+
+        // then
+        assertThat(sql).isEqualTo(
+            Sql(
+                "SELECT data->>'\$name' FROM t WHERE id = :p0 AND tag = :p1",
+                listOf(NamedSqlParameter("p0", 5), NamedSqlParameter("p1", "X")),
+            ),
+        )
+    }
+
+    @Test
     fun `interpolated percent chars are inlined as raw text around a bound value`() {
         // given
         val keyword = "foo"


### PR DESCRIPTION
## Summary

Adds a functional test verifying that the compiler plugin works with Kotlin's multi-dollar string interpolation (`$$"..."`).

There was no coverage for this syntax. It works without any plugin changes — multi-dollar interpolation is resolved by the parser, so by the time `StringInterpolationTransformer` runs, the template is indistinguishable from a regular one — but nothing pinned that behavior down against regressions.

The new test sits next to the existing `${'$'}` workaround test and asserts that:

- a single `$` inside a `$$` template stays raw SQL text (e.g. `data->>'$name'`)
- `$$`-prefixed entries (both a variable and an expression) are bound as `:pN` parameters

## Test plan

- `./gradlew :kuery-client-compiler:functional-test:test --tests "dev.hsbrysk.kuery.core.StringInterpolationTest"`
- `./gradlew :kuery-client-compiler:functional-test:ktlintCheck :kuery-client-compiler:functional-test:detektTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)