### PR TITLE
Add minimumReleaseAge to Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,5 +7,9 @@
   "major": {
     "automerge": false
   },
+  // Supply chain mitigation: don't pick up a release until it has been public for a while,
+  // so compromised versions are usually detected and unpublished before automerge sees them.
+  // Renovate's vulnerabilityAlerts updates bypass this delay by default.
+  "minimumReleaseAge": "7 days",
   "labels": ["renovate"],
 }


### PR DESCRIPTION
## Summary

This repository automerges Renovate PRs for minor/patch updates. Without any release-age gate, a compromised upstream release (Gradle deps, npm dev deps, GitHub Actions) could land on `main` within hours of being published — and its code would later run in the publish workflow alongside the Maven Central / signing credentials.

This PR adds `"minimumReleaseAge": "7 days"` so Renovate does not even open a PR until a release has been public for a week. Real-world supply chain attacks are typically detected and unpublished within hours to days, so this closes most of the window while keeping automerge convenient.

Notes:
- Security updates driven by `vulnerabilityAlerts` bypass `minimumReleaseAge` by default, so vulnerability patches are not delayed.
- `internalChecksFilter` defaults to `strict`, so pending (too-new) versions are simply skipped rather than creating a PR that waits.

## Test plan

- Config-only change; validated against the Renovate schema (`minimumReleaseAge` is a standard option, formerly `stabilityDays`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)